### PR TITLE
internal: reject mismatched JSON object counts

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"math"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/samber/lo/it"
 )
+
+var ErrMismatchedJSONObjectFields = errors.New("mismatched JSON object key/value count")
 
 // ResolveColumnNames returns a copy of columnNames with every empty string
 // replaced by a name produced by namer. Already-named columns are preserved.
@@ -76,7 +79,7 @@ func AssembleResolvedJSONObject(columnNames []string, values []string) (string, 
 	if err != nil {
 		return "", err
 	}
-	return AssembleJSONObjectWithMarshaledKeys(marshaledKeys, values), nil
+	return AssembleJSONObjectWithMarshaledKeys(marshaledKeys, values)
 }
 
 // MarshalJSONObjectKeys marshals JSON object keys once for reuse across rows.
@@ -97,7 +100,11 @@ func MarshalJSONObjectKeys(columnNames []string) ([][]byte, error) {
 
 // AssembleJSONObjectWithMarshaledKeys combines pre-marshaled JSON object keys
 // and pre-formatted JSON value strings into a single JSON object string.
-func AssembleJSONObjectWithMarshaledKeys(keys [][]byte, values []string) string {
+func AssembleJSONObjectWithMarshaledKeys(keys [][]byte, values []string) (string, error) {
+	if len(keys) != len(values) {
+		return "", fmt.Errorf("%w: %d keys, %d values", ErrMismatchedJSONObjectFields, len(keys), len(values))
+	}
+
 	var b strings.Builder
 	// Grow uses a cheap lower bound only. Key/value sizes are content-dependent.
 	b.Grow(len(values))
@@ -106,16 +113,12 @@ func AssembleJSONObjectWithMarshaledKeys(keys [][]byte, values []string) string 
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		if i < len(keys) {
-			b.Write(keys[i])
-		} else {
-			b.WriteString(`""`)
-		}
+		b.Write(keys[i])
 		b.WriteByte(':')
 		b.WriteString(val)
 	}
 	b.WriteByte('}')
-	return b.String()
+	return b.String(), nil
 }
 
 // ByteToEscapeSequenceReadable formats a byte as a string without quote processing

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAssembleResolvedJSONObject_MismatchedCounts(t *testing.T) {
+	t.Parallel()
+
+	_, err := AssembleResolvedJSONObject([]string{"a"}, []string{"1", "2"})
+	if !errors.Is(err, ErrMismatchedJSONObjectFields) {
+		t.Fatalf("error = %v, want ErrMismatchedJSONObjectFields", err)
+	}
+}
+
+func TestAssembleJSONObjectWithMarshaledKeys_MismatchedCounts(t *testing.T) {
+	t.Parallel()
+
+	_, err := AssembleJSONObjectWithMarshaledKeys([][]byte{[]byte(`"a"`), []byte(`"b"`)}, []string{"1"})
+	if !errors.Is(err, ErrMismatchedJSONObjectFields) {
+		t.Fatalf("error = %v, want ErrMismatchedJSONObjectFields", err)
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -248,7 +248,10 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if err != nil {
 		return err
 	}
-	s := internal.AssembleJSONObjectWithMarshaledKeys(marshaledKeys, formattedValues)
+	s, err := internal.AssembleJSONObjectWithMarshaledKeys(marshaledKeys, formattedValues)
+	if err != nil {
+		return err
+	}
 	_, err = fmt.Fprintln(w.out, s)
 	return err
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/apstndb/spanvalue/internal"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -373,6 +374,22 @@ func TestJSONLWriterWriteGCVsKeepsResolvedNamesAfterNamerChange(t *testing.T) {
 	want := "{\"_0\":42,\"_1\":\"hello\"}\n{\"_0\":43,\"_1\":\"world\"}\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("JSONL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestJSONLWriterWriteGCVs_MismatchedCachedKeys(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriter(&out, metadataWithColumnNames("name", "age"))
+	w.marshaledKeys = [][]byte{[]byte(`"name"`)}
+
+	err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Alice"),
+		gcvctor.Int64Value(42),
+	})
+	if !errors.Is(err, internal.ErrMismatchedJSONObjectFields) {
+		t.Fatalf("WriteGCVs() error = %v, want ErrMismatchedJSONObjectFields", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- return an error when JSON object key and value counts differ in internal assembly helpers
- stop fabricating fallback empty-string keys for extra values
- cover both internal assembly entry points and propagate the error through the JSONL writer path

Closes #58.