### PR TITLE
spanvalue: reject nil struct field descriptors

### DIFF
--- a/common.go
+++ b/common.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	ErrNilRow                     = errors.New("nil row")
+	ErrNilStructField             = errors.New("nil struct field descriptor")
 	ErrUnknownType                = errors.New("unknown type")
 	ErrMismatchedFields           = errors.New("mismatched struct value/field count")
 	ErrUnexpectedComplexValueKind = errors.New("unexpected complex value kind")

--- a/common_test.go
+++ b/common_test.go
@@ -291,3 +291,38 @@ func TestFormatColumnRejectsEmptyTypeFQN(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatColumnRejectsNilStructFieldDescriptor(t *testing.T) {
+	t.Parallel()
+
+	gcv := spanner.GenericColumnValue{
+		Type: &sppb.Type{
+			Code:       sppb.TypeCode_STRUCT,
+			StructType: &sppb.StructType{Fields: []*sppb.StructType_Field{nil}},
+		},
+		Value: structpb.NewListValue(&structpb.ListValue{
+			Values: []*structpb.Value{structpb.NewStringValue("1")},
+		}),
+	}
+
+	tests := []struct {
+		name string
+		fc   *FormatConfig
+	}{
+		{name: "simple", fc: SimpleFormatConfig()},
+		{name: "literal", fc: LiteralFormatConfig()},
+		{name: "json", fc: JSONFormatConfig()},
+		{name: "spanner cli compatible", fc: SpannerCLICompatibleFormatConfig()},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.fc.FormatToplevelColumn(gcv)
+			if !errors.Is(err, ErrNilStructField) {
+				t.Fatalf("error = %v, want ErrNilStructField", err)
+			}
+		})
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -316,6 +316,7 @@ func TestFormatColumnRejectsNilStructFieldDescriptor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := tt.fc.FormatToplevelColumn(gcv)

--- a/common_test.go
+++ b/common_test.go
@@ -316,7 +316,6 @@ func TestFormatColumnRejectsNilStructFieldDescriptor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := tt.fc.FormatToplevelColumn(gcv)

--- a/format_func.go
+++ b/format_func.go
@@ -19,20 +19,15 @@ func FormatTupleStruct(typ *sppb.Type, toplevel bool, fieldStrings []string) (st
 }
 
 func formatSimpleStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {
-	fieldType, err := structFieldType(field)
-	if err != nil {
-		return "", err
-	}
-	return fc.FormatColumn(typeValueToGCV(fieldType, value), false)
+	return FormatSimpleStructField(fc, field, value)
 }
 
 func FormatTypelessStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {
-	fieldType, err := structFieldType(field)
+	exprStr, err := FormatSimpleStructField(fc, field, value)
 	if err != nil {
 		return "", err
 	}
-	exprStr, err := fc.FormatColumn(typeValueToGCV(fieldType, value), false)
-	return exprStr + lo.Ternary(field.GetName() != "", " AS "+field.GetName(), ""), err
+	return exprStr + lo.Ternary(field.GetName() != "", " AS "+field.GetName(), ""), nil
 }
 
 func FormatSimpleStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {

--- a/format_func.go
+++ b/format_func.go
@@ -19,16 +19,35 @@ func FormatTupleStruct(typ *sppb.Type, toplevel bool, fieldStrings []string) (st
 }
 
 func formatSimpleStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {
-	return fc.FormatColumn(typeValueToGCV(field.GetType(), value), false)
+	fieldType, err := structFieldType(field)
+	if err != nil {
+		return "", err
+	}
+	return fc.FormatColumn(typeValueToGCV(fieldType, value), false)
 }
 
 func FormatTypelessStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {
-	exprStr, err := fc.FormatColumn(typeValueToGCV(field.GetType(), value), false)
+	fieldType, err := structFieldType(field)
+	if err != nil {
+		return "", err
+	}
+	exprStr, err := fc.FormatColumn(typeValueToGCV(fieldType, value), false)
 	return exprStr + lo.Ternary(field.GetName() != "", " AS "+field.GetName(), ""), err
 }
 
 func FormatSimpleStructField(fc *FormatConfig, field *sppb.StructType_Field, value *structpb.Value) (string, error) {
-	return fc.FormatColumn(typeValueToGCV(field.Type, value), false)
+	fieldType, err := structFieldType(field)
+	if err != nil {
+		return "", err
+	}
+	return fc.FormatColumn(typeValueToGCV(fieldType, value), false)
+}
+
+func structFieldType(field *sppb.StructType_Field) (*sppb.Type, error) {
+	if field == nil {
+		return nil, ErrNilStructField
+	}
+	return field.GetType(), nil
 }
 
 func FormatUntypedArray(_ *sppb.Type, _ bool, elemStrings []string) (string, error) {


### PR DESCRIPTION
## Summary
- return a shared error for nil struct field descriptors instead of panicking during formatting
- route all struct field formatter variants through the same descriptor validation helper
- add regression coverage across the public formatting presets

Closes #63.