### PR TITLE
docs(gcvctor): empty ArrayValue/ArrayValueWithType and NULL ARRAY pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
 - `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure.
-  Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
+- Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. For `ArrayValue`, a nil variadic slice (`ArrayValue()`, `ArrayValue(nil...)`) yields a typed NULL `ARRAY<INT64>`; a non-nil empty slice (`ArrayValue([]GenericColumnValue{}...)`) yields an empty non-null array.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure.
+  Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. For `ArrayValue`, a nil variadic slice (`ArrayValue()`, `ArrayValue(nil...)`) yields a typed NULL `ARRAY<INT64>`; a non-nil empty slice (`ArrayValue([]GenericColumnValue{}...)`) yields an empty non-null array.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. For `ArrayValue` / `ArrayValueWithType`, a nil variadic slice (no value args or `...(nil)`) yields a typed NULL array of the relevant element type; a non-nil empty slice yields an empty non-null array.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. For `ArrayValue` / `ArrayValueWithType`, a nil variadic slice (no value args or `...(nil)`) yields a typed NULL array of the relevant element type; a non-nil empty slice yields an empty non-null array.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `ArrayTypeTypedNull` / `TypedNull` for NULL ARRAYs.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `ArrayTypeTypedNull` / `TypedNull` for NULL ARRAYs.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure. Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -9,7 +9,7 @@
 // names with values; counts must match.
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
-// stored Value is always a scalar protobuf null. [SimpleTypedNull] does the same for simple
+// [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a scalar protobuf null at the top level. [SimpleTypedNull] does the same for simple
 // scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValue] with
 // per-field nulls when you need that shape.

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -3,8 +3,9 @@
 //
 // [ArrayValue] infers the element type from the first element (or uses a default empty ARRAY<INT64>
 // when len==0, whether the variadic slice is nil or empty). [ArrayValueWithType] takes the element type
-// explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [ArrayTypeTypedNull],
-// [ArrayCodeTypedNull], or [TypedNull] instead of relying on variadic nil. [StructValue] pairs field
+// explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or ElemCodeToArrayType instead of relying
+// on variadic nil. [StructValue] pairs field
 // names with values; counts must match.
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -1,9 +1,10 @@
 // Package gcvctor constructs [cloud.google.com/go/spanner.GenericColumnValue] values from Go values and
 // explicit [cloud.google.com/go/spanner/apiv1/spannerpb.Type] metadata, using [github.com/apstndb/spantype/typector] for type shapes.
 //
-// [ArrayValue] infers the element type from the first element (or uses a default empty
-// ARRAY<INT64> when called with no arguments). [ArrayValueWithType] takes the element type
-// explicitly. [StructValue] pairs field names with values; counts must match.
+// [ArrayValue] infers the element type from the first element when arguments are non-empty.
+// With no arguments, or with ArrayValue(nil...), it returns a typed NULL ARRAY<INT64> ([ArrayCodeTypedNull]).
+// With a non-nil empty slice (ArrayValue([]GenericColumnValue{}...)), it returns a non-null empty ARRAY<INT64>.
+// [ArrayValueWithType] takes the element type explicitly. [StructValue] pairs field names with values; counts must match.
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // stored Value is always a scalar protobuf null. [SimpleTypedNull] does the same for simple

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -4,7 +4,9 @@
 // [ArrayValue] infers the element type from the first element when arguments are non-empty.
 // With no arguments, or with ArrayValue(nil...), it returns a typed NULL ARRAY<INT64> ([ArrayCodeTypedNull]).
 // With a non-nil empty slice (ArrayValue([]GenericColumnValue{}...)), it returns a non-null empty ARRAY<INT64>.
-// [ArrayValueWithType] takes the element type explicitly. [StructValue] pairs field names with values; counts must match.
+// [ArrayValueWithType] takes the element type explicitly and follows the same variadic rule: nil elems
+// yields a typed NULL ARRAY<elemType> ([ArrayTypeTypedNull]); a non-nil empty slice yields an empty
+// non-null array. [StructValue] pairs field names with values; counts must match.
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // stored Value is always a scalar protobuf null. [SimpleTypedNull] does the same for simple

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -4,7 +4,7 @@
 // [ArrayValue] infers the element type from the first element (or uses a default empty ARRAY<INT64>
 // when len==0, whether the variadic slice is nil or empty). [ArrayValueWithType] takes the element type
 // explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [TypedNull] with
-// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or ElemCodeToArrayType instead of relying
+// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
 // on variadic nil. [StructValue] pairs field
 // names with values; counts must match.
 //

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -1,12 +1,11 @@
 // Package gcvctor constructs [cloud.google.com/go/spanner.GenericColumnValue] values from Go values and
 // explicit [cloud.google.com/go/spanner/apiv1/spannerpb.Type] metadata, using [github.com/apstndb/spantype/typector] for type shapes.
 //
-// [ArrayValue] infers the element type from the first element when arguments are non-empty.
-// With no arguments, or with ArrayValue(nil...), it returns a typed NULL ARRAY<INT64> ([ArrayCodeTypedNull]).
-// With a non-nil empty slice (ArrayValue([]GenericColumnValue{}...)), it returns a non-null empty ARRAY<INT64>.
-// [ArrayValueWithType] takes the element type explicitly and follows the same variadic rule: nil elems
-// yields a typed NULL ARRAY<elemType> ([ArrayTypeTypedNull]); a non-nil empty slice yields an empty
-// non-null array. [StructValue] pairs field names with values; counts must match.
+// [ArrayValue] infers the element type from the first element (or uses a default empty ARRAY<INT64>
+// when len==0, whether the variadic slice is nil or empty). [ArrayValueWithType] takes the element type
+// explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [ArrayTypeTypedNull],
+// [ArrayCodeTypedNull], or [TypedNull] instead of relying on variadic nil. [StructValue] pairs field
+// names with values; counts must match.
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // stored Value is always a scalar protobuf null. [SimpleTypedNull] does the same for simple

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -224,7 +224,8 @@ func TypedNull(typ *sppb.Type) spanner.GenericColumnValue {
 
 // ArrayTypeTypedNull constructs a NULL ARRAY with the given element type.
 //
-// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] instead:
+// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] instead:
 //
 //	TypedNull(typector.ElemTypeToArrayType(elemType))
 func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
@@ -233,7 +234,8 @@ func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
 
 // ArrayCodeTypedNull constructs a NULL ARRAY with a simple element type code.
 //
-// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead:
+// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead:
 //
 //	TypedNull(typector.ElemCodeToArrayType(elemCode))
 func ArrayCodeTypedNull(elemCode sppb.TypeCode) spanner.GenericColumnValue {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -136,8 +136,8 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 // ArrayValue constructs ARRAY GenericColumnValue.
 //
 // With no elements (including a nil or empty variadic slice), it returns an empty ARRAY<INT64>
-// (SQL length zero, not SQL NULL). For a typed NULL ARRAY<INT64>, use [ArrayCodeTypedNull] or
-// [ArrayTypeTypedNull] with the element type; see also [TypedNull].
+// (SQL length zero, not SQL NULL). For a typed NULL ARRAY<INT64>, use [TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or ElemTypeToArrayType).
 //
 // For other element types or explicit typing policy, use [ArrayValueWithType] or [ElemTypeToEmptyArray].
 //
@@ -152,7 +152,7 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 // ArrayValueWithType constructs ARRAY GenericColumnValue using elemType as the element type
 // instead of inferring it from the first element. When elems is empty (nil or length zero), it
 // returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
-// use [ArrayTypeTypedNull] or [TypedNull]; see also [ArrayCodeTypedNull] for simple element codes.
+// use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or ElemCodeToArrayType.
 //
 // Each element's Type must match elemType (no coercion).
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
@@ -222,11 +222,19 @@ func TypedNull(typ *sppb.Type) spanner.GenericColumnValue {
 }
 
 // ArrayTypeTypedNull constructs a NULL ARRAY with the given element type.
+//
+// Deprecated: use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType]:
+//
+//	TypedNull(typector.ElemTypeToArrayType(elemType))
 func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
 	return TypedNull(typector.ElemTypeToArrayType(elemType))
 }
 
 // ArrayCodeTypedNull constructs a NULL ARRAY with a simple element type code.
+//
+// Deprecated: use [TypedNull] with [github.com/apstndb/spantype/typector.ElemCodeToArrayType]:
+//
+//	TypedNull(typector.ElemCodeToArrayType(elemCode))
 func ArrayCodeTypedNull(elemCode sppb.TypeCode) spanner.GenericColumnValue {
 	return TypedNull(typector.ElemCodeToArrayType(elemCode))
 }

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -135,39 +135,29 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 
 // ArrayValue constructs ARRAY GenericColumnValue.
 //
-// If vs is nil—either [ArrayValue] with no arguments or [ArrayValue] with a nil slice argument
-// (ArrayValue(nil...))—the result is a typed SQL NULL of type ARRAY<INT64> (see [ArrayCodeTypedNull]);
-// the [cloud.google.com/go/spanner.GenericColumnValue.Value] is a scalar protobuf null at the top level.
+// With no elements (including a nil or empty variadic slice), it returns an empty ARRAY<INT64>
+// (SQL length zero, not SQL NULL). For a typed NULL ARRAY<INT64>, use [ArrayCodeTypedNull] or
+// [ArrayTypeTypedNull] with the element type; see also [TypedNull].
 //
-// If vs is a non-nil empty slice (ArrayValue([]GenericColumnValue{}...)), the result is a non-null
-// empty ARRAY<INT64> (zero elements). For other element types or explicit typing policy, use
-// [ArrayValueWithType] or [ElemTypeToEmptyArray].
+// For other element types or explicit typing policy, use [ArrayValueWithType] or [ElemTypeToEmptyArray].
 //
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.
 func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
-	if vs == nil {
-		return ArrayCodeTypedNull(sppb.TypeCode_INT64), nil
-	}
 	if len(vs) == 0 {
-		return ArrayValueWithType(typector.CodeToSimpleType(sppb.TypeCode_INT64), vs...)
+		return ElemTypeCodeToEmptyArray(sppb.TypeCode_INT64), nil
 	}
 	return ArrayValueWithType(vs[0].Type, vs...)
 }
 
 // ArrayValueWithType constructs ARRAY GenericColumnValue using elemType as the element type
-// instead of inferring it from the first element.
+// instead of inferring it from the first element. When elems is empty (nil or length zero), it
+// returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
+// use [ArrayTypeTypedNull] or [TypedNull]; see also [ArrayCodeTypedNull] for simple element codes.
 //
-// If elems is nil—either only elemType was passed or ArrayValueWithType(elemType, nil...) was
-// used—the result is a typed SQL NULL ARRAY<elemType> (see [ArrayTypeTypedNull]).
-//
-// If elems is a non-nil empty slice, the result is a non-null empty ARRAY<elemType>. Each
-// non-empty element's Type must match elemType (no coercion).
+// Each element's Type must match elemType (no coercion).
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if elemType == nil {
 		return spanner.GenericColumnValue{}, fmt.Errorf("nil element type")
-	}
-	if elems == nil {
-		return ArrayTypeTypedNull(elemType), nil
 	}
 	if len(elems) == 0 {
 		return ElemTypeToEmptyArray(elemType), nil

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -149,17 +149,25 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 		return ArrayCodeTypedNull(sppb.TypeCode_INT64), nil
 	}
 	if len(vs) == 0 {
-		return ElemTypeCodeToEmptyArray(sppb.TypeCode_INT64), nil
+		return ArrayValueWithType(typector.CodeToSimpleType(sppb.TypeCode_INT64), vs...)
 	}
 	return ArrayValueWithType(vs[0].Type, vs...)
 }
 
 // ArrayValueWithType constructs ARRAY GenericColumnValue using elemType as the element type
-// instead of inferring it from the first element. When elems is empty, it returns an empty
-// ARRAY<elemType>. Each element's Type must match elemType (no coercion).
+// instead of inferring it from the first element.
+//
+// If elems is nil—either only elemType was passed or ArrayValueWithType(elemType, nil...) was
+// used—the result is a typed SQL NULL ARRAY<elemType> (see [ArrayTypeTypedNull]).
+//
+// If elems is a non-nil empty slice, the result is a non-null empty ARRAY<elemType>. Each
+// non-empty element's Type must match elemType (no coercion).
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if elemType == nil {
 		return spanner.GenericColumnValue{}, fmt.Errorf("nil element type")
+	}
+	if elems == nil {
+		return ArrayTypeTypedNull(elemType), nil
 	}
 	if len(elems) == 0 {
 		return ElemTypeToEmptyArray(elemType), nil

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -224,7 +224,7 @@ func TypedNull(typ *sppb.Type) spanner.GenericColumnValue {
 
 // ArrayTypeTypedNull constructs a NULL ARRAY with the given element type.
 //
-// Deprecated: use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType]:
+// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] instead:
 //
 //	TypedNull(typector.ElemTypeToArrayType(elemType))
 func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
@@ -233,7 +233,7 @@ func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
 
 // ArrayCodeTypedNull constructs a NULL ARRAY with a simple element type code.
 //
-// Deprecated: use [TypedNull] with [github.com/apstndb/spantype/typector.ElemCodeToArrayType]:
+// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead:
 //
 //	TypedNull(typector.ElemCodeToArrayType(elemCode))
 func ArrayCodeTypedNull(elemCode sppb.TypeCode) spanner.GenericColumnValue {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -201,8 +201,8 @@ func StructValue(names []string, gcvs []spanner.GenericColumnValue) (spanner.Gen
 }
 
 // SimpleTypedNull returns a typed NULL for a simple scalar type code.
-// The Value field is always a protobuf NullValue; see [TypedNull] for STRUCT and ARRAY
-// semantics.
+// The [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a protobuf
+// NullValue; see [TypedNull] for STRUCT and ARRAY semantics.
 func SimpleTypedNull(code sppb.TypeCode) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(code),
@@ -211,7 +211,8 @@ func SimpleTypedNull(code sppb.TypeCode) spanner.GenericColumnValue {
 }
 
 // TypedNull returns a typed NULL for typ.
-// The Value field is always a protobuf NullValue, including when typ is STRUCT or ARRAY.
+// The [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a protobuf
+// NullValue, including when typ is STRUCT or ARRAY.
 // It does not represent a non-null STRUCT whose fields are all null—use StructValue with
 // per-field nulls (using [TypedNull] or [SimpleTypedNull] for each field) when you need that shape.
 func TypedNull(typ *sppb.Type) spanner.GenericColumnValue {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -134,10 +134,20 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 }
 
 // ArrayValue constructs ARRAY GenericColumnValue.
-// With no arguments it returns an empty ARRAY<INT64> (not a scalar NULL). For other
-// element types or explicit typing policy, use ArrayValueWithType or ElemTypeToEmptyArray.
+//
+// If vs is nil—either [ArrayValue] with no arguments or [ArrayValue] with a nil slice argument
+// (ArrayValue(nil...))—the result is a typed SQL NULL of type ARRAY<INT64> (see [ArrayCodeTypedNull]);
+// the [cloud.google.com/go/spanner.GenericColumnValue.Value] is a scalar protobuf null at the top level.
+//
+// If vs is a non-nil empty slice (ArrayValue([]GenericColumnValue{}...)), the result is a non-null
+// empty ARRAY<INT64> (zero elements). For other element types or explicit typing policy, use
+// [ArrayValueWithType] or [ElemTypeToEmptyArray].
+//
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.
 func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	if vs == nil {
+		return ArrayCodeTypedNull(sppb.TypeCode_INT64), nil
+	}
 	if len(vs) == 0 {
 		return ElemTypeCodeToEmptyArray(sppb.TypeCode_INT64), nil
 	}

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -137,7 +137,7 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 //
 // With no elements (including a nil or empty variadic slice), it returns an empty ARRAY<INT64>
 // (SQL length zero, not SQL NULL). For a typed NULL ARRAY<INT64>, use [TypedNull] with
-// [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or ElemTypeToArrayType).
+// [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or [github.com/apstndb/spantype/typector.ElemTypeToArrayType]).
 //
 // For other element types or explicit typing policy, use [ArrayValueWithType] or [ElemTypeToEmptyArray].
 //
@@ -152,7 +152,7 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 // ArrayValueWithType constructs ARRAY GenericColumnValue using elemType as the element type
 // instead of inferring it from the first element. When elems is empty (nil or length zero), it
 // returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
-// use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or ElemCodeToArrayType.
+// use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType].
 //
 // Each element's Type must match elemType (no coercion).
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -391,9 +391,31 @@ func TestArrayTypeTypedNull(t *testing.T) {
 	}
 }
 
-func TestArrayValue_zeroArgsIsEmptyInt64Array(t *testing.T) {
+func TestArrayValue_noArgsIsTypedNullArrayInt64(t *testing.T) {
 	t.Parallel()
 	got, err := gcvctor.ArrayValue()
+	if err != nil {
+		t.Fatalf("ArrayValue: %v", err)
+	}
+	want := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	var nilSlice []spanner.GenericColumnValue
+	got2, err := gcvctor.ArrayValue(nilSlice...)
+	if err != nil {
+		t.Fatalf("ArrayValue(nil...): %v", err)
+	}
+	if diff := cmp.Diff(want, got2, protocmp.Transform()); diff != "" {
+		t.Errorf("ArrayValue(nil...): mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestArrayValue_emptyNonNilSliceIsEmptyInt64Array(t *testing.T) {
+	t.Parallel()
+	empty := []spanner.GenericColumnValue{}
+	got, err := gcvctor.ArrayValue(empty...)
 	if err != nil {
 		t.Fatalf("ArrayValue: %v", err)
 	}

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -391,37 +391,28 @@ func TestArrayTypeTypedNull(t *testing.T) {
 	}
 }
 
-func TestArrayValue_noArgsIsTypedNullArrayInt64(t *testing.T) {
+func TestArrayValue_zeroLengthIsEmptyInt64Array(t *testing.T) {
 	t.Parallel()
-	got, err := gcvctor.ArrayValue()
-	if err != nil {
-		t.Fatalf("ArrayValue: %v", err)
-	}
-	want := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
-	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-
-	var nilSlice []spanner.GenericColumnValue
-	got2, err := gcvctor.ArrayValue(nilSlice...)
-	if err != nil {
-		t.Fatalf("ArrayValue(nil...): %v", err)
-	}
-	if diff := cmp.Diff(want, got2, protocmp.Transform()); diff != "" {
-		t.Errorf("ArrayValue(nil...): mismatch (-want +got):\n%s", diff)
-	}
-}
-
-func TestArrayValue_emptyNonNilSliceIsEmptyInt64Array(t *testing.T) {
-	t.Parallel()
-	empty := []spanner.GenericColumnValue{}
-	got, err := gcvctor.ArrayValue(empty...)
-	if err != nil {
-		t.Fatalf("ArrayValue: %v", err)
-	}
 	want := gcvctor.ElemTypeCodeToEmptyArray(sppb.TypeCode_INT64)
-	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+
+	for _, name := range []string{"no args", "nil slice", "empty slice"} {
+		var got spanner.GenericColumnValue
+		var err error
+		switch name {
+		case "no args":
+			got, err = gcvctor.ArrayValue()
+		case "nil slice":
+			var nilSlice []spanner.GenericColumnValue
+			got, err = gcvctor.ArrayValue(nilSlice...)
+		case "empty slice":
+			got, err = gcvctor.ArrayValue([]spanner.GenericColumnValue{}...)
+		}
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("%s: mismatch (-want +got):\n%s", name, diff)
+		}
 	}
 }
 
@@ -440,28 +431,22 @@ func TestArrayValueWithType(t *testing.T) {
 		errIs     error
 	}{
 		{
-			desc:     "nil elems: typed NULL ARRAY<INT64>",
+			desc:     "empty INT64 (nil elems)",
 			elemType: int64Elem,
 			elems:    nil,
-			want:     gcvctor.ArrayTypeTypedNull(int64Elem),
-		},
-		{
-			desc:     "nil elems: typed NULL ARRAY<STRUCT<n INT64>>",
-			elemType: structElem,
-			elems:    nil,
-			want:     gcvctor.ArrayTypeTypedNull(structElem),
-		},
-		{
-			desc:     "non-nil empty INT64 slice",
-			elemType: int64Elem,
-			elems:    []spanner.GenericColumnValue{},
 			want:     gcvctor.ElemTypeToEmptyArray(int64Elem),
 		},
 		{
-			desc:     "non-nil empty STRUCT element slice",
+			desc:     "empty ARRAY<STRUCT<n INT64>> (nil elems)",
 			elemType: structElem,
-			elems:    []spanner.GenericColumnValue{},
+			elems:    nil,
 			want:     gcvctor.ElemTypeToEmptyArray(structElem),
+		},
+		{
+			desc:     "empty INT64 (non-nil empty slice)",
+			elemType: int64Elem,
+			elems:    []spanner.GenericColumnValue{},
+			want:     gcvctor.ElemTypeToEmptyArray(int64Elem),
 		},
 		{
 			desc:     "non-empty INT64",

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -440,15 +440,27 @@ func TestArrayValueWithType(t *testing.T) {
 		errIs     error
 	}{
 		{
-			desc:     "empty INT64 matches ElemTypeToEmptyArray",
+			desc:     "nil elems: typed NULL ARRAY<INT64>",
 			elemType: int64Elem,
 			elems:    nil,
+			want:     gcvctor.ArrayTypeTypedNull(int64Elem),
+		},
+		{
+			desc:     "nil elems: typed NULL ARRAY<STRUCT<n INT64>>",
+			elemType: structElem,
+			elems:    nil,
+			want:     gcvctor.ArrayTypeTypedNull(structElem),
+		},
+		{
+			desc:     "non-nil empty INT64 slice",
+			elemType: int64Elem,
+			elems:    []spanner.GenericColumnValue{},
 			want:     gcvctor.ElemTypeToEmptyArray(int64Elem),
 		},
 		{
-			desc:     "empty ARRAY<STRUCT<n INT64>>",
+			desc:     "non-nil empty STRUCT element slice",
 			elemType: structElem,
-			elems:    nil,
+			elems:    []spanner.GenericColumnValue{},
 			want:     gcvctor.ElemTypeToEmptyArray(structElem),
 		},
 		{

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -355,7 +355,8 @@ func TestTypedNull_STRUCT(t *testing.T) {
 	}
 }
 
-func TestArrayCodeTypedNull(t *testing.T) {
+func TestDeprecated_ArrayCodeTypedNull_matchesTypedNull(t *testing.T) {
+	// Deprecated API: must stay equivalent to TypedNull(typector.ElemCodeToArrayType(...)) until removed.
 	got := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
 	want := gcvctor.TypedNull(typector.ElemCodeToArrayType(sppb.TypeCode_INT64))
 
@@ -381,7 +382,8 @@ func TestNullRawValueFromType_STRUCT(t *testing.T) {
 	}
 }
 
-func TestArrayTypeTypedNull(t *testing.T) {
+func TestDeprecated_ArrayTypeTypedNull_matchesTypedNull(t *testing.T) {
+	// Deprecated API: must stay equivalent to TypedNull(typector.ElemTypeToArrayType(...)) until removed.
 	structType := typector.NameCodeToStructType("n", sppb.TypeCode_INT64)
 	got := gcvctor.ArrayTypeTypedNull(structType)
 	want := gcvctor.TypedNull(typector.ElemTypeToArrayType(structType))

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -356,6 +356,7 @@ func TestTypedNull_STRUCT(t *testing.T) {
 }
 
 func TestDeprecated_ArrayCodeTypedNull_matchesTypedNull(t *testing.T) {
+	t.Parallel()
 	// Deprecated API: must stay equivalent to TypedNull(typector.ElemCodeToArrayType(...)) until removed.
 	got := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
 	want := spanner.GenericColumnValue{
@@ -386,6 +387,7 @@ func TestNullRawValueFromType_STRUCT(t *testing.T) {
 }
 
 func TestDeprecated_ArrayTypeTypedNull_matchesTypedNull(t *testing.T) {
+	t.Parallel()
 	// Deprecated API: must stay equivalent to TypedNull(typector.ElemTypeToArrayType(...)) until removed.
 	structType := typector.NameCodeToStructType("n", sppb.TypeCode_INT64)
 	got := gcvctor.ArrayTypeTypedNull(structType)
@@ -400,6 +402,7 @@ func TestDeprecated_ArrayTypeTypedNull_matchesTypedNull(t *testing.T) {
 }
 
 func TestArrayValue_zeroLengthIsEmptyInt64Array(t *testing.T) {
+	t.Parallel()
 	want := spanner.GenericColumnValue{
 		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_INT64),
 		Value: structpb.NewListValue(&structpb.ListValue{}),

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -358,7 +358,10 @@ func TestTypedNull_STRUCT(t *testing.T) {
 func TestDeprecated_ArrayCodeTypedNull_matchesTypedNull(t *testing.T) {
 	// Deprecated API: must stay equivalent to TypedNull(typector.ElemCodeToArrayType(...)) until removed.
 	got := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
-	want := gcvctor.TypedNull(typector.ElemCodeToArrayType(sppb.TypeCode_INT64))
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_INT64),
+		Value: structpb.NewNullValue(),
+	}
 
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("diff (-want, +got) = %v", diff)
@@ -386,7 +389,10 @@ func TestDeprecated_ArrayTypeTypedNull_matchesTypedNull(t *testing.T) {
 	// Deprecated API: must stay equivalent to TypedNull(typector.ElemTypeToArrayType(...)) until removed.
 	structType := typector.NameCodeToStructType("n", sppb.TypeCode_INT64)
 	got := gcvctor.ArrayTypeTypedNull(structType)
-	want := gcvctor.TypedNull(typector.ElemTypeToArrayType(structType))
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemTypeToArrayType(structType),
+		Value: structpb.NewNullValue(),
+	}
 
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("diff (-want, +got) = %v", diff)
@@ -394,27 +400,32 @@ func TestDeprecated_ArrayTypeTypedNull_matchesTypedNull(t *testing.T) {
 }
 
 func TestArrayValue_zeroLengthIsEmptyInt64Array(t *testing.T) {
-	t.Parallel()
-	want := gcvctor.ElemTypeCodeToEmptyArray(sppb.TypeCode_INT64)
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_INT64),
+		Value: structpb.NewListValue(&structpb.ListValue{}),
+	}
 
 	for _, name := range []string{"no args", "nil slice", "empty slice"} {
-		var got spanner.GenericColumnValue
-		var err error
-		switch name {
-		case "no args":
-			got, err = gcvctor.ArrayValue()
-		case "nil slice":
-			var nilSlice []spanner.GenericColumnValue
-			got, err = gcvctor.ArrayValue(nilSlice...)
-		case "empty slice":
-			got, err = gcvctor.ArrayValue([]spanner.GenericColumnValue{}...)
-		}
-		if err != nil {
-			t.Fatalf("%s: %v", name, err)
-		}
-		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-			t.Errorf("%s: mismatch (-want +got):\n%s", name, diff)
-		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var got spanner.GenericColumnValue
+			var err error
+			switch name {
+			case "no args":
+				got, err = gcvctor.ArrayValue()
+			case "nil slice":
+				var nilSlice []spanner.GenericColumnValue
+				got, err = gcvctor.ArrayValue(nilSlice...)
+			case "empty slice":
+				got, err = gcvctor.ArrayValue([]spanner.GenericColumnValue{}...)
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -436,19 +447,28 @@ func TestArrayValueWithType(t *testing.T) {
 			desc:     "empty INT64 (nil elems)",
 			elemType: int64Elem,
 			elems:    nil,
-			want:     gcvctor.ElemTypeToEmptyArray(int64Elem),
+			want: spanner.GenericColumnValue{
+				Type:  typector.ElemTypeToArrayType(int64Elem),
+				Value: structpb.NewListValue(&structpb.ListValue{}),
+			},
 		},
 		{
 			desc:     "empty ARRAY<STRUCT<n INT64>> (nil elems)",
 			elemType: structElem,
 			elems:    nil,
-			want:     gcvctor.ElemTypeToEmptyArray(structElem),
+			want: spanner.GenericColumnValue{
+				Type:  typector.ElemTypeToArrayType(structElem),
+				Value: structpb.NewListValue(&structpb.ListValue{}),
+			},
 		},
 		{
 			desc:     "empty INT64 (non-nil empty slice)",
 			elemType: int64Elem,
 			elems:    []spanner.GenericColumnValue{},
-			want:     gcvctor.ElemTypeToEmptyArray(int64Elem),
+			want: spanner.GenericColumnValue{
+				Type:  typector.ElemTypeToArrayType(int64Elem),
+				Value: structpb.NewListValue(&structpb.ListValue{}),
+			},
 		},
 		{
 			desc:     "non-empty INT64",


### PR DESCRIPTION
## Summary
- **`ArrayValue`** / **`ArrayValueWithType`**: when **`len == 0`** (no args, nil `...`, or empty slice), return an **empty SQL array** (`ARRAY_LENGTH` 0), same for nil vs non-nil empty variadic—no special NULL case.
- **NULL ARRAY** is **not** produced by empty variadic; use **`ArrayTypeTypedNull`**, **`ArrayCodeTypedNull`**, or **`TypedNull`** (with links in godoc from `ArrayValue` / `ArrayValueWithType` and package `doc.go`).
- **`AGENTS.md`**: empty variadic ⇒ empty array; NULL ⇒ typed-null helpers.

## Test plan
- [x] `make check`