### PR TITLE
Add delimited writer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 ```
 
 TSV output uses the same CSV-style writer with a tab delimiter. Set the
-delimiter before the first write. Explicit delimiters must be valid runes other
-than `0`, `"`, `\r`, `\n`, or `utf8.RuneError`.
+delimiter before the first write. A zero delimiter selects the default comma;
+non-zero delimiters must be valid runes other than `"`, `\r`, `\n`, or
+`utf8.RuneError`.
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Helpers for working with Cloud Spanner’s [`spanner.GenericColumnValue`](https:
 |--------|------|
 | [`github.com/apstndb/spanvalue`](https://pkg.go.dev/github.com/apstndb/spanvalue) | Format `spanner.GenericColumnValue` and `*spanner.Row` using [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig) and presets such as [`LiteralFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#LiteralFormatConfig), [`JSONFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#JSONFormatConfig), [`SpannerCLICompatibleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SpannerCLICompatibleFormatConfig). |
 | [`github.com/apstndb/spanvalue/gcvctor`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor) | Build `spanner.GenericColumnValue` (scalars, `ARRAY`, `STRUCT`, typed nulls). Types are often composed with [`github.com/apstndb/spantype/typector`](https://pkg.go.dev/github.com/apstndb/spantype/typector). |
-| [`github.com/apstndb/spanvalue/writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) | Stream Spanner rows to CSV, JSONL, or SQL INSERT statements using spanvalue formatters. |
+| [`github.com/apstndb/spanvalue/writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) | Stream Spanner rows to CSV, TSV, JSONL, or SQL INSERT statements using spanvalue formatters. |
 
 ## Identifier quoting helpers
 
@@ -52,7 +52,83 @@ jsonLine, err := spanvalue.FormatRowJSONObjectFromColumns(
 
 ```go
 w := writer.NewSQLInsertWriter(out, "analytics.daily_metrics")
-err := w.WriteValues(columnNames, gcvs)
+if err := w.WriteValues(columnNames, gcvs); err != nil {
+    return err
+}
+return w.Flush()
+```
+
+## Streaming row exports
+
+The `writer` package accepts `*spanner.Row` values directly through `WriteRow`.
+Use `writer.Writer` when an adapter only needs row streaming. Use
+`writer.Flusher` alongside `writer.Writer` when an adapter owns the full write
+lifecycle.
+`CSVWriter` and `JSONLWriter` preserve explicit duplicate column names. Empty
+column names are the only names passed to `UnnamedFieldNamer`, and generated
+names avoid collisions with existing explicit names. Set `UnnamedFieldNamer` to
+`nil` when callers need empty names to remain empty.
+
+Call `Flush` after the final row when the writer also implements
+`writer.Flusher`; see the `Writer` and `Flusher` godoc for the interface
+lifecycle contract.
+
+CSV output:
+
+```go
+func writeCSV(out io.Writer, rows []*spanner.Row) error {
+	w := writer.NewCSVWriter(out)
+	for _, row := range rows {
+		if err := w.WriteRow(row); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+```
+
+TSV output uses the same CSV-style writer with a tab delimiter. Set the
+delimiter before the first write; it follows the same validity rules as
+`encoding/csv.Writer.Comma`.
+
+```go
+func writeTSV(out io.Writer, rows []*spanner.Row) error {
+	w := writer.NewDelimitedWriter(out, '\t')
+	for _, row := range rows {
+		if err := w.WriteRow(row); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+```
+
+JSONL output:
+
+```go
+func writeJSONL(out io.Writer, rows []*spanner.Row) error {
+	w := writer.NewJSONLWriter(out)
+	for _, row := range rows {
+		if err := w.WriteRow(row); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+```
+
+SQL INSERT output:
+
+```go
+func writeInserts(out io.Writer, table string, rows []*spanner.Row) error {
+	w := writer.NewSQLInsertWriter(out, table)
+	for _, row := range rows {
+		if err := w.WriteRow(row); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
 ```
 
 ## Related: PostgreSQL dialect probes

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 ```
 
 TSV output uses the same CSV-style writer with a tab delimiter. Set the
-delimiter before the first write; it follows the same validity rules as
-`encoding/csv.Writer.Comma`.
+delimiter before the first write. Explicit delimiters must be valid runes other
+than `0`, `"`, `\r`, `\n`, or `utf8.RuneError`.
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,5 +1,14 @@
 // Package writer provides small streaming helpers for exporting Spanner rows
 // using spanvalue formatters.
+//
+// CSVWriter and JSONLWriter preserve explicit duplicate column names. Their
+// UnnamedFieldNamer only fills empty column names, and generated names avoid
+// collisions with existing names. CSVWriter buffers through encoding/csv, so
+// callers must call Flush after the final write.
+//
+// CSVWriter, JSONLWriter, and SQLInsertWriter implement Flusher. If an adapter
+// exposes a Close method, that Close method should call Flush; Flush does not
+// close the underlying io.Writer.
 package writer
 
 import (
@@ -9,6 +18,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"cloud.google.com/go/spanner"
 	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
@@ -33,17 +43,39 @@ var (
 	ErrColumnNamesMismatch = errors.New("column names mismatch")
 	// ErrHeaderAfterData reports that CSVWriter.WriteHeader was called after data rows were emitted.
 	ErrHeaderAfterData = errors.New("header after data")
+	// ErrInvalidDelimiter reports that CSVWriter.Comma is not a valid delimiter.
+	ErrInvalidDelimiter = errors.New("invalid delimiter")
+	// ErrDelimiterAfterWrite reports that CSVWriter.Comma changed after the underlying CSV writer was initialized.
+	ErrDelimiterAfterWrite = errors.New("delimiter changed after writer initialization")
 )
 
-// Writer writes rows to an output stream.
+// Writer writes Spanner rows to an output stream.
+//
+// Writer intentionally models row streaming only. Some concrete writers also
+// implement [Flusher]; callers that own the full write lifecycle must call
+// Flush after the final row when it is available. Factories that may return a
+// buffered writer should return a concrete type or a local composite interface
+// such as interface { Writer; Flusher }, not Writer alone.
 type Writer interface {
 	WriteRow(row *spanner.Row) error
 }
 
-// CSVWriter writes rows as CSV. Call Flush after the final write.
+// Flusher finalizes any buffered output. Flush does not close the underlying
+// io.Writer. CSVWriter uses Flush to forward buffered CSV or TSV data; JSONLWriter
+// and SQLInsertWriter implement it as a no-op so adapters can use one finalize
+// path for all writer implementations.
+type Flusher interface {
+	Flush() error
+}
+
+// CSVWriter writes rows as CSV-style delimited text. Call Flush after the final write.
 type CSVWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
+	// Comma is the field delimiter. The zero value uses ','. Set it before the
+	// first write; use '\t' for TSV output. It must be a valid encoding/csv
+	// delimiter: not 0, '"', '\r', '\n', or utf8.RuneError.
+	Comma rune
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached header names.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
@@ -52,6 +84,7 @@ type CSVWriter struct {
 	resolvedColumnNames []string
 	out                 io.Writer
 	writer              *csv.Writer
+	delimiter           rune
 	wroteHeader         bool
 	wroteData           bool
 }
@@ -65,6 +98,14 @@ func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *CSVWriter
 		out:               out,
 	}
 	w.setMetadata(firstMetadata(metadata))
+	return w
+}
+
+// NewDelimitedWriter returns a CSV-style writer using delimiter as the field delimiter.
+// Pass '\t' for TSV output.
+func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
+	w := NewCSVWriter(out, metadata...)
+	w.Comma = delimiter
 	return w
 }
 
@@ -163,17 +204,43 @@ func (w *CSVWriter) formatter() *spanvalue.FormatConfig {
 }
 
 func (w *CSVWriter) csvWriter() (*csv.Writer, error) {
+	delimiter := w.effectiveDelimiter()
+	if !validDelimiter(delimiter) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
+	}
 	if w.writer != nil {
+		if w.delimiter != delimiter {
+			return nil, ErrDelimiterAfterWrite
+		}
 		return w.writer, nil
 	}
 	if w.out == nil {
 		return nil, ErrNilOutputWriter
 	}
 	w.writer = csv.NewWriter(w.out)
+	w.writer.Comma = delimiter
+	w.delimiter = delimiter
 	return w.writer, nil
 }
 
-// Flush flushes buffered CSV data to the underlying writer.
+func (w *CSVWriter) effectiveDelimiter() rune {
+	if w.Comma == 0 {
+		return ','
+	}
+	return w.Comma
+}
+
+func validDelimiter(delimiter rune) bool {
+	return delimiter != 0 &&
+		delimiter != '"' &&
+		delimiter != '\r' &&
+		delimiter != '\n' &&
+		utf8.ValidRune(delimiter) &&
+		delimiter != utf8.RuneError
+}
+
+// Flush flushes buffered CSV or TSV data to the underlying writer. It does not
+// close the underlying writer.
 func (w *CSVWriter) Flush() error {
 	if w.writer == nil {
 		return nil
@@ -261,6 +328,11 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	}
 	_, err = fmt.Fprintln(w.out, s)
 	return err
+}
+
+// Flush finalizes JSONL output. JSONLWriter is unbuffered, so this is a no-op.
+func (w *JSONLWriter) Flush() error {
+	return nil
 }
 
 func (w *JSONLWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
@@ -360,6 +432,12 @@ func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 		return err
 	}
 	return w.writeGCVs(values, quotedColumns)
+}
+
+// Flush finalizes SQL INSERT output. SQLInsertWriter is unbuffered, so this is
+// a no-op.
+func (w *SQLInsertWriter) Flush() error {
+	return nil
 }
 
 func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedColumns string) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -73,8 +73,9 @@ type CSVWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
 	// Comma is the field delimiter. The zero value uses ','. Set it before the
-	// first write; use '\t' for TSV output. It must be a valid encoding/csv
-	// delimiter: not 0, '"', '\r', '\n', or utf8.RuneError.
+	// first write; use '\t' for TSV output. When set explicitly, it must be a
+	// valid encoding/csv delimiter: a valid rune other than 0, '"', '\r', '\n',
+	// or utf8.RuneError.
 	Comma rune
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached header names.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -205,14 +205,14 @@ func (w *CSVWriter) formatter() *spanvalue.FormatConfig {
 
 func (w *CSVWriter) csvWriter() (*csv.Writer, error) {
 	delimiter := w.effectiveDelimiter()
-	if !validDelimiter(delimiter) {
-		return nil, fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
-	}
 	if w.writer != nil {
 		if w.delimiter != delimiter {
 			return nil, ErrDelimiterAfterWrite
 		}
 		return w.writer, nil
+	}
+	if !validDelimiter(delimiter) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
 	}
 	if w.out == nil {
 		return nil, ErrNilOutputWriter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -72,9 +72,9 @@ type Flusher interface {
 type CSVWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
-	// Comma is the field delimiter. The zero value uses ','. Set it before the
-	// first write; use '\t' for TSV output. When set explicitly, it must be a
-	// valid encoding/csv delimiter: a valid rune other than 0, '"', '\r', '\n',
+	// Comma is the field delimiter. The zero value selects ','. Set it before
+	// the first write; use '\t' for TSV output. Any non-zero delimiter must be
+	// a valid encoding/csv delimiter: a valid rune other than '"', '\r', '\n',
 	// or utf8.RuneError.
 	Comma rune
 	// Set before the first write. Once names have been resolved for the current

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+var (
+	_ Writer  = (*CSVWriter)(nil)
+	_ Writer  = (*JSONLWriter)(nil)
+	_ Writer  = (*SQLInsertWriter)(nil)
+	_ Flusher = (*CSVWriter)(nil)
+	_ Flusher = (*JSONLWriter)(nil)
+	_ Flusher = (*SQLInsertWriter)(nil)
+)
+
 func metadataWithColumnNames(names ...string) *sppb.ResultSetMetadata {
 	fields := make([]*sppb.StructType_Field, len(names))
 	for i, name := range names {
@@ -65,6 +74,96 @@ func TestCSVWriterWriteValues(t *testing.T) {
 	want := "name,_0\nAlice,<null>\nBob,7\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		new  func(out *bytes.Buffer) *CSVWriter
+	}{
+		{
+			name: "constructor",
+			new: func(out *bytes.Buffer) *CSVWriter {
+				return NewDelimitedWriter(out, '\t')
+			},
+		},
+		{
+			name: "field",
+			new: func(out *bytes.Buffer) *CSVWriter {
+				w := NewCSVWriter(out)
+				w.Comma = '\t'
+				return w
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w := tt.new(&out)
+
+			err := w.WriteValues(
+				[]string{"name", "note", "with_tab"},
+				[]spanner.GenericColumnValue{
+					gcvctor.StringValue("Alice"),
+					gcvctor.StringValue("comma, ok"),
+					gcvctor.StringValue("tab\tok"),
+				},
+			)
+			if err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+			flushCSVWriter(t, w)
+
+			want := "name\tnote\twith_tab\nAlice\tcomma, ok\t\"tab\tok\"\n"
+			if diff := cmp.Diff(want, out.String()); diff != "" {
+				t.Fatalf("delimited output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCSVWriterWriteValuesInvalidComma(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, '\n')
+
+	err := w.WriteValues(
+		[]string{"name"},
+		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
+	)
+	if !errors.Is(err, ErrInvalidDelimiter) {
+		t.Fatalf("WriteValues() error = %v, want ErrInvalidDelimiter", err)
+	}
+}
+
+func TestCSVWriterWriteValuesCommaChangeAfterWrite(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, '\t')
+
+	err := w.WriteValues(
+		[]string{"name"},
+		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
+	)
+	if err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+
+	w.Comma = ','
+	err = w.WriteValues(
+		[]string{"name"},
+		[]spanner.GenericColumnValue{gcvctor.StringValue("Bob")},
+	)
+	if !errors.Is(err, ErrDelimiterAfterWrite) {
+		t.Fatalf("WriteValues() after Comma change error = %v, want ErrDelimiterAfterWrite", err)
 	}
 }
 
@@ -125,6 +224,34 @@ func TestCSVWriterWriteHeaderWithMetadata(t *testing.T) {
 	want := "name,age\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("CSV header mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnbufferedWritersFlushIsNoop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		writer Flusher
+	}{
+		{
+			name:   "jsonl",
+			writer: NewJSONLWriter(&bytes.Buffer{}),
+		},
+		{
+			name:   "sql",
+			writer: NewSQLInsertWriter(&bytes.Buffer{}, "users"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := tt.writer.Flush(); err != nil {
+				t.Fatalf("Flush() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -128,6 +128,30 @@ func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
 	}
 }
 
+func TestCSVWriterWriteValuesZeroCommaUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, 0)
+
+	err := w.WriteValues(
+		[]string{"name", "note"},
+		[]spanner.GenericColumnValue{
+			gcvctor.StringValue("Alice"),
+			gcvctor.StringValue("comma, ok"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+	flushCSVWriter(t, w)
+
+	want := "name,note\nAlice,\"comma, ok\"\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestCSVWriterWriteValuesInvalidComma(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add CSVWriter delimiter configuration and NewDelimitedWriter for TSV-style output
- add Flusher for writer lifecycle finalization while keeping Writer as WriteRow-only
- document duplicate-name behavior, Flush lifecycle, and streaming CSV/TSV/JSONL/SQL INSERT examples
- validate delimiters and reject delimiter changes after CSV writer initialization

## Verification
- go test ./writer
- make check
- review-router: cursor-agent-composer-2.5-fast and gemini-flash reported no material issues