### PR TITLE
gcvctor: normalize nil type pointers

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -21,6 +21,7 @@
 // [NullOf] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a scalar protobuf null at the top level. [NullFromCode] does the same for simple
 // scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
+// A nil type pointer is normalized to TYPE_CODE_UNSPECIFIED so these helpers never fabricate malformed nil Type pointers.
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -21,8 +21,8 @@
 // [NullOf] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a scalar protobuf null at the top level. [NullFromCode] does the same for simple
 // scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
-// Helpers that take a Type pointer (such as [NullOf], [NullArrayOf], and [EmptyArrayOf]) normalize
-// a nil input to TYPE_CODE_UNSPECIFIED so they never fabricate malformed nil Type pointers.
+// [NullOf], [NullArrayOf], and [EmptyArrayOf] normalize a nil Type pointer input to
+// TYPE_CODE_UNSPECIFIED so they never fabricate malformed nil Type pointers.
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -21,7 +21,8 @@
 // [NullOf] returns a typed NULL for any [cloud.google.com/go/spanner/apiv1/spannerpb.Type], including STRUCT and ARRAY; the
 // [cloud.google.com/go/spanner.GenericColumnValue] Value field is always a scalar protobuf null at the top level. [NullFromCode] does the same for simple
 // scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
-// A nil type pointer is normalized to TYPE_CODE_UNSPECIFIED so these helpers never fabricate malformed nil Type pointers.
+// Helpers that take a Type pointer (such as [NullOf], [NullArrayOf], and [EmptyArrayOf]) normalize
+// a nil input to TYPE_CODE_UNSPECIFIED so they never fabricate malformed nil Type pointers.
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -39,6 +39,14 @@ func normalizeNilType(typ *sppb.Type) *sppb.Type {
 	return typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
 }
 
+func normalizeNilArrayType(elemType *sppb.Type) *sppb.Type {
+	arrayType := typector.ElemTypeToArrayType(normalizeNilType(elemType))
+	if arrayType != nil {
+		return arrayType
+	}
+	return typector.ElemCodeToArrayType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
+}
+
 // BoolValue returns a non-null BOOL GenericColumnValue.
 func BoolValue(v bool) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
@@ -319,8 +327,10 @@ func NullOf(typ *sppb.Type) spanner.GenericColumnValue {
 }
 
 // NullArrayOf returns a typed SQL NULL for ARRAY<elemType>.
+// A nil elemType is normalized to TYPE_CODE_UNSPECIFIED, so NullArrayOf(nil)
+// returns a NULL ARRAY<TYPE_CODE_UNSPECIFIED> rather than an invalid ARRAY shape.
 func NullArrayOf(elemType *sppb.Type) spanner.GenericColumnValue {
-	return NullOf(typector.ElemTypeToArrayType(normalizeNilType(elemType)))
+	return NullOf(normalizeNilArrayType(elemType))
 }
 
 // NullArrayFromCode returns a typed SQL NULL for ARRAY<T> where T is a simple scalar type code.
@@ -329,9 +339,11 @@ func NullArrayFromCode(elemCode sppb.TypeCode) spanner.GenericColumnValue {
 }
 
 // EmptyArrayOf returns a non-null empty ARRAY<elemType> (length zero).
+// A nil elemType is normalized to TYPE_CODE_UNSPECIFIED, so EmptyArrayOf(nil)
+// returns an empty ARRAY<TYPE_CODE_UNSPECIFIED> rather than an invalid ARRAY shape.
 func EmptyArrayOf(elemType *sppb.Type) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
-		Type:  typector.ElemTypeToArrayType(normalizeNilType(elemType)),
+		Type:  normalizeNilArrayType(elemType),
 		Value: structpb.NewListValue(&structpb.ListValue{}),
 	}
 }

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -40,11 +40,7 @@ func normalizeNilType(typ *sppb.Type) *sppb.Type {
 }
 
 func normalizeNilArrayType(elemType *sppb.Type) *sppb.Type {
-	arrayType := typector.ElemTypeToArrayType(normalizeNilType(elemType))
-	if arrayType != nil {
-		return arrayType
-	}
-	return typector.ElemCodeToArrayType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
+	return typector.ElemTypeToArrayType(normalizeNilType(elemType))
 }
 
 // BoolValue returns a non-null BOOL GenericColumnValue.

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -32,6 +32,13 @@ var (
 	ErrNilFieldType = errors.New("gcvctor: nil struct field type")
 )
 
+func normalizeNilType(typ *sppb.Type) *sppb.Type {
+	if typ != nil {
+		return typ
+	}
+	return typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
+}
+
 // BoolValue returns a non-null BOOL GenericColumnValue.
 func BoolValue(v bool) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
@@ -303,16 +310,17 @@ func NullFromCode(code sppb.TypeCode) spanner.GenericColumnValue {
 // NullValue, including when typ is STRUCT or ARRAY.
 // It does not represent a non-null STRUCT whose fields are all null—use [StructValueOf] with
 // per-field nulls (using [NullOf] or [NullFromCode] for each field) when you need that shape.
+// A nil typ is normalized to TYPE_CODE_UNSPECIFIED to avoid a malformed nil Type pointer.
 func NullOf(typ *sppb.Type) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
-		Type:  typ,
+		Type:  normalizeNilType(typ),
 		Value: structpb.NewNullValue(),
 	}
 }
 
 // NullArrayOf returns a typed SQL NULL for ARRAY<elemType>.
 func NullArrayOf(elemType *sppb.Type) spanner.GenericColumnValue {
-	return NullOf(typector.ElemTypeToArrayType(elemType))
+	return NullOf(typector.ElemTypeToArrayType(normalizeNilType(elemType)))
 }
 
 // NullArrayFromCode returns a typed SQL NULL for ARRAY<T> where T is a simple scalar type code.
@@ -323,7 +331,7 @@ func NullArrayFromCode(elemCode sppb.TypeCode) spanner.GenericColumnValue {
 // EmptyArrayOf returns a non-null empty ARRAY<elemType> (length zero).
 func EmptyArrayOf(elemType *sppb.Type) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
-		Type:  typector.ElemTypeToArrayType(elemType),
+		Type:  typector.ElemTypeToArrayType(normalizeNilType(elemType)),
 		Value: structpb.NewListValue(&structpb.ListValue{}),
 	}
 }

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -478,6 +478,19 @@ func TestNullOf_STRUCT_MultipleFields(t *testing.T) {
 	}
 }
 
+func TestNullOf_nilTypeNormalizesToUnspecified(t *testing.T) {
+	t.Parallel()
+
+	got := gcvctor.NullOf(nil)
+	want := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED),
+		Value: structpb.NewNullValue(),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("diff (-want, +got) = %v", diff)
+	}
+}
+
 func TestNullArrayFromCode_matchesNullOf(t *testing.T) {
 	t.Parallel()
 	got := gcvctor.NullArrayFromCode(sppb.TypeCode_INT64)
@@ -497,6 +510,32 @@ func TestNullArrayOf_matchesNullOf(t *testing.T) {
 	want := spanner.GenericColumnValue{
 		Type:  typector.ElemTypeToArrayType(elem),
 		Value: structpb.NewNullValue(),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("diff (-want, +got) = %v", diff)
+	}
+}
+
+func TestNullArrayOf_nilElementTypeNormalizesToUnspecified(t *testing.T) {
+	t.Parallel()
+
+	got := gcvctor.NullArrayOf(nil)
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED),
+		Value: structpb.NewNullValue(),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("diff (-want, +got) = %v", diff)
+	}
+}
+
+func TestEmptyArrayOf_nilElementTypeNormalizesToUnspecified(t *testing.T) {
+	t.Parallel()
+
+	got := gcvctor.EmptyArrayOf(nil)
+	want := spanner.GenericColumnValue{
+		Type:  typector.ElemCodeToArrayType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED),
+		Value: structpb.NewListValue(&structpb.ListValue{}),
 	}
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("diff (-want, +got) = %v", diff)


### PR DESCRIPTION
## Summary
- normalize nil type pointers in `NullOf`, `NullArrayOf`, and `EmptyArrayOf` to `TYPE_CODE_UNSPECIFIED`
- avoid fabricating malformed nil `Type` pointers while keeping the public helper signatures stable
- add regression tests for nil scalar and ARRAY helper inputs and document the normalization behavior

Closes #59.