### PR TITLE
deps: bump spantype to v0.3.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.2
 require (
 	cloud.google.com/go v0.121.4
 	cloud.google.com/go/spanner v1.84.1
-	github.com/apstndb/spantype v0.3.6
+	github.com/apstndb/spantype v0.3.10
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apstndb/spantype v0.3.6 h1:vHMsjpuE2m+Y4Q2FJ1W11nFTd0vMHLzfBWISr6RWAX0=
-github.com/apstndb/spantype v0.3.6/go.mod h1:y0EmWJfRVoJEaZZfJS6j2Y9xXPyXoQwtngibq9A3RT8=
+github.com/apstndb/spantype v0.3.10 h1:6iSctAPl15UnOuaZweVozjx/kpbPnZGRtitAX45zaNA=
+github.com/apstndb/spantype v0.3.10/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
## Summary

Bump `github.com/apstndb/spantype` from **v0.3.6** (current `main`) to **v0.3.10**.

`make check` passes.

## Notes on semver range

This PR moves `main` **v0.3.6 → v0.3.10**, so it also includes **v0.3.7–v0.3.9** (not only the delta below). The following section is the **full v0.3.9 → v0.3.10** module diff review.

## v0.3.9 → v0.3.10: files changed

| Path | Kind of change |
|------|----------------|
| `.github/workflows/go.yml` | CI: `actions/setup-go@v5`, `go-version-file: go.mod` (was fixed `1.21`) |
| `AGENTS.md` | **New** repository guidelines |
| `README.md` | Expanded: `spantype` vs `typector`, FormatType\* table, `typector` conventions, CLI example |
| `cmd/spantype/README.md` | Document `--mode=more` |
| `cmd/spantype/main.go` | Flag help + import order; `more` mode already supported in code path |
| `format.go` | Package/typedocs; **behavior**: `FormatStructFields` appends `typeStr` without redundant `fmt.Sprintf("%v", …)` (equivalent for `string`); godoc typo fixes (`ARRAY`, commas) |
| `format_test.go` | Subtest order + fix error string `FormatProtoEnum` vs `FormatTypeCode` |
| `typector/typector.go` | Package doc + per-function godoc for constructors (no signature changes) |

## Impact on spanvalue

- **No changes required** in `spanvalue` source: public APIs used (`typector` builders, `spantype.FormatTypeMoreVerbose`, etc.) are unchanged.
- **Functional risk**: very low — only observable runtime change in `format.go` is equivalent string assembly for STRUCT field lines.

## Re-request Copilot review

After opening, request a fresh Copilot review with:

`gh copilot-review request <PR#>`

(Optionally `--wait` to poll until the review finishes.)

Gemini Code Review is not used (quota).
