### PR TITLE
gcvctor: reject nil struct field types

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -18,6 +18,7 @@ func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 }
 
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
+// It does not validate the path; callers that reject empty segments must do so before calling it.
 func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	parts := strings.Split(name, ".")
 	for i, part := range parts {

--- a/dialect.go
+++ b/dialect.go
@@ -1,0 +1,30 @@
+package spanvalue
+
+import "strings"
+
+// SQLDialect selects SQL-surface details such as identifier quoting rules.
+type SQLDialect string
+
+const (
+	SQLDialectGoogleSQL  SQLDialect = "googlesql"
+	SQLDialectPostgreSQL SQLDialect = "postgresql"
+)
+
+// QuoteIdentifier quotes a single identifier for dialect.
+func QuoteIdentifier(dialect SQLDialect, name string) string {
+	switch dialect {
+	case SQLDialectPostgreSQL:
+		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	default:
+		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	}
+}
+
+// QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
+func QuoteQualifiedIdentifier(dialect SQLDialect, name string) string {
+	parts := strings.Split(name, ".")
+	for i, part := range parts {
+		parts[i] = QuoteIdentifier(dialect, part)
+	}
+	return strings.Join(parts, ".")
+}

--- a/dialect.go
+++ b/dialect.go
@@ -1,19 +1,16 @@
 package spanvalue
 
-import "strings"
+import (
+	"strings"
 
-// SQLDialect selects SQL-surface details such as identifier quoting rules.
-type SQLDialect string
-
-const (
-	SQLDialectGoogleSQL  SQLDialect = "googlesql"
-	SQLDialectPostgreSQL SQLDialect = "postgresql"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 )
 
 // QuoteIdentifier quotes a single identifier for dialect.
-func QuoteIdentifier(dialect SQLDialect, name string) string {
+// DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
+func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {
-	case SQLDialectPostgreSQL:
+	case databasepb.DatabaseDialect_POSTGRESQL:
 		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 	default:
 		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
@@ -21,7 +18,7 @@ func QuoteIdentifier(dialect SQLDialect, name string) string {
 }
 
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
-func QuoteQualifiedIdentifier(dialect SQLDialect, name string) string {
+func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	parts := strings.Split(name, ".")
 	for i, part := range parts {
 		parts[i] = QuoteIdentifier(dialect, part)

--- a/dialect.go
+++ b/dialect.go
@@ -21,6 +21,9 @@ func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 // QuoteQualifiedIdentifier quotes each segment of a dotted identifier path for dialect.
 // It does not validate the path; callers that reject empty segments must do so before calling it.
 func QuoteQualifiedIdentifier(dialect databasepb.DatabaseDialect, name string) string {
+	if !strings.Contains(name, ".") {
+		return QuoteIdentifier(dialect, name)
+	}
 	parts := strings.Split(name, ".")
 	for i, part := range parts {
 		parts[i] = QuoteIdentifier(dialect, part)

--- a/dialect.go
+++ b/dialect.go
@@ -7,6 +7,7 @@ import (
 )
 
 // QuoteIdentifier quotes a single identifier for dialect.
+// It does not validate the identifier; for example, an empty string becomes an empty quoted identifier.
 // DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
 func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,0 +1,54 @@
+package spanvalue
+
+import "testing"
+
+func TestQuoteIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect SQLDialect
+		input   string
+		want    string
+	}{
+		{"GoogleSQL simple", SQLDialectGoogleSQL, "table", "`table`"},
+		{"GoogleSQL escapes backtick", SQLDialectGoogleSQL, "a`b", "`a``b`"},
+		{"PostgreSQL simple", SQLDialectPostgreSQL, "table", `"table"`},
+		{"PostgreSQL escapes quote", SQLDialectPostgreSQL, `a"b`, `"a""b"`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := QuoteIdentifier(tt.dialect, tt.input); got != tt.want {
+				t.Fatalf("QuoteIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuoteQualifiedIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect SQLDialect
+		input   string
+		want    string
+	}{
+		{"GoogleSQL qualified", SQLDialectGoogleSQL, "schema.table", "`schema`.`table`"},
+		{"PostgreSQL qualified", SQLDialectPostgreSQL, "schema.table", `"schema"."table"`},
+		{"GoogleSQL preserves empty segment shape", SQLDialectGoogleSQL, "schema..table", "`schema`.``.`table`"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := QuoteQualifiedIdentifier(tt.dialect, tt.input); got != tt.want {
+				t.Fatalf("QuoteQualifiedIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -27,7 +27,7 @@ func TestQuoteIdentifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteIdentifier(tt.dialect, tt.input); got != tt.want {
-				t.Fatalf("QuoteIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+				t.Fatalf("QuoteIdentifier(%v, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
 			}
 		})
 	}
@@ -52,7 +52,7 @@ func TestQuoteQualifiedIdentifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteQualifiedIdentifier(tt.dialect, tt.input); got != tt.want {
-				t.Fatalf("QuoteQualifiedIdentifier(%q, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+				t.Fatalf("QuoteQualifiedIdentifier(%v, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
 			}
 		})
 	}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,20 +1,25 @@
 package spanvalue
 
-import "testing"
+import (
+	"testing"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
 
 func TestQuoteIdentifier(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name    string
-		dialect SQLDialect
+		dialect databasepb.DatabaseDialect
 		input   string
 		want    string
 	}{
-		{"GoogleSQL simple", SQLDialectGoogleSQL, "table", "`table`"},
-		{"GoogleSQL escapes backtick", SQLDialectGoogleSQL, "a`b", "`a``b`"},
-		{"PostgreSQL simple", SQLDialectPostgreSQL, "table", `"table"`},
-		{"PostgreSQL escapes quote", SQLDialectPostgreSQL, `a"b`, `"a""b"`},
+		{"GoogleSQL simple", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "table", "`table`"},
+		{"GoogleSQL escapes backtick", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "a`b", "`a``b`"},
+		{"PostgreSQL simple", databasepb.DatabaseDialect_POSTGRESQL, "table", `"table"`},
+		{"PostgreSQL escapes quote", databasepb.DatabaseDialect_POSTGRESQL, `a"b`, `"a""b"`},
+		{"Unspecified defaults to GoogleSQL", databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, "table", "`table`"},
 	}
 
 	for _, tt := range tests {
@@ -33,13 +38,13 @@ func TestQuoteQualifiedIdentifier(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		dialect SQLDialect
+		dialect databasepb.DatabaseDialect
 		input   string
 		want    string
 	}{
-		{"GoogleSQL qualified", SQLDialectGoogleSQL, "schema.table", "`schema`.`table`"},
-		{"PostgreSQL qualified", SQLDialectPostgreSQL, "schema.table", `"schema"."table"`},
-		{"GoogleSQL preserves empty segment shape", SQLDialectGoogleSQL, "schema..table", "`schema`.``.`table`"},
+		{"GoogleSQL qualified", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "schema.table", "`schema`.`table`"},
+		{"PostgreSQL qualified", databasepb.DatabaseDialect_POSTGRESQL, "schema.table", `"schema"."table"`},
+		{"GoogleSQL preserves empty segment shape", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "schema..table", "`schema`.``.`table`"},
 	}
 
 	for _, tt := range tests {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -28,6 +28,8 @@ var (
 	ErrMismatchedCounts = errors.New("gcvctor: mismatched name/value count")
 	// ErrNilElementType is returned by [ArrayValueOf] when elemType is nil.
 	ErrNilElementType = errors.New("gcvctor: nil array element type")
+	// ErrNilFieldType is returned by [StructValueOf] when a field's Type is nil.
+	ErrNilFieldType = errors.New("gcvctor: nil struct field type")
 )
 
 // BoolValue returns a non-null BOOL GenericColumnValue.
@@ -255,6 +257,7 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 }
 
 // StructValueOf constructs STRUCT GenericColumnValue.
+// A nil field Type returns [ErrNilFieldType].
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.
 func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if len(names) != len(gcvs) {
@@ -263,7 +266,13 @@ func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.G
 
 	var types []*sppb.Type
 	var values []*structpb.Value
-	for _, gcv := range gcvs {
+	for i, gcv := range gcvs {
+		if gcv.Type == nil {
+			if names[i] == "" {
+				return spanner.GenericColumnValue{}, fmt.Errorf("%w: field %d", ErrNilFieldType, i)
+			}
+			return spanner.GenericColumnValue{}, fmt.Errorf("%w: field %d (%q)", ErrNilFieldType, i, names[i])
+		}
 		types = append(types, gcv.Type)
 		values = append(values, gcv.Value)
 	}

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -627,6 +628,89 @@ func TestArrayValueOf(t *testing.T) {
 				}
 				if tt.errIs != nil && !errors.Is(err, tt.errIs) {
 					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				var zero spanner.GenericColumnValue
+				if diff := cmp.Diff(zero, got, protocmp.Transform()); diff != "" {
+					t.Errorf("expected zero value on error (-want +got):\n%s", diff)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStructValueOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc      string
+		names     []string
+		gcvs      []spanner.GenericColumnValue
+		want      spanner.GenericColumnValue
+		expectErr bool
+		errIs     error
+		errSubstr string
+	}{
+		{
+			desc:  "single field",
+			names: []string{"a"},
+			gcvs:  []spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			want: spanner.GenericColumnValue{
+				Type: must(typector.NameCodeSlicesToStructType(
+					[]string{"a"},
+					[]sppb.TypeCode{sppb.TypeCode_INT64},
+				)),
+				Value: structpb.NewListValue(&structpb.ListValue{
+					Values: []*structpb.Value{structpb.NewStringValue("1")},
+				}),
+			},
+		},
+		{
+			desc:      "mismatched counts",
+			names:     []string{"a"},
+			gcvs:      nil,
+			expectErr: true,
+			errIs:     gcvctor.ErrMismatchedCounts,
+		},
+		{
+			desc:      "nil field type named",
+			names:     []string{"broken"},
+			gcvs:      []spanner.GenericColumnValue{{}},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: `field 0 ("broken")`,
+		},
+		{
+			desc:      "nil field type unnamed",
+			names:     []string{""},
+			gcvs:      []spanner.GenericColumnValue{{}},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: "field 0",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := gcvctor.StructValueOf(tt.names, tt.gcvs)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err, tt.errSubstr)
 				}
 				var zero spanner.GenericColumnValue
 				if diff := cmp.Diff(zero, got, protocmp.Transform()); diff != "" {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	cloud.google.com/go/auth v0.16.3 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
+	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -508,10 +508,12 @@ func quoteIdentifiers(names []string) ([]string, error) {
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	for _, part := range parts {
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
+		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
 	}
-	return spanvalue.QuoteQualifiedIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name), nil
+	return strings.Join(quoted, "."), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -508,12 +508,11 @@ func quoteIdentifiers(names []string) ([]string, error) {
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	quoted := make([]string, len(parts))
 	for i, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
-		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
+		parts[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
 	}
-	return strings.Join(quoted, "."), nil
+	return strings.Join(parts, "."), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -499,24 +499,18 @@ func quoteIdentifiers(names []string) ([]string, error) {
 		if name == "" {
 			return nil, ErrEmptyColumnName
 		}
-		quoted[i] = quoteIdentifier(name)
+		quoted[i] = spanvalue.QuoteIdentifier(spanvalue.SQLDialectGoogleSQL, name)
 	}
 	return quoted, nil
-}
-
-// quoteIdentifier quotes a GoogleSQL identifier, escaping backticks by doubling them.
-func quoteIdentifier(name string) string {
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
 // quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
 func quoteQualifiedIdentifier(name string) (string, error) {
 	parts := strings.Split(name, ".")
-	for i, part := range parts {
+	for _, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
-		parts[i] = quoteIdentifier(part)
 	}
-	return strings.Join(parts, "."), nil
+	return spanvalue.QuoteQualifiedIdentifier(spanvalue.SQLDialectGoogleSQL, name), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/spanner"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 
 	"github.com/apstndb/spanvalue"
@@ -499,7 +500,7 @@ func quoteIdentifiers(names []string) ([]string, error) {
 		if name == "" {
 			return nil, ErrEmptyColumnName
 		}
-		quoted[i] = spanvalue.QuoteIdentifier(spanvalue.SQLDialectGoogleSQL, name)
+		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name)
 	}
 	return quoted, nil
 }
@@ -512,5 +513,5 @@ func quoteQualifiedIdentifier(name string) (string, error) {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
 	}
-	return spanvalue.QuoteQualifiedIdentifier(spanvalue.SQLDialectGoogleSQL, name), nil
+	return spanvalue.QuoteQualifiedIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name), nil
 }


### PR DESCRIPTION
## Summary
- reject `StructValueOf` inputs whose field `Type` is nil instead of constructing a malformed STRUCT
- add `ErrNilFieldType` so callers can use `errors.Is` on the new failure mode
- cover named and unnamed nil-field cases in unit tests

Closes #54.