### PR TITLE
feat(gcvctor): ErrNilElementType for nil ArrayValueWithType elemType

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Preserve copied-test attribution comments in `literal_test.go` and `spanner_cli_compatible_test.go`.
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
-- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure.
+- `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`, `ErrNilElementType` for a nil `ArrayValueWithType` element type) on failure.
 - Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -3,6 +3,7 @@ package gcvctor
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -23,6 +24,8 @@ import (
 var (
 	ErrTypeMismatch     = fmt.Errorf("type mismatch")
 	ErrMismatchedCounts = fmt.Errorf("mismatched name/value count")
+	// ErrNilElementType is returned by [ArrayValueWithType] when elemType is nil.
+	ErrNilElementType = errors.New("gcvctor: nil array element type")
 )
 
 func BoolValue(v bool) spanner.GenericColumnValue {
@@ -156,10 +159,10 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 // returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
 // use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType].
 //
-// Each element's Type must match elemType (no coercion).
+// Each element's Type must match elemType (no coercion). A nil elemType returns [ErrNilElementType].
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if elemType == nil {
-		return spanner.GenericColumnValue{}, fmt.Errorf("nil element type")
+		return spanner.GenericColumnValue{}, fmt.Errorf("%w", ErrNilElementType)
 	}
 	if len(elems) == 0 {
 		return ElemTypeToEmptyArray(elemType), nil

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -506,6 +506,7 @@ func TestArrayValueWithType(t *testing.T) {
 			elemType:  nil,
 			elems:     []spanner.GenericColumnValue{gcvctor.Int64Value(1)},
 			expectErr: true,
+			errIs:     gcvctor.ErrNilElementType,
 		},
 		{
 			desc:      "element type mismatch",


### PR DESCRIPTION
## Summary
- Introduce [`ErrNilElementType`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ErrNilElementType) and return `fmt.Errorf("%w", ErrNilElementType)` when [`ArrayValueWithType`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ArrayValueWithType) is called with a nil element type, so callers can use `errors.Is(err, gcvctor.ErrNilElementType)`.
- Document on `ArrayValueWithType` and `AGENTS.md`.

Closes #28

## Test plan
- [x] `make check`

Made with [Cursor](https://cursor.com)