### PR TITLE
spanvalue: add dialect quote helpers

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -18,6 +18,7 @@ func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 }
 
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
+// It does not validate the path; callers that reject empty segments must do so before calling it.
 func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	parts := strings.Split(name, ".")
 	for i, part := range parts {

--- a/dialect.go
+++ b/dialect.go
@@ -1,0 +1,30 @@
+package spanvalue
+
+import "strings"
+
+// SQLDialect selects SQL-surface details such as identifier quoting rules.
+type SQLDialect string
+
+const (
+	SQLDialectGoogleSQL  SQLDialect = "googlesql"
+	SQLDialectPostgreSQL SQLDialect = "postgresql"
+)
+
+// QuoteIdentifier quotes a single identifier for dialect.
+func QuoteIdentifier(dialect SQLDialect, name string) string {
+	switch dialect {
+	case SQLDialectPostgreSQL:
+		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	default:
+		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	}
+}
+
+// QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
+func QuoteQualifiedIdentifier(dialect SQLDialect, name string) string {
+	parts := strings.Split(name, ".")
+	for i, part := range parts {
+		parts[i] = QuoteIdentifier(dialect, part)
+	}
+	return strings.Join(parts, ".")
+}

--- a/dialect.go
+++ b/dialect.go
@@ -1,19 +1,16 @@
 package spanvalue
 
-import "strings"
+import (
+	"strings"
 
-// SQLDialect selects SQL-surface details such as identifier quoting rules.
-type SQLDialect string
-
-const (
-	SQLDialectGoogleSQL  SQLDialect = "googlesql"
-	SQLDialectPostgreSQL SQLDialect = "postgresql"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 )
 
 // QuoteIdentifier quotes a single identifier for dialect.
-func QuoteIdentifier(dialect SQLDialect, name string) string {
+// DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
+func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {
-	case SQLDialectPostgreSQL:
+	case databasepb.DatabaseDialect_POSTGRESQL:
 		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 	default:
 		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
@@ -21,7 +18,7 @@ func QuoteIdentifier(dialect SQLDialect, name string) string {
 }
 
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
-func QuoteQualifiedIdentifier(dialect SQLDialect, name string) string {
+func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	parts := strings.Split(name, ".")
 	for i, part := range parts {
 		parts[i] = QuoteIdentifier(dialect, part)

--- a/dialect.go
+++ b/dialect.go
@@ -21,6 +21,9 @@ func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
 // It does not validate the path; callers that reject empty segments must do so before calling it.
 func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
+	if !strings.Contains(name, ".") {
+		return QuoteIdentifier(dialect, name)
+	}
 	parts := strings.Split(name, ".")
 	for i, part := range parts {
 		parts[i] = QuoteIdentifier(dialect, part)

--- a/dialect.go
+++ b/dialect.go
@@ -7,6 +7,7 @@ import (
 )
 
 // QuoteIdentifier quotes a single identifier for dialect.
+// It does not validate the identifier; for example, an empty string becomes an empty quoted identifier.
 // DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
 func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,0 +1,54 @@
+package spanvalue
+
+import "testing"
+
+func TestQuoteIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect SQLDialect
+		input   string
+		want    string
+	}{
+		{"GoogleSQL simple", SQLDialectGoogleSQL, "table", "`table`"},
+		{"GoogleSQL escapes backtick", SQLDialectGoogleSQL, "a`b", "`a``b`"},
+		{"PostgreSQL simple", SQLDialectPostgreSQL, "table", `"table"`},
+		{"PostgreSQL escapes quote", SQLDialectPostgreSQL, `a"b`, `"a""b"`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := QuoteIdentifier(tt.dialect, tt.input); got != tt.want {
+				t.Fatalf("QuoteIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuoteQualifiedIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect SQLDialect
+		input   string
+		want    string
+	}{
+		{"GoogleSQL qualified", SQLDialectGoogleSQL, "schema.table", "`schema`.`table`"},
+		{"PostgreSQL qualified", SQLDialectPostgreSQL, "schema.table", `"schema"."table"`},
+		{"GoogleSQL preserves empty segment shape", SQLDialectGoogleSQL, "schema..table", "`schema`.``.`table`"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := QuoteQualifiedIdentifier(tt.dialect, tt.input); got != tt.want {
+				t.Fatalf("QuoteQualifiedIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -27,7 +27,7 @@ func TestQuoteIdentifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteIdentifier(tt.dialect, tt.input); got != tt.want {
-				t.Fatalf("QuoteIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+				t.Fatalf("QuoteIdentifier(%v, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
 			}
 		})
 	}
@@ -52,7 +52,7 @@ func TestQuoteQualifiedIdentifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteQualifiedIdentifier(tt.dialect, tt.input); got != tt.want {
-				t.Fatalf("QuoteQualifiedIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+				t.Fatalf("QuoteQualifiedIdentifier(%v, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
 			}
 		})
 	}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,20 +1,25 @@
 package spanvalue
 
-import "testing"
+import (
+	"testing"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
 
 func TestQuoteIdentifier(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name    string
-		dialect SQLDialect
+		dialect databasepb.DatabaseDialect
 		input   string
 		want    string
 	}{
-		{"GoogleSQL simple", SQLDialectGoogleSQL, "table", "`table`"},
-		{"GoogleSQL escapes backtick", SQLDialectGoogleSQL, "a`b", "`a``b`"},
-		{"PostgreSQL simple", SQLDialectPostgreSQL, "table", `"table"`},
-		{"PostgreSQL escapes quote", SQLDialectPostgreSQL, `a"b`, `"a""b"`},
+		{"GoogleSQL simple", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "table", "`table`"},
+		{"GoogleSQL escapes backtick", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "a`b", "`a``b`"},
+		{"PostgreSQL simple", databasepb.DatabaseDialect_POSTGRESQL, "table", `"table"`},
+		{"PostgreSQL escapes quote", databasepb.DatabaseDialect_POSTGRESQL, `a"b`, `"a""b"`},
+		{"Unspecified defaults to GoogleSQL", databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, "table", "`table`"},
 	}
 
 	for _, tt := range tests {
@@ -33,13 +38,13 @@ func TestQuoteQualifiedIdentifier(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		dialect SQLDialect
+		dialect databasepb.DatabaseDialect
 		input   string
 		want    string
 	}{
-		{"GoogleSQL qualified", SQLDialectGoogleSQL, "schema.table", "`schema`.`table`"},
-		{"PostgreSQL qualified", SQLDialectPostgreSQL, "schema.table", `"schema"."table"`},
-		{"GoogleSQL preserves empty segment shape", SQLDialectGoogleSQL, "schema..table", "`schema`.``.`table`"},
+		{"GoogleSQL qualified", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "schema.table", "`schema`.`table`"},
+		{"PostgreSQL qualified", databasepb.DatabaseDialect_POSTGRESQL, "schema.table", `"schema"."table"`},
+		{"GoogleSQL preserves empty segment shape", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "schema..table", "`schema`.``.`table`"},
 	}
 
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	cloud.google.com/go/auth v0.16.3 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
+	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -508,10 +508,12 @@ func quoteIdentifiers(names []string) ([]string, error) {
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	for _, part := range parts {
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
+		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
 	}
-	return spanvalue.QuoteQualifiedIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name), nil
+	return strings.Join(quoted, "."), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -508,12 +508,11 @@ func quoteIdentifiers(names []string) ([]string, error) {
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	quoted := make([]string, len(parts))
 	for i, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
-		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
+		parts[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
 	}
-	return strings.Join(quoted, "."), nil
+	return strings.Join(parts, "."), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -499,24 +499,18 @@ func quoteIdentifiers(names []string) ([]string, error) {
 		if name == "" {
 			return nil, ErrEmptyColumnName
 		}
-		quoted[i] = quoteIdentifier(name)
+		quoted[i] = spanvalue.QuoteIdentifier(spanvalue.SQLDialectGoogleSQL, name)
 	}
 	return quoted, nil
-}
-
-// quoteIdentifier quotes a GoogleSQL identifier, escaping backticks by doubling them.
-func quoteIdentifier(name string) string {
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	for i, part := range parts {
+	for _, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
-		parts[i] = quoteIdentifier(part)
 	}
-	return strings.Join(parts, "."), nil
+	return spanvalue.QuoteQualifiedIdentifier(spanvalue.SQLDialectGoogleSQL, name), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/spanner"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 
 	"github.com/apstndb/spanvalue"
@@ -499,7 +500,7 @@ func quoteIdentifiers(names []string) ([]string, error) {
 		if name == "" {
 			return nil, ErrEmptyColumnName
 		}
-		quoted[i] = spanvalue.QuoteIdentifier(spanvalue.SQLDialectGoogleSQL, name)
+		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name)
 	}
 	return quoted, nil
 }
@@ -512,5 +513,5 @@ func quoteQualifiedIdentifier(name string) (string, error) {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
 	}
-	return spanvalue.QuoteQualifiedIdentifier(spanvalue.SQLDialectGoogleSQL, name), nil
+	return spanvalue.QuoteQualifiedIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name), nil
 }


### PR DESCRIPTION
## Summary
- add generic SQL dialect identifier quoting helpers for GoogleSQL and PostgreSQL
- cover identifier and qualified-identifier quoting behavior with unit tests
- switch writers GoogleSQL quoting path to reuse the shared helpers while keeping existing validation behavior

Partially addresses #24 (item 3).