### PR TITLE
spanvalue: return ErrNilRow for nil rows

### DIFF
--- a/common.go
+++ b/common.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	ErrNilRow           = errors.New("nil row")
 	ErrUnknownType      = errors.New("unknown type")
 	ErrMismatchedFields = errors.New("mismatched struct value/field count")
 )
@@ -247,6 +248,9 @@ func (fc *FormatConfig) FormatColumn(value spanner.GenericColumnValue, toplevel 
 }
 
 func (fc *FormatConfig) FormatRow(row *spanner.Row) ([]string, error) {
+	if row == nil {
+		return nil, ErrNilRow
+	}
 	gcvs := make([]spanner.GenericColumnValue, row.Size())
 	if err := row.Columns(slices.Collect(internal.ToAny(internal.Pointers(gcvs)))...); err != nil {
 		return nil, err

--- a/common_test.go
+++ b/common_test.go
@@ -1,6 +1,7 @@
 package spanvalue
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
@@ -167,5 +168,53 @@ func TestFormatColumn_PostgreSQLAnnotatedTypes(t *testing.T) {
 	}
 	if got, want := spantype.FormatTypeVerbose(typector.PGJSONB()), "JSON(PG_JSONB)"; got != want {
 		t.Errorf("FormatTypeVerbose(PGJSONB): got %q want %q", got, want)
+	}
+}
+
+func TestFormatRowNilRow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "FormatConfig.FormatRow",
+			call: func() error {
+				_, err := SimpleFormatConfig().FormatRow(nil)
+				return err
+			},
+		},
+		{
+			name: "FormatRowLiteral",
+			call: func() error {
+				_, err := FormatRowLiteral(nil)
+				return err
+			},
+		},
+		{
+			name: "FormatRowSpannerCLICompatible",
+			call: func() error {
+				_, err := FormatRowSpannerCLICompatible(nil)
+				return err
+			},
+		},
+		{
+			name: "FormatRowJSONObject",
+			call: func() error {
+				_, err := FormatRowJSONObject(JSONFormatConfig(), nil, IndexedUnnamedFieldNamer)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.call(); !errors.Is(err, ErrNilRow) {
+				t.Fatalf("error = %v, want ErrNilRow", err)
+			}
+		})
 	}
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -26,7 +26,7 @@ var (
 	// ErrNilOutputWriter reports that a writer was constructed without an output.
 	ErrNilOutputWriter = errors.New("nil output writer")
 	// ErrNilRow reports that WriteRow was called with a nil row.
-	ErrNilRow = errors.New("nil row")
+	ErrNilRow = spanvalue.ErrNilRow
 	// ErrMissingColumnNames reports that writing values requires initialized column names.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.


### PR DESCRIPTION
## Summary
- return `ErrNilRow` from `FormatConfig.FormatRow` instead of panicking on nil `*spanner.Row`
- verify the convenience row-formatting wrappers now surface the same sentinel error
- align `writer.ErrNilRow` with the root package sentinel so `errors.Is` works consistently

Closes #56.