### PR TITLE
Change STRUCT NULL representation to scalar NULL

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -89,3 +89,31 @@ func TestFormatColumnConstructedNullStruct(t *testing.T) {
 		t.Fatalf("FormatToplevelColumn() = %q, want %q", got, SimpleFormatConfig().NullString)
 	}
 }
+
+func TestIsNull(t *testing.T) {
+	t.Parallel()
+
+	structType := typector.MustNameCodeSlicesToStructType(
+		[]string{"a", "b"},
+		[]sppb.TypeCode{sppb.TypeCode_INT64, sppb.TypeCode_STRING},
+	)
+
+	scalarNullGcv := spanner.GenericColumnValue{
+		Type:  structType,
+		Value: structpb.NewNullValue(),
+	}
+
+	listNullGcv := spanner.GenericColumnValue{
+		Type: structType,
+		Value: structpb.NewListValue(&structpb.ListValue{
+			Values: []*structpb.Value{structpb.NewNullValue(), structpb.NewNullValue()},
+		}),
+	}
+
+	if !IsNull(scalarNullGcv) {
+		t.Errorf("Expected scalarNullGcv to be IsNull == true")
+	}
+	if IsNull(listNullGcv) {
+		t.Errorf("Expected listNullGcv to be IsNull == false")
+	}
+}

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"slices"
 	"strconv"
 	"time"
 
@@ -185,16 +184,9 @@ func SimpleTypedNull(code sppb.TypeCode) spanner.GenericColumnValue {
 }
 
 func TypedNull(typ *sppb.Type) spanner.GenericColumnValue {
-	var value *structpb.Value
-	if typ.GetCode() == sppb.TypeCode_STRUCT {
-		value = structpb.NewListValue(&structpb.ListValue{Values: slices.Repeat([]*structpb.Value{structpb.NewNullValue()}, len(typ.GetStructType().GetFields()))})
-	} else {
-		value = structpb.NewNullValue()
-	}
-
 	return spanner.GenericColumnValue{
 		Type:  typ,
-		Value: value,
+		Value: structpb.NewNullValue(),
 	}
 }
 


### PR DESCRIPTION
This PR changes the STRUCT NULL representation in gcvctor.TypedNull from a list of NULLs to a scalar NULL, and updates IsNull/formatting to handle it consistently.