### PR TITLE
feat(gcvctor): SimpleTypedNullArray for NULL ARRAY from element TypeCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - Use `ErrFallthrough` from `FormatComplexFunc` plugins to defer to the built-in array/struct/scalar logic.
 - `IsNull` treats a `spanner.GenericColumnValue` as NULL when its `Value` field is nil or a protobuf `NullValue`; `gcvctor.TypedNull` returns a scalar `NullValue` for all types including `STRUCT` and `ARRAY`. Plugins should check it early when they need custom NULL handling.
 - `gcvctor.ArrayValue` and `gcvctor.StructValue` are strict: they do not coerce types, arrays must be homogeneous, and struct field names must line up with values. They return sentinel errors (`ErrTypeMismatch`, `ErrMismatchedCounts`) on failure.
-- Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `TypedNull` with `typector.ElemTypeToArrayType` or `typector.ElemCodeToArrayType` for NULL ARRAYs.
+- Empty variadic `ArrayValue` / `ArrayValueWithType` builds an empty SQL array (length 0), not NULL; use `SimpleTypedNullArray` for NULL ARRAYs with a simple scalar element code, or `TypedNull` with `typector.ElemTypeToArrayType` / `ElemCodeToArrayType` for other element shapes.
 - `FormatColumn` and formatting functions return sentinel errors (`ErrUnknownType`, `ErrMismatchedFields`) on failure.
 - `gcvctor.Float32Value` and `Float64Value` encode `NaN` and `±Inf` as string values to match Spanner's wire format.
 - Tests commonly use `t.Parallel()`, `cmp.Diff`, and `protocmp.Transform()` when comparing protobuf-backed values.

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -3,8 +3,9 @@
 //
 // [ArrayValue] infers the element type from the first element (or uses a default empty ARRAY<INT64>
 // when len==0, whether the variadic slice is nil or empty). [ArrayValueWithType] takes the element type
-// explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [TypedNull] with
-// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
+// explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY with a simple scalar
+// element code, use [SimpleTypedNullArray], or [TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType], instead of relying
 // on variadic nil. [StructValue] pairs field
 // names with values; counts must match.
 //
@@ -20,7 +21,8 @@
 //
 // [TypedNull] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a scalar protobuf null at the top level. [SimpleTypedNull] does the same for simple
-// scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
+// scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types. [SimpleTypedNullArray] returns a NULL ARRAY whose element type is a
+// simple scalar code (via [github.com/apstndb/spantype/typector.ElemCodeToArrayType]).
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValue] with
 // per-field nulls when you need that shape.
 //

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -138,7 +138,7 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 // With no elements (including a nil or empty variadic slice), it returns an empty ARRAY<INT64>
 // (SQL length zero, not SQL NULL), using a concrete element type so the Type field is a well-formed
 // [cloud.google.com/go/spanner/apiv1/spannerpb.Type] (including array_element_type for ARRAY shapes).
-// For a typed NULL ARRAY<INT64>, use [TypedNull] with
+// For a typed NULL ARRAY<INT64>, use [SimpleTypedNullArray] or [TypedNull] with
 // [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or [github.com/apstndb/spantype/typector.ElemTypeToArrayType]).
 //
 // For other element types or explicit typing policy, use [ArrayValueWithType] or [ElemTypeToEmptyArray].
@@ -153,8 +153,9 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 
 // ArrayValueWithType constructs ARRAY GenericColumnValue using elemType as the element type
 // instead of inferring it from the first element. When elems is empty (nil or length zero), it
-// returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
-// use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType].
+// returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>
+// with a simple scalar element code, use [SimpleTypedNullArray]; otherwise use [TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType].
 //
 // Each element's Type must match elemType (no coercion).
 func ArrayValueWithType(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
@@ -212,6 +213,14 @@ func SimpleTypedNull(code sppb.TypeCode) spanner.GenericColumnValue {
 	}
 }
 
+// SimpleTypedNullArray returns a typed SQL NULL for ARRAY<T> where T is a simple scalar
+// [cloud.google.com/go/spanner/apiv1/spannerpb.TypeCode]. It is equivalent to [TypedNull] with
+// [github.com/apstndb/spantype/typector.ElemCodeToArrayType]. For STRUCT or other non-simple
+// element types, use [TypedNull] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType].
+func SimpleTypedNullArray(elemCode sppb.TypeCode) spanner.GenericColumnValue {
+	return TypedNull(typector.ElemCodeToArrayType(elemCode))
+}
+
 // TypedNull returns a typed NULL for typ.
 // The [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a protobuf
 // NullValue, including when typ is STRUCT or ARRAY.
@@ -236,12 +245,9 @@ func ArrayTypeTypedNull(elemType *sppb.Type) spanner.GenericColumnValue {
 
 // ArrayCodeTypedNull constructs a NULL ARRAY with a simple element type code.
 //
-// Deprecated: Use [github.com/apstndb/spanvalue/gcvctor.TypedNull] with
-// [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead:
-//
-//	TypedNull(typector.ElemCodeToArrayType(elemCode))
+// Deprecated: use [SimpleTypedNullArray].
 func ArrayCodeTypedNull(elemCode sppb.TypeCode) spanner.GenericColumnValue {
-	return TypedNull(typector.ElemCodeToArrayType(elemCode))
+	return SimpleTypedNullArray(elemCode)
 }
 
 func ElemTypeToEmptyArray(typ *sppb.Type) spanner.GenericColumnValue {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -355,9 +355,21 @@ func TestTypedNull_STRUCT(t *testing.T) {
 	}
 }
 
+func TestSimpleTypedNullArray_matchesTypedNull(t *testing.T) {
+	t.Parallel()
+	got := gcvctor.SimpleTypedNullArray(sppb.TypeCode_INT64)
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_INT64),
+		Value: structpb.NewNullValue(),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("diff (-want, +got) = %v", diff)
+	}
+}
+
 func TestDeprecated_ArrayCodeTypedNull_matchesTypedNull(t *testing.T) {
 	t.Parallel()
-	// Deprecated API: must stay equivalent to TypedNull(typector.ElemCodeToArrayType(...)) until removed.
+	// Deprecated API: must stay equivalent to SimpleTypedNullArray / TypedNull(typector.ElemCodeToArrayType(...)) until removed.
 	got := gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)
 	want := spanner.GenericColumnValue{
 		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_INT64),


### PR DESCRIPTION
## Summary
- Add [`SimpleTypedNullArray`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#SimpleTypedNullArray) as the API counterpart to [`SimpleTypedNull`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#SimpleTypedNull) for **NULL ARRAY** when the element type is a simple scalar [`TypeCode`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#TypeCode) (implemented as `TypedNull(typector.ElemCodeToArrayType(...))`).
- [`ArrayCodeTypedNull`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ArrayCodeTypedNull) now delegates to `SimpleTypedNullArray`; deprecation text points at the new helper.
- Update package `doc.go`, `ArrayValue` / `ArrayValueWithType` comments, `AGENTS.md`, and tests.

Closes #37

## Test plan
- [x] `make check`

Made with [Cursor](https://cursor.com)