### PR TITLE
Add gcvctor array NULL normalization helper

### DIFF
--- a/common.go
+++ b/common.go
@@ -140,11 +140,7 @@ var (
 // IsNull reports whether gcv represents a NULL value.
 // A nil gcv.Value is treated as NULL.
 func IsNull(gcv spanner.GenericColumnValue) bool {
-	if gcv.Value == nil {
-		return true
-	}
-	_, ok := gcv.Value.GetKind().(*structpb.Value_NullValue)
-	return ok
+	return internal.IsNullGenericColumnValue(gcv)
 }
 
 func FormatProtoAsCast(formatter Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -5,7 +5,7 @@
 // when len==0, whether the variadic slice is nil or empty). [ArrayValueOf] takes the element type
 // explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [NullOf] with
 // [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
-// on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf](elemType) before
+// on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
 // names with values; counts must match.
 //

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -5,7 +5,8 @@
 // when len==0, whether the variadic slice is nil or empty). [ArrayValueOf] takes the element type
 // explicitly; len==0 yields an empty ARRAY<elemType>. For a SQL NULL ARRAY, use [NullOf] with
 // [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
-// on variadic nil. [StructValueOf] pairs field
+// on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf](elemType) before
+// a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
 // names with values; counts must match.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -23,7 +23,7 @@ func ExampleNullOf() {
 	// ARRAY DATE true
 }
 
-func ExampleArrayValueOf_typedNullNormalization() {
+func ExampleNormalizeArrayElements() {
 	elemType := typector.CodeToSimpleType(sppb.TypeCode_DATE)
 	elems := []spanner.GenericColumnValue{
 		must(gcvctor.DateStringValue("2026-04-01")),
@@ -31,15 +31,7 @@ func ExampleArrayValueOf_typedNullNormalization() {
 		must(gcvctor.DateStringValue("2026-04-03")),
 	}
 
-	normalized := make([]spanner.GenericColumnValue, len(elems))
-	for i, elem := range elems {
-		if spanvalue.IsNull(elem) {
-			normalized[i] = gcvctor.NullOf(elemType)
-			continue
-		}
-		normalized[i] = elem
-	}
-
+	normalized := must(gcvctor.NormalizeArrayElements(elemType, elems...))
 	array := must(gcvctor.ArrayValueOf(elemType, normalized...))
 	values := array.Value.GetListValue().Values
 

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -18,6 +18,7 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spantype/typector"
+	"github.com/apstndb/spanvalue/internal"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -325,13 +326,38 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 	return ArrayValueOf(vs[0].Type, vs...)
 }
 
+// NormalizeArrayElements rewrites SQL NULL elements to [NullOf](elemType) while preserving
+// strict type checks for non-NULL elements. A nil elemType returns [ErrNilElementType].
+// Per-element failures are wrapped in [ArrayElementError].
+func NormalizeArrayElements(elemType *sppb.Type, elems ...spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {
+	if elemType == nil {
+		return nil, ErrNilElementType
+	}
+	normalized := make([]spanner.GenericColumnValue, len(elems))
+	for i, elem := range elems {
+		if internal.IsNullGenericColumnValue(elem) {
+			normalized[i] = NullOf(elemType)
+			continue
+		}
+		if elem.Type == nil {
+			return nil, wrapArrayElementError(i, ErrNilElementType)
+		}
+		if !proto.Equal(elemType, elem.Type) {
+			return nil, wrapArrayElementError(i, fmt.Errorf("%w: %v is not %v", ErrTypeMismatch, spantype.FormatTypeMoreVerbose(elem.Type), spantype.FormatTypeMoreVerbose(elemType)))
+		}
+		normalized[i] = elem
+	}
+	return normalized, nil
+}
+
 // ArrayValueOf constructs ARRAY GenericColumnValue using elemType as the element type
 // instead of inferring it from the first element. When elems is empty (nil or length zero), it
 // returns an empty ARRAY<elemType> (SQL length zero, not SQL NULL). For a typed NULL ARRAY<elemType>,
 // use [NullOf] with [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType].
 //
 // Each element's Type must match elemType (no coercion). A nil elemType returns [ErrNilElementType].
-// Per-element failures are wrapped in [ArrayElementError].
+// Per-element failures are wrapped in [ArrayElementError]. To accept SQL NULL elements regardless of
+// their current Type metadata, normalize them first with [NormalizeArrayElements].
 func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if elemType == nil {
 		return spanner.GenericColumnValue{}, ErrNilElementType

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -326,7 +326,7 @@ func ArrayValue(vs ...spanner.GenericColumnValue) (spanner.GenericColumnValue, e
 	return ArrayValueOf(vs[0].Type, vs...)
 }
 
-// NormalizeArrayElements rewrites SQL NULL elements to [NullOf](elemType) while preserving
+// NormalizeArrayElements rewrites SQL NULL elements to [NullOf] with elemType while preserving
 // strict type checks for non-NULL elements. A nil elemType returns [ErrNilElementType].
 // Per-element failures are wrapped in [ArrayElementError].
 func NormalizeArrayElements(elemType *sppb.Type, elems ...spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -658,6 +658,112 @@ func TestArrayValueNilFirstElementTypeReturnsArrayElementError(t *testing.T) {
 	}
 }
 
+func TestNormalizeArrayElements(t *testing.T) {
+	t.Parallel()
+
+	dateElem := typector.CodeToSimpleType(sppb.TypeCode_DATE)
+	stringElem := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+
+	tests := []struct {
+		desc      string
+		elemType  *sppb.Type
+		elems     []spanner.GenericColumnValue
+		want      []spanner.GenericColumnValue
+		expectErr bool
+		errIs     error
+		errIndex  int
+	}{
+		{
+			desc:     "empty elems",
+			elemType: dateElem,
+			elems:    nil,
+			want:     []spanner.GenericColumnValue{},
+		},
+		{
+			desc:     "normalize null element with nil type",
+			elemType: dateElem,
+			elems: []spanner.GenericColumnValue{
+				must(gcvctor.DateStringValue("2026-04-01")),
+				gcvctor.NullOf(nil),
+			},
+			want: []spanner.GenericColumnValue{
+				{Type: dateElem, Value: structpb.NewStringValue("2026-04-01")},
+				{Type: dateElem, Value: structpb.NewNullValue()},
+			},
+		},
+		{
+			desc:     "normalize null element with mismatched type",
+			elemType: dateElem,
+			elems: []spanner.GenericColumnValue{
+				gcvctor.NullFromCode(sppb.TypeCode_STRING),
+			},
+			want: []spanner.GenericColumnValue{
+				{Type: dateElem, Value: structpb.NewNullValue()},
+			},
+		},
+		{
+			desc:      "nil element type",
+			elemType:  nil,
+			elems:     []spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilElementType,
+			errIndex:  -1,
+		},
+		{
+			desc:      "non-null element with nil type",
+			elemType:  dateElem,
+			elems:     []spanner.GenericColumnValue{{Value: structpb.NewStringValue("2026-04-01")}},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilElementType,
+			errIndex:  0,
+		},
+		{
+			desc:      "type mismatch",
+			elemType:  stringElem,
+			elems:     []spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			expectErr: true,
+			errIs:     gcvctor.ErrTypeMismatch,
+			errIndex:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := gcvctor.NormalizeArrayElements(tt.elemType, tt.elems...)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !errors.Is(err, tt.errIs) {
+					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				if tt.errIndex >= 0 {
+					var ctx *gcvctor.ArrayElementError
+					if !errors.As(err, &ctx) {
+						t.Fatalf("errors.As(err, *ArrayElementError) = false; err = %v", err)
+					}
+					if ctx.Index != tt.errIndex {
+						t.Fatalf("ctx.Index = %d, want %d", ctx.Index, tt.errIndex)
+					}
+				}
+				if got != nil {
+					t.Fatalf("got = %#v, want nil on error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestArrayValueOf(t *testing.T) {
 	t.Parallel()
 	int64Elem := typector.CodeToSimpleType(sppb.TypeCode_INT64)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -11,10 +11,22 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/spanner"
 	"github.com/samber/lo/it"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var ErrMismatchedJSONObjectFields = errors.New("mismatched JSON object key/value count")
+
+// IsNullGenericColumnValue reports whether gcv represents SQL NULL.
+// A nil gcv.Value is treated as NULL.
+func IsNullGenericColumnValue(gcv spanner.GenericColumnValue) bool {
+	if gcv.Value == nil {
+		return true
+	}
+	_, ok := gcv.Value.GetKind().(*structpb.Value_NullValue)
+	return ok
+}
 
 // ResolveColumnNames returns a copy of columnNames with every empty string
 // replaced by a name produced by namer. Already-named columns are preserved.


### PR DESCRIPTION
## Summary
- add `gcvctor.NormalizeArrayElements` for callers that want typed-NULL normalization before strict `ArrayValueOf`
- share GenericColumnValue NULL detection through `internal.IsNullGenericColumnValue` and reuse it from `spanvalue.IsNull`
- update `gcvctor` docs, examples, and tests to cover the new helper and its error behavior

## Related
- Closes #76