### PR TITLE
gcvctor: add validated string constructors

### DIFF
--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -116,9 +116,27 @@ func DateValue(v civil.Date) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_DATE, v.String())
 }
 
+// DateStringValue validates an RFC3339 full-date string and returns a non-null DATE GenericColumnValue.
+func DateStringValue(v string) (spanner.GenericColumnValue, error) {
+	d, err := civil.ParseDate(v)
+	if err != nil {
+		return spanner.GenericColumnValue{}, err
+	}
+	return DateValue(d), nil
+}
+
 // TimestampValue returns a non-null TIMESTAMP GenericColumnValue (RFC3339Nano string wire format).
 func TimestampValue(v time.Time) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, v.Format(time.RFC3339Nano))
+}
+
+// TimestampStringValue validates an RFC3339Nano timestamp string and returns a non-null TIMESTAMP GenericColumnValue.
+func TimestampStringValue(v string) (spanner.GenericColumnValue, error) {
+	ts, err := time.Parse(time.RFC3339Nano, v)
+	if err != nil {
+		return spanner.GenericColumnValue{}, err
+	}
+	return TimestampValue(ts), nil
 }
 
 // NumericValue returns a non-null NUMERIC GenericColumnValue.
@@ -129,6 +147,15 @@ func NumericValue(v *big.Rat) spanner.GenericColumnValue {
 // IntervalValue returns a non-null INTERVAL GenericColumnValue.
 func IntervalValue(v spanner.Interval) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_INTERVAL, v.String())
+}
+
+// IntervalStringValue validates an ISO8601 duration string and returns a non-null INTERVAL GenericColumnValue.
+func IntervalStringValue(v string) (spanner.GenericColumnValue, error) {
+	iv, err := spanner.ParseInterval(v)
+	if err != nil {
+		return spanner.GenericColumnValue{}, err
+	}
+	return IntervalValue(iv), nil
 }
 
 // UUIDValue returns a non-null UUID GenericColumnValue.

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -116,7 +116,8 @@ func DateValue(v civil.Date) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_DATE, v.String())
 }
 
-// DateStringValue validates an RFC3339 full-date string and returns a non-null DATE GenericColumnValue.
+// DateStringValue validates an RFC3339 full-date string and returns a non-null DATE
+// GenericColumnValue using the canonical DATE wire string.
 func DateStringValue(v string) (spanner.GenericColumnValue, error) {
 	d, err := civil.ParseDate(v)
 	if err != nil {
@@ -130,13 +131,14 @@ func TimestampValue(v time.Time) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, v.Format(time.RFC3339Nano))
 }
 
-// TimestampStringValue validates an RFC3339Nano timestamp string and returns a non-null TIMESTAMP GenericColumnValue.
+// TimestampStringValue validates an RFC3339Nano timestamp string and returns a non-null
+// TIMESTAMP GenericColumnValue using the canonical UTC wire string.
 func TimestampStringValue(v string) (spanner.GenericColumnValue, error) {
 	ts, err := time.Parse(time.RFC3339Nano, v)
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
-	return TimestampValue(ts), nil
+	return TimestampValue(ts.UTC()), nil
 }
 
 // NumericValue returns a non-null NUMERIC GenericColumnValue.
@@ -149,7 +151,8 @@ func IntervalValue(v spanner.Interval) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_INTERVAL, v.String())
 }
 
-// IntervalStringValue validates an ISO8601 duration string and returns a non-null INTERVAL GenericColumnValue.
+// IntervalStringValue validates an ISO8601 duration string and returns a non-null
+// INTERVAL GenericColumnValue using spanner.Interval's canonical wire string.
 func IntervalStringValue(v string) (spanner.GenericColumnValue, error) {
 	iv, err := spanner.ParseInterval(v)
 	if err != nil {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -336,6 +336,85 @@ func TestParseExpr(t *testing.T) {
 	}
 }
 
+func TestValidatedStringValueHelpers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		call    func(string) (spanner.GenericColumnValue, error)
+		want    spanner.GenericColumnValue
+		wantErr bool
+	}{
+		{
+			name:  "DATE valid",
+			input: "2024-01-15",
+			call:  gcvctor.DateStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_DATE),
+				Value: structpb.NewStringValue("2024-01-15"),
+			},
+		},
+		{
+			name:    "DATE invalid",
+			input:   "2024-02-30",
+			call:    gcvctor.DateStringValue,
+			wantErr: true,
+		},
+		{
+			name:  "TIMESTAMP valid",
+			input: "2024-01-15T12:34:56.789Z",
+			call:  gcvctor.TimestampStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_TIMESTAMP),
+				Value: structpb.NewStringValue("2024-01-15T12:34:56.789Z"),
+			},
+		},
+		{
+			name:    "TIMESTAMP invalid",
+			input:   "2024-01-15 12:34:56",
+			call:    gcvctor.TimestampStringValue,
+			wantErr: true,
+		},
+		{
+			name:  "INTERVAL valid",
+			input: "P1Y2M3DT4H5M6S",
+			call:  gcvctor.IntervalStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_INTERVAL),
+				Value: structpb.NewStringValue("P1Y2M3DT4H5M6S"),
+			},
+		},
+		{
+			name:    "INTERVAL invalid",
+			input:   "not-an-interval",
+			call:    gcvctor.IntervalStringValue,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.call(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestNullRawValueFromType_EnumerateSimpleTypes(t *testing.T) {
 	for rawcode, typename := range sppb.TypeCode_name {
 		if typename == "STRUCT" || typename == "ARRAY" {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -371,6 +371,15 @@ func TestValidatedStringValueHelpers(t *testing.T) {
 			},
 		},
 		{
+			name:  "TIMESTAMP canonical UTC",
+			input: "2024-01-15T21:34:56.789+09:00",
+			call:  gcvctor.TimestampStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_TIMESTAMP),
+				Value: structpb.NewStringValue("2024-01-15T12:34:56.789Z"),
+			},
+		},
+		{
 			name:    "TIMESTAMP invalid",
 			input:   "2024-01-15 12:34:56",
 			call:    gcvctor.TimestampStringValue,


### PR DESCRIPTION
## Summary
- add validated string-based helpers for `DATE`, `TIMESTAMP`, and `INTERVAL` values in `gcvctor`
- reuse the existing typed constructors after parsing via `civil.ParseDate`, `time.Parse(time.RFC3339Nano, ...)`, and `spanner.ParseInterval`
- add unit tests for valid and invalid input cases

Partially addresses #24 (item 6).