### PR TITLE
ci: use go-version-file in setup-go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23.2'
+          go-version-file: go.mod
           # Avoid stale module/build caches that can surface impossible typecheck
           # failures even when the current tree passes locally.
           cache: false

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23.2'
+          go-version-file: go.mod
           # Avoid stale module/build caches that can surface old typecheck
           # results in golangci-lint.
           cache: false


### PR DESCRIPTION
Restore `go-version-file: go.mod` in the GitHub Actions `setup-go` steps now that the earlier CI mismatch investigation showed the real problem was elsewhere.

- switch `go.yml` back to `go-version-file: go.mod`
- switch `golangci-lint.yml` back to `go-version-file: go.mod`
- keep the cache-disabling and cache-clearing reliability fixes from PR #15