### PR TITLE
gcvctor: reject nil struct field types

### DIFF
--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -264,8 +264,8 @@ func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.G
 		return spanner.GenericColumnValue{}, fmt.Errorf("%w: len(names)=%v != len(gcvs)=%v", ErrMismatchedCounts, len(names), len(gcvs))
 	}
 
-	var types []*sppb.Type
-	var values []*structpb.Value
+	types := make([]*sppb.Type, len(gcvs))
+	values := make([]*structpb.Value, len(gcvs))
 	for i, gcv := range gcvs {
 		if gcv.Type == nil {
 			if names[i] == "" {
@@ -273,8 +273,8 @@ func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.G
 			}
 			return spanner.GenericColumnValue{}, fmt.Errorf("%w: field %d (%q)", ErrNilFieldType, i, names[i])
 		}
-		types = append(types, gcv.Type)
-		values = append(values, gcv.Value)
+		types[i] = gcv.Type
+		values[i] = gcv.Value
 	}
 
 	typ, err := typector.NameTypeSlicesToStructType(names, types)

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -28,6 +28,8 @@ var (
 	ErrMismatchedCounts = errors.New("gcvctor: mismatched name/value count")
 	// ErrNilElementType is returned by [ArrayValueOf] when elemType is nil.
 	ErrNilElementType = errors.New("gcvctor: nil array element type")
+	// ErrNilFieldType is returned by [StructValueOf] when a field's Type is nil.
+	ErrNilFieldType = errors.New("gcvctor: nil struct field type")
 )
 
 // BoolValue returns a non-null BOOL GenericColumnValue.
@@ -255,6 +257,7 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 }
 
 // StructValueOf constructs STRUCT GenericColumnValue.
+// A nil field Type returns [ErrNilFieldType].
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.
 func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if len(names) != len(gcvs) {
@@ -263,7 +266,13 @@ func StructValueOf(names []string, gcvs []spanner.GenericColumnValue) (spanner.G
 
 	var types []*sppb.Type
 	var values []*structpb.Value
-	for _, gcv := range gcvs {
+	for i, gcv := range gcvs {
+		if gcv.Type == nil {
+			if names[i] == "" {
+				return spanner.GenericColumnValue{}, fmt.Errorf("%w: field %d", ErrNilFieldType, i)
+			}
+			return spanner.GenericColumnValue{}, fmt.Errorf("%w: field %d (%q)", ErrNilFieldType, i, names[i])
+		}
 		types = append(types, gcv.Type)
 		values = append(values, gcv.Value)
 	}

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -627,6 +628,89 @@ func TestArrayValueOf(t *testing.T) {
 				}
 				if tt.errIs != nil && !errors.Is(err, tt.errIs) {
 					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				var zero spanner.GenericColumnValue
+				if diff := cmp.Diff(zero, got, protocmp.Transform()); diff != "" {
+					t.Errorf("expected zero value on error (-want +got):\n%s", diff)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStructValueOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc      string
+		names     []string
+		gcvs      []spanner.GenericColumnValue
+		want      spanner.GenericColumnValue
+		expectErr bool
+		errIs     error
+		errSubstr string
+	}{
+		{
+			desc:  "single field",
+			names: []string{"a"},
+			gcvs:  []spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			want: spanner.GenericColumnValue{
+				Type: must(typector.NameCodeSlicesToStructType(
+					[]string{"a"},
+					[]sppb.TypeCode{sppb.TypeCode_INT64},
+				)),
+				Value: structpb.NewListValue(&structpb.ListValue{
+					Values: []*structpb.Value{structpb.NewStringValue("1")},
+				}),
+			},
+		},
+		{
+			desc:      "mismatched counts",
+			names:     []string{"a"},
+			gcvs:      nil,
+			expectErr: true,
+			errIs:     gcvctor.ErrMismatchedCounts,
+		},
+		{
+			desc:      "nil field type named",
+			names:     []string{"broken"},
+			gcvs:      []spanner.GenericColumnValue{{}},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: `field 0 ("broken")`,
+		},
+		{
+			desc:      "nil field type unnamed",
+			names:     []string{""},
+			gcvs:      []spanner.GenericColumnValue{{}},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: "field 0",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := gcvctor.StructValueOf(tt.names, tt.gcvs)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err, tt.errSubstr)
 				}
 				var zero spanner.GenericColumnValue
 				if diff := cmp.Diff(zero, got, protocmp.Transform()); diff != "" {


### PR DESCRIPTION
## Summary
- reject `StructValueOf` inputs whose field `Type` is nil instead of constructing a malformed STRUCT
- add `ErrNilFieldType` so callers can use `errors.Is` on the new failure mode
- cover named and unnamed nil-field cases in unit tests

Closes #54.