### PR TITLE
spanvalue: validate raw JSON output payloads

### DIFF
--- a/json.go
+++ b/json.go
@@ -1,11 +1,14 @@
 package spanvalue
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spanvalue/internal"
 )
@@ -140,10 +143,7 @@ func FormatJSONSimpleValue(formatter Formatter, value spanner.GenericColumnValue
 
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM, sppb.TypeCode_JSON:
-		// INT64: StringValue is already a valid JSON number
-		// ENUM: Spanner stores proto enum values as INT64; StringValue is a valid JSON number
-		// JSON column: StringValue is already valid JSON
-		return val.GetStringValue(), nil
+		return validateRawJSONValue(value.Type.GetCode(), val)
 
 	default:
 		// For all other types, structpb.Value's JSON marshaling matches our needs
@@ -153,4 +153,24 @@ func FormatJSONSimpleValue(formatter Formatter, value spanner.GenericColumnValue
 		}
 		return string(b), nil
 	}
+}
+
+func validateRawJSONValue(code sppb.TypeCode, value *structpb.Value) (string, error) {
+	stringValue, ok := value.GetKind().(*structpb.Value_StringValue)
+	if !ok {
+		return "", fmt.Errorf("invalid %s JSON payload kind %T: want string value", code, value.GetKind())
+	}
+
+	switch code {
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+		if _, err := strconv.ParseInt(stringValue.StringValue, 10, 64); err != nil {
+			return "", fmt.Errorf("invalid %s JSON payload %q: %w", code, stringValue.StringValue, err)
+		}
+	case sppb.TypeCode_JSON:
+		if !json.Valid([]byte(stringValue.StringValue)) {
+			return "", fmt.Errorf("invalid %s JSON payload %q", code, stringValue.StringValue)
+		}
+	}
+
+	return stringValue.StringValue, nil
 }

--- a/json.go
+++ b/json.go
@@ -163,7 +163,11 @@ func validateRawJSONValue(code sppb.TypeCode, value *structpb.Value) (string, er
 
 	switch code {
 	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
-		if _, err := strconv.ParseInt(stringValue.StringValue, 10, 64); err != nil {
+		trimmed := strings.TrimSpace(stringValue.StringValue)
+		if !json.Valid([]byte(stringValue.StringValue)) {
+			return "", fmt.Errorf("invalid %s JSON payload %q", code, stringValue.StringValue)
+		}
+		if _, err := strconv.ParseInt(trimmed, 10, 64); err != nil {
 			return "", fmt.Errorf("invalid %s JSON payload %q: %w", code, stringValue.StringValue, err)
 		}
 	case sppb.TypeCode_JSON:

--- a/json_test.go
+++ b/json_test.go
@@ -3,6 +3,7 @@ package spanvalue
 import (
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestJSONFormatConfig(t *testing.T) {
@@ -75,6 +77,64 @@ func TestJSONFormatConfig(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.wantJSON, got); diff != "" {
 				t.Errorf("JSON output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJSONFormatConfig_InvalidRawPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		gcv     spanner.GenericColumnValue
+		wantErr string
+	}{
+		{
+			name: "INT64 invalid lexical form",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_INT64),
+				Value: structpb.NewStringValue("12.5"),
+			},
+			wantErr: `invalid INT64 JSON payload "12.5"`,
+		},
+		{
+			name: "ENUM invalid lexical form",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.FQNToEnumType("example.Enum"),
+				Value: structpb.NewStringValue("abc"),
+			},
+			wantErr: `invalid ENUM JSON payload "abc"`,
+		},
+		{
+			name: "JSON invalid text",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+				Value: structpb.NewStringValue(`{"unterminated":`),
+			},
+			wantErr: `invalid JSON JSON payload "{\"unterminated\":"`,
+		},
+		{
+			name: "JSON wrong wire kind",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+				Value: structpb.NewNumberValue(1),
+			},
+			wantErr: `invalid JSON JSON payload kind *structpb.Value_NumberValue`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := JSONFormatConfig().FormatToplevelColumn(tt.gcv)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
 			}
 		})
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -99,12 +99,28 @@ func TestJSONFormatConfig_InvalidRawPayload(t *testing.T) {
 			wantErr: `invalid INT64 JSON payload "12.5"`,
 		},
 		{
+			name: "INT64 invalid JSON number lexical form",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_INT64),
+				Value: structpb.NewStringValue("0001"),
+			},
+			wantErr: `invalid INT64 JSON payload "0001"`,
+		},
+		{
 			name: "ENUM invalid lexical form",
 			gcv: spanner.GenericColumnValue{
 				Type:  typector.FQNToEnumType("example.Enum"),
 				Value: structpb.NewStringValue("abc"),
 			},
 			wantErr: `invalid ENUM JSON payload "abc"`,
+		},
+		{
+			name: "ENUM invalid JSON number lexical form",
+			gcv: spanner.GenericColumnValue{
+				Type:  typector.FQNToEnumType("example.Enum"),
+				Value: structpb.NewStringValue("+1"),
+			},
+			wantErr: `invalid ENUM JSON payload "+1"`,
 		},
 		{
 			name: "JSON invalid text",


### PR DESCRIPTION
## Summary
- validate pass-through JSON output payloads before embedding them in JSON mode
- reject malformed `INT64` and `ENUM` string payloads instead of emitting invalid JSON numbers
- reject malformed `JSON` text and wrong wire kinds that would otherwise silently become invalid output

Closes #57.