### PR TITLE
Polish writer APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ column names are the only names passed to `UnnamedFieldNamer`, and generated
 names avoid collisions with existing explicit names. Set `UnnamedFieldNamer` to
 `nil` when callers need empty names to remain empty.
 
-Call `Flush` after the final row when the writer also implements
-`writer.Flusher`; see the `Writer` and `Flusher` godoc for the interface
-lifecycle contract.
+Call `Flush` after the final row when using `writer.FlushWriter`; see the
+`Writer`, `FlushWriter`, and `Flusher` godoc for the interface lifecycle
+contract.
 
 Options-style constructors are available when setup should be explicit:
 
@@ -88,7 +88,15 @@ w := writer.NewDelimitedWriterWithOptions(
 When metadata is known after construction but before rows are streamed, call
 `Prepare(metadata)` on the concrete writer. For non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
-directly.
+directly. Pass the JSON field-name policy explicitly, for example:
+
+```go
+line, err := writer.FormatJSONLRow(
+	spanvalue.JSONFormatConfig(),
+	row,
+	spanvalue.IndexedUnnamedFieldNamer,
+)
+```
 
 CSV output:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ return w.Flush()
 
 The `writer` package accepts `*spanner.Row` values directly through `WriteRow`.
 Use `writer.Writer` when an adapter only needs row streaming. Use
-`writer.Flusher` alongside `writer.Writer` when an adapter owns the full write
-lifecycle.
+`writer.FlushWriter` when an adapter owns both row streaming and finalization.
 `CSVWriter` and `JSONLWriter` preserve explicit duplicate column names. Empty
 column names are the only names passed to `UnnamedFieldNamer`, and generated
 names avoid collisions with existing explicit names. Set `UnnamedFieldNamer` to
@@ -72,6 +71,24 @@ names avoid collisions with existing explicit names. Set `UnnamedFieldNamer` to
 Call `Flush` after the final row when the writer also implements
 `writer.Flusher`; see the `Writer` and `Flusher` godoc for the interface
 lifecycle contract.
+
+Options-style constructors are available when setup should be explicit:
+
+```go
+w := writer.NewDelimitedWriterWithOptions(
+	out,
+	'\t',
+	writer.WithMetadata(meta),
+	writer.WithFormatter(cfg),
+	writer.WithHeader(true),
+	writer.WithUnnamedFieldNamer(nil),
+)
+```
+
+When metadata is known after construction but before rows are streamed, call
+`Prepare(metadata)` on the concrete writer. For non-streaming paths, use
+`writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
+directly.
 
 CSV output:
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ return w.Flush()
 The `writer` package accepts `*spanner.Row` values directly through `WriteRow`.
 Use `writer.Writer` when an adapter only needs row streaming. Use
 `writer.FlushWriter` when an adapter owns both row streaming and finalization.
-`CSVWriter` and `JSONLWriter` preserve explicit duplicate column names. Empty
-column names are the only names passed to `UnnamedFieldNamer`, and generated
-names avoid collisions with existing explicit names. Set `UnnamedFieldNamer` to
-`nil` when callers need empty names to remain empty.
+`DelimitedWriter` and `JSONLWriter` preserve explicit duplicate column names.
+Empty column names are the only names passed to `UnnamedFieldNamer`, and
+generated names avoid collisions with existing explicit names. Set
+`UnnamedFieldNamer` to `nil` when callers need empty names to remain empty.
 
 Call `Flush` after the final row when using `writer.FlushWriter`; see the
 `Writer`, `FlushWriter`, and `Flusher` godoc for the interface lifecycle
@@ -102,7 +102,7 @@ CSV output:
 
 ```go
 func writeCSV(out io.Writer, rows []*spanner.Row) error {
-	w := writer.NewCSVWriter(out)
+	w := writer.NewDelimitedWriter(out, 0)
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err
@@ -113,9 +113,10 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 ```
 
 TSV output uses the same CSV-style writer with a tab delimiter. Set the
-delimiter before the first write. A zero delimiter selects the default comma;
-non-zero delimiters must be valid runes other than `"`, `\r`, `\n`, or
-`utf8.RuneError`.
+delimiter before the first write. A zero delimiter selects the default comma.
+Non-zero delimiters must be valid runes other than `"`, `\r`, `\n`, or
+`utf8.RuneError`. `CSVWriter`, `NewCSVWriter`, and the `Comma` field remain as
+deprecated compatibility APIs.
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ CSV output:
 
 ```go
 func writeCSV(out io.Writer, rows []*spanner.Row) error {
-	w := writer.NewDelimitedWriter(out, 0)
+	w := writer.NewCSVWriter(out)
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err
@@ -112,11 +112,13 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 }
 ```
 
-TSV output uses the same CSV-style writer with a tab delimiter. Set the
-delimiter before the first write. A zero delimiter selects the default comma.
-Non-zero delimiters must be valid runes other than `"`, `\r`, `\n`, or
-`utf8.RuneError`. `CSVWriter`, `NewCSVWriter`, and the `Comma` field remain as
-deprecated compatibility APIs.
+TSV output uses the same CSV-style writer with a tab delimiter. `NewCSVWriter`
+is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
+`writer.Comma` when using the generic delimited constructor for CSV output. A
+zero delimiter is accepted for compatibility and selects comma, but new code
+should be explicit. Non-zero delimiters must be valid runes other than `"`,
+`\r`, `\n`, or `utf8.RuneError`. `CSVWriter` and `DelimitedWriter.Comma` remain
+as deprecated compatibility APIs.
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -6,9 +6,15 @@
 // collisions with existing names. CSVWriter buffers through encoding/csv, so
 // callers must call Flush after the final write.
 //
-// CSVWriter, JSONLWriter, and SQLInsertWriter implement Flusher. If an adapter
-// exposes a Close method, that Close method should call Flush; Flush does not
-// close the underlying io.Writer.
+// Use Writer when an adapter only needs row streaming, and FlushWriter when it
+// owns the full write lifecycle. CSVWriter, JSONLWriter, and SQLInsertWriter
+// implement FlushWriter. If an adapter exposes a Close method, that Close
+// method should call Flush; Flush does not close the underlying io.Writer.
+//
+// WithOptions constructors collect setup such as FormatConfig, metadata, and
+// unnamed-field naming policy before the first write. Prepare initializes a
+// concrete writer from result-set metadata after construction. RowData and the
+// Format* helpers support one-row non-streaming paths.
 package writer
 
 import (
@@ -55,8 +61,8 @@ var (
 // Writer intentionally models row streaming only. Some concrete writers also
 // implement [Flusher]; callers that own the full write lifecycle must call
 // Flush after the final row when it is available. Factories that may return a
-// buffered writer should return a concrete type or a local composite interface
-// such as interface { Writer; Flusher }, not Writer alone.
+// buffered writer should return a concrete type or [FlushWriter], not Writer
+// alone.
 type Writer interface {
 	WriteRow(row *spanner.Row) error
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -12,6 +12,7 @@
 package writer
 
 import (
+	"bytes"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -68,6 +69,113 @@ type Flusher interface {
 	Flush() error
 }
 
+// FlushWriter streams Spanner rows and finalizes any buffered output.
+type FlushWriter interface {
+	Writer
+	Flusher
+}
+
+// Option configures any writer type created by a WithOptions constructor.
+type Option interface {
+	CSVOption
+	JSONLOption
+	SQLInsertOption
+}
+
+// NameOption configures field-name handling for CSV and JSONL writers.
+type NameOption interface {
+	CSVOption
+	JSONLOption
+}
+
+// CSVOption configures a CSVWriter created by NewCSVWriterWithOptions or
+// NewDelimitedWriterWithOptions.
+type CSVOption interface {
+	applyCSVOption(*CSVWriter)
+}
+
+// JSONLOption configures a JSONLWriter created by NewJSONLWriterWithOptions.
+type JSONLOption interface {
+	applyJSONLOption(*JSONLWriter)
+}
+
+// SQLInsertOption configures a SQLInsertWriter created by NewSQLInsertWriterWithOptions.
+type SQLInsertOption interface {
+	applySQLInsertOption(*SQLInsertWriter)
+}
+
+type csvOptionFunc func(*CSVWriter)
+
+func (f csvOptionFunc) applyCSVOption(w *CSVWriter) {
+	f(w)
+}
+
+type metadataOption struct {
+	metadata *sppb.ResultSetMetadata
+}
+
+// WithMetadata initializes a writer schema from result-set metadata.
+func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
+	return metadataOption{metadata: metadata}
+}
+
+func (o metadataOption) applyCSVOption(w *CSVWriter) {
+	w.setMetadata(o.metadata)
+}
+
+func (o metadataOption) applyJSONLOption(w *JSONLWriter) {
+	w.setMetadata(o.metadata)
+}
+
+func (o metadataOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.setMetadata(o.metadata)
+}
+
+type formatterOption struct {
+	formatter *spanvalue.FormatConfig
+}
+
+// WithFormatter sets the FormatConfig used by a writer.
+func WithFormatter(formatter *spanvalue.FormatConfig) Option {
+	return formatterOption{formatter: formatter}
+}
+
+func (o formatterOption) applyCSVOption(w *CSVWriter) {
+	w.Formatter = o.formatter
+}
+
+func (o formatterOption) applyJSONLOption(w *JSONLWriter) {
+	w.Formatter = o.formatter
+}
+
+func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.Formatter = o.formatter
+}
+
+type unnamedFieldNamerOption struct {
+	namer spanvalue.UnnamedFieldNamer
+}
+
+// WithUnnamedFieldNamer sets the unnamed-field naming policy for CSV and JSONL writers.
+func WithUnnamedFieldNamer(namer spanvalue.UnnamedFieldNamer) NameOption {
+	return unnamedFieldNamerOption{namer: namer}
+}
+
+func (o unnamedFieldNamerOption) applyCSVOption(w *CSVWriter) {
+	w.UnnamedFieldNamer = o.namer
+}
+
+func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
+	w.UnnamedFieldNamer = o.namer
+}
+
+// WithHeader sets whether CSVWriter writes a header before data rows.
+func WithHeader(header bool) CSVOption {
+	return csvOptionFunc(func(w *CSVWriter) {
+		w.Header = header
+	})
+}
+
 // CSVWriter writes rows as CSV-style delimited text. Call Flush after the final write.
 type CSVWriter struct {
 	Formatter *spanvalue.FormatConfig
@@ -92,21 +200,49 @@ type CSVWriter struct {
 
 // NewCSVWriter returns a CSV writer optionally initialized from result-set metadata.
 func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
-	w := &CSVWriter{
+	w := newCSVWriter(out)
+	w.setMetadata(firstMetadata(metadata))
+	return w
+}
+
+// NewCSVWriterWithOptions returns a CSV writer configured by options.
+func NewCSVWriterWithOptions(out io.Writer, options ...CSVOption) *CSVWriter {
+	w := newCSVWriter(out)
+	for _, opt := range options {
+		if opt != nil {
+			opt.applyCSVOption(w)
+		}
+	}
+	return w
+}
+
+func newCSVWriter(out io.Writer) *CSVWriter {
+	return &CSVWriter{
 		Formatter:         spanvalue.SimpleFormatConfig(),
 		Header:            true,
 		UnnamedFieldNamer: spanvalue.IndexedUnnamedFieldNamer,
 		out:               out,
 	}
-	w.setMetadata(firstMetadata(metadata))
-	return w
 }
 
-// NewDelimitedWriter returns a CSV-style writer using delimiter as the field delimiter.
-// Pass '\t' for TSV output.
+// NewDelimitedWriter returns a CSV-style writer using delimiter as the field
+// delimiter. Pass '\t' for TSV output.
 func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
 	w := NewCSVWriter(out, metadata...)
 	w.Comma = delimiter
+	return w
+}
+
+// NewDelimitedWriterWithOptions returns a CSV-style writer using delimiter as
+// the field delimiter and configured by options. Pass '\t' for TSV output.
+func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...CSVOption) *CSVWriter {
+	w := newCSVWriter(out)
+	w.Comma = delimiter
+	for _, opt := range options {
+		if opt != nil {
+			opt.applyCSVOption(w)
+		}
+	}
 	return w
 }
 
@@ -117,6 +253,17 @@ func (w *CSVWriter) WriteRow(row *spanner.Row) error {
 		return err
 	}
 	return w.WriteValues(columnNames, values)
+}
+
+// Prepare initializes the CSV schema from result-set metadata before the first
+// row is written. If a schema is already initialized, Prepare verifies that the
+// metadata column names match the existing schema.
+func (w *CSVWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	columnNames, err := prepareColumnNames(metadata)
+	if err != nil {
+		return err
+	}
+	return w.initOrValidateColumnNames(columnNames)
 }
 
 // WriteHeader writes the CSV header once using the initialized column names.
@@ -225,10 +372,14 @@ func (w *CSVWriter) csvWriter() (*csv.Writer, error) {
 }
 
 func (w *CSVWriter) effectiveDelimiter() rune {
-	if w.Comma == 0 {
+	return effectiveDelimiter(w.Comma)
+}
+
+func effectiveDelimiter(delimiter rune) rune {
+	if delimiter == 0 {
 		return ','
 	}
-	return w.Comma
+	return delimiter
 }
 
 func validDelimiter(delimiter rune) bool {
@@ -280,13 +431,28 @@ type JSONLWriter struct {
 
 // NewJSONLWriter returns a JSONL writer optionally initialized from result-set metadata.
 func NewJSONLWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *JSONLWriter {
-	w := &JSONLWriter{
+	w := newJSONLWriter(out)
+	w.setMetadata(firstMetadata(metadata))
+	return w
+}
+
+// NewJSONLWriterWithOptions returns a JSONL writer configured by options.
+func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWriter {
+	w := newJSONLWriter(out)
+	for _, opt := range options {
+		if opt != nil {
+			opt.applyJSONLOption(w)
+		}
+	}
+	return w
+}
+
+func newJSONLWriter(out io.Writer) *JSONLWriter {
+	return &JSONLWriter{
 		Formatter:         spanvalue.JSONFormatConfig(),
 		UnnamedFieldNamer: spanvalue.IndexedUnnamedFieldNamer,
 		out:               out,
 	}
-	w.setMetadata(firstMetadata(metadata))
-	return w
 }
 
 func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
@@ -295,6 +461,17 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 		return err
 	}
 	return w.WriteValues(columnNames, values)
+}
+
+// Prepare initializes the JSONL schema from result-set metadata before the first
+// row is written. If a schema is already initialized, Prepare verifies that the
+// metadata column names match the existing schema.
+func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	columnNames, err := prepareColumnNames(metadata)
+	if err != nil {
+		return err
+	}
+	return w.initOrValidateColumnNames(columnNames)
 }
 
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
@@ -402,13 +579,28 @@ type SQLInsertWriter struct {
 
 // NewSQLInsertWriter returns a SQL INSERT writer optionally initialized from result-set metadata.
 func NewSQLInsertWriter(out io.Writer, table string, metadata ...*sppb.ResultSetMetadata) *SQLInsertWriter {
-	w := &SQLInsertWriter{
+	w := newSQLInsertWriter(out, table)
+	w.setMetadata(firstMetadata(metadata))
+	return w
+}
+
+// NewSQLInsertWriterWithOptions returns a SQL INSERT writer configured by options.
+func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+	w := newSQLInsertWriter(out, table)
+	for _, opt := range options {
+		if opt != nil {
+			opt.applySQLInsertOption(w)
+		}
+	}
+	return w
+}
+
+func newSQLInsertWriter(out io.Writer, table string) *SQLInsertWriter {
+	return &SQLInsertWriter{
 		Table:     table,
 		Formatter: spanvalue.LiteralFormatConfig(),
 		out:       out,
 	}
-	w.setMetadata(firstMetadata(metadata))
-	return w
 }
 
 func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
@@ -417,6 +609,18 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 		return err
 	}
 	return w.WriteValues(columnNames, values)
+}
+
+// Prepare initializes the SQL INSERT schema from result-set metadata before the
+// first row is written. If a schema is already initialized, Prepare verifies
+// that the metadata column names match the existing schema.
+func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	columnNames, err := prepareColumnNames(metadata)
+	if err != nil {
+		return err
+	}
+	_, err = w.initOrValidateQuotedColumns(columnNames)
+	return err
 }
 
 func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
@@ -517,8 +721,58 @@ func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
 	return quotedTable, nil
 }
 
-// rowData extracts column names and GenericColumnValue cells from row.
-func rowData(row *spanner.Row) ([]string, []spanner.GenericColumnValue, error) {
+// FormatCSVRow formats one row as a CSV record without a trailing newline.
+func FormatCSVRow(fc *spanvalue.FormatConfig, row *spanner.Row) (string, error) {
+	return FormatDelimitedRow(fc, row, 0)
+}
+
+// FormatCSVValues formats one row represented as column names plus GCV values
+// as a CSV record without a trailing newline.
+func FormatCSVValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue) (string, error) {
+	return FormatDelimitedValues(fc, columnNames, values, 0)
+}
+
+// FormatDelimitedRow formats one row as a CSV-style delimited record without a
+// trailing newline. A zero delimiter selects comma.
+func FormatDelimitedRow(fc *spanvalue.FormatConfig, row *spanner.Row, delimiter rune) (string, error) {
+	columnNames, values, err := RowData(row)
+	if err != nil {
+		return "", err
+	}
+	return FormatDelimitedValues(fc, columnNames, values, delimiter)
+}
+
+// FormatDelimitedValues formats one row represented as column names plus GCV
+// values as a CSV-style delimited record without a trailing newline. A zero
+// delimiter selects comma.
+func FormatDelimitedValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue, delimiter rune) (string, error) {
+	formattedValues, err := spanvalue.FormatRowColumns(simpleFormatter(fc), columnNames, values)
+	if err != nil {
+		return "", err
+	}
+	return formatDelimitedRecord(formattedValues, delimiter)
+}
+
+// FormatJSONLRow formats one row as a JSON object string without a trailing
+// newline. Callers writing JSONL streams should add the newline at the stream
+// boundary.
+func FormatJSONLRow(fc *spanvalue.FormatConfig, row *spanner.Row, namer spanvalue.UnnamedFieldNamer) (string, error) {
+	columnNames, values, err := RowData(row)
+	if err != nil {
+		return "", err
+	}
+	return FormatJSONLValues(fc, columnNames, values, namer)
+}
+
+// FormatJSONLValues formats one row represented as column names plus GCV values
+// as a JSON object string without a trailing newline. Callers writing JSONL
+// streams should add the newline at the stream boundary.
+func FormatJSONLValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue, namer spanvalue.UnnamedFieldNamer) (string, error) {
+	return spanvalue.FormatRowJSONObjectFromColumns(jsonFormatter(fc), columnNames, values, namer)
+}
+
+// RowData extracts column names and GenericColumnValue cells from row.
+func RowData(row *spanner.Row) ([]string, []spanner.GenericColumnValue, error) {
 	if row == nil {
 		return nil, nil, ErrNilRow
 	}
@@ -528,7 +782,43 @@ func rowData(row *spanner.Row) ([]string, []spanner.GenericColumnValue, error) {
 			return nil, nil, err
 		}
 	}
-	return row.ColumnNames(), values, nil
+	return slices.Clone(row.ColumnNames()), values, nil
+}
+
+func rowData(row *spanner.Row) ([]string, []spanner.GenericColumnValue, error) {
+	return RowData(row)
+}
+
+func formatDelimitedRecord(values []string, delimiter rune) (string, error) {
+	delimiter = effectiveDelimiter(delimiter)
+	if !validDelimiter(delimiter) {
+		return "", fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
+	}
+	var out bytes.Buffer
+	w := csv.NewWriter(&out)
+	w.Comma = delimiter
+	if err := w.Write(values); err != nil {
+		return "", err
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(out.String(), "\n"), nil
+}
+
+func simpleFormatter(fc *spanvalue.FormatConfig) *spanvalue.FormatConfig {
+	if fc != nil {
+		return fc
+	}
+	return spanvalue.SimpleFormatConfig()
+}
+
+func jsonFormatter(fc *spanvalue.FormatConfig) *spanvalue.FormatConfig {
+	if fc != nil {
+		return fc
+	}
+	return spanvalue.JSONFormatConfig()
 }
 
 // firstMetadata keeps the constructors backward-compatible while allowing an
@@ -538,6 +828,14 @@ func firstMetadata(metadata []*sppb.ResultSetMetadata) *sppb.ResultSetMetadata {
 		return nil
 	}
 	return metadata[0]
+}
+
+func prepareColumnNames(metadata *sppb.ResultSetMetadata) ([]string, error) {
+	columnNames := metadataColumnNames(metadata)
+	if len(columnNames) == 0 {
+		return nil, ErrMissingColumnNames
+	}
+	return columnNames, nil
 }
 
 func metadataColumnNames(metadata *sppb.ResultSetMetadata) []string {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -35,6 +35,12 @@ import (
 	"github.com/apstndb/spanvalue/internal"
 )
 
+const (
+	// Comma is the standard CSV field delimiter. Pass Comma to
+	// NewDelimitedWriter for CSV output.
+	Comma rune = ','
+)
+
 var (
 	// ErrEmptyTableName reports that SQLInsertWriter.Table is empty.
 	ErrEmptyTableName = errors.New("empty table name")
@@ -185,10 +191,10 @@ func WithHeader(header bool) DelimitedOption {
 type DelimitedWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
-	// Comma is the field delimiter. The zero value selects ','. Set it before
-	// the first write; use '\t' for TSV output. Any non-zero delimiter must be
-	// a valid encoding/csv delimiter: a valid rune other than '"', '\r', '\n',
-	// or utf8.RuneError.
+	// Comma is the field delimiter. The zero value selects Comma for
+	// compatibility. Set it before the first write; use '\t' for TSV output.
+	// Any non-zero delimiter must be a valid encoding/csv delimiter: a valid
+	// rune other than '"', '\r', '\n', or utf8.RuneError.
 	//
 	// Deprecated: prefer the delimiter argument to NewDelimitedWriter or
 	// NewDelimitedWriterWithOptions.
@@ -206,16 +212,15 @@ type DelimitedWriter struct {
 	wroteData           bool
 }
 
-// CSVWriter writes rows as CSV-style delimited text.
+// CSVWriter is a compatibility alias for DelimitedWriter.
 //
 // Deprecated: use DelimitedWriter.
 type CSVWriter = DelimitedWriter
 
 // NewCSVWriter returns a CSV writer optionally initialized from result-set metadata.
-//
-// Deprecated: use NewDelimitedWriter with delimiter 0.
-func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
-	return NewDelimitedWriter(out, 0, metadata...)
+// It is a thin helper for NewDelimitedWriter(out, Comma, metadata...).
+func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *DelimitedWriter {
+	return NewDelimitedWriter(out, Comma, metadata...)
 }
 
 func newDelimitedWriter(out io.Writer) *DelimitedWriter {
@@ -228,7 +233,8 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 }
 
 // NewDelimitedWriter returns a CSV-style writer using delimiter as the field
-// delimiter. Pass '\t' for TSV output.
+// delimiter. Pass Comma for CSV output or '\t' for TSV output. A zero delimiter
+// is accepted for compatibility and is treated as Comma.
 func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.Comma = delimiter
@@ -237,7 +243,9 @@ func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultS
 }
 
 // NewDelimitedWriterWithOptions returns a CSV-style writer using delimiter as
-// the field delimiter and configured by options. Pass '\t' for TSV output.
+// the field delimiter and configured by options. Pass Comma for CSV output or
+// '\t' for TSV output. A zero delimiter is accepted for compatibility and is
+// treated as Comma.
 func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.Comma = delimiter
@@ -380,7 +388,7 @@ func (w *DelimitedWriter) effectiveDelimiter() rune {
 
 func effectiveDelimiter(delimiter rune) rune {
 	if delimiter == 0 {
-		return ','
+		return Comma
 	}
 	return delimiter
 }
@@ -725,7 +733,8 @@ func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
 }
 
 // FormatDelimitedRow formats one row as a CSV-style delimited record without a
-// trailing newline. A zero delimiter selects comma.
+// trailing newline. Pass Comma for CSV output. A zero delimiter is accepted for
+// compatibility and is treated as Comma.
 func FormatDelimitedRow(fc *spanvalue.FormatConfig, row *spanner.Row, delimiter rune) (string, error) {
 	columnNames, values, err := RowData(row)
 	if err != nil {
@@ -735,8 +744,9 @@ func FormatDelimitedRow(fc *spanvalue.FormatConfig, row *spanner.Row, delimiter 
 }
 
 // FormatDelimitedValues formats one row represented as column names plus GCV
-// values as a CSV-style delimited record without a trailing newline. A zero
-// delimiter selects comma.
+// values as a CSV-style delimited record without a trailing newline. Pass Comma
+// for CSV output. A zero delimiter is accepted for compatibility and is treated
+// as Comma.
 func FormatDelimitedValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue, delimiter rune) (string, error) {
 	formattedValues, err := spanvalue.FormatRowColumns(simpleFormatter(fc), columnNames, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,10 +1,13 @@
 // Package writer provides small streaming helpers for exporting Spanner rows
 // using spanvalue formatters.
 //
-// DelimitedWriter and JSONLWriter preserve explicit duplicate column names. Their
-// UnnamedFieldNamer only fills empty column names, and generated names avoid
-// collisions with existing names. DelimitedWriter buffers through encoding/csv, so
-// callers must call Flush after the final write.
+// DelimitedWriter is the primary writer for CSV-style delimited text.
+// NewCSVWriter is a thin helper for the common comma-delimited CSV case, while
+// NewDelimitedWriter accepts an explicit delimiter for TSV and other delimited
+// output. DelimitedWriter and JSONLWriter preserve explicit duplicate column
+// names. Their UnnamedFieldNamer only fills empty column names, and generated
+// names avoid collisions with existing names. DelimitedWriter buffers through
+// encoding/csv, so callers must call Flush after the final write.
 //
 // Use Writer when an adapter only needs row streaming, and FlushWriter when it
 // owns the full write lifecycle. DelimitedWriter, JSONLWriter, and SQLInsertWriter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,13 +1,13 @@
 // Package writer provides small streaming helpers for exporting Spanner rows
 // using spanvalue formatters.
 //
-// CSVWriter and JSONLWriter preserve explicit duplicate column names. Their
+// DelimitedWriter and JSONLWriter preserve explicit duplicate column names. Their
 // UnnamedFieldNamer only fills empty column names, and generated names avoid
-// collisions with existing names. CSVWriter buffers through encoding/csv, so
+// collisions with existing names. DelimitedWriter buffers through encoding/csv, so
 // callers must call Flush after the final write.
 //
 // Use Writer when an adapter only needs row streaming, and FlushWriter when it
-// owns the full write lifecycle. CSVWriter, JSONLWriter, and SQLInsertWriter
+// owns the full write lifecycle. DelimitedWriter, JSONLWriter, and SQLInsertWriter
 // implement FlushWriter. If an adapter exposes a Close method, that Close
 // method should call Flush; Flush does not close the underlying io.Writer.
 //
@@ -48,11 +48,11 @@ var (
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
 	ErrColumnNamesMismatch = errors.New("column names mismatch")
-	// ErrHeaderAfterData reports that CSVWriter.WriteHeader was called after data rows were emitted.
+	// ErrHeaderAfterData reports that DelimitedWriter.WriteHeader was called after data rows were emitted.
 	ErrHeaderAfterData = errors.New("header after data")
-	// ErrInvalidDelimiter reports that CSVWriter.Comma is not a valid delimiter.
+	// ErrInvalidDelimiter reports that DelimitedWriter received an invalid delimiter.
 	ErrInvalidDelimiter = errors.New("invalid delimiter")
-	// ErrDelimiterAfterWrite reports that CSVWriter.Comma changed after the underlying CSV writer was initialized.
+	// ErrDelimiterAfterWrite reports that DelimitedWriter delimiter changed after the underlying CSV writer was initialized.
 	ErrDelimiterAfterWrite = errors.New("delimiter changed after writer initialization")
 )
 
@@ -68,9 +68,9 @@ type Writer interface {
 }
 
 // Flusher finalizes any buffered output. Flush does not close the underlying
-// io.Writer. CSVWriter uses Flush to forward buffered CSV or TSV data; JSONLWriter
-// and SQLInsertWriter implement it as a no-op so adapters can use one finalize
-// path for all writer implementations.
+// io.Writer. DelimitedWriter uses Flush to forward buffered CSV-style data;
+// JSONLWriter and SQLInsertWriter implement it as a no-op so adapters can use
+// one finalize path for all writer implementations.
 type Flusher interface {
 	Flush() error
 }
@@ -83,20 +83,20 @@ type FlushWriter interface {
 
 // Option configures any writer type created by a WithOptions constructor.
 type Option interface {
-	CSVOption
+	DelimitedOption
 	JSONLOption
 	SQLInsertOption
 }
 
-// NameOption configures field-name handling for CSV and JSONL writers.
+// NameOption configures field-name handling for delimited and JSONL writers.
 type NameOption interface {
-	CSVOption
+	DelimitedOption
 	JSONLOption
 }
 
-// CSVOption configures a CSVWriter created by NewDelimitedWriterWithOptions.
-type CSVOption interface {
-	applyCSVOption(*CSVWriter)
+// DelimitedOption configures a DelimitedWriter created by NewDelimitedWriterWithOptions.
+type DelimitedOption interface {
+	applyDelimitedOption(*DelimitedWriter)
 }
 
 // JSONLOption configures a JSONLWriter created by NewJSONLWriterWithOptions.
@@ -109,9 +109,9 @@ type SQLInsertOption interface {
 	applySQLInsertOption(*SQLInsertWriter)
 }
 
-type csvOptionFunc func(*CSVWriter)
+type delimitedOptionFunc func(*DelimitedWriter)
 
-func (f csvOptionFunc) applyCSVOption(w *CSVWriter) {
+func (f delimitedOptionFunc) applyDelimitedOption(w *DelimitedWriter) {
 	f(w)
 }
 
@@ -124,7 +124,7 @@ func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
 
-func (o metadataOption) applyCSVOption(w *CSVWriter) {
+func (o metadataOption) applyDelimitedOption(w *DelimitedWriter) {
 	w.setMetadata(o.metadata)
 }
 
@@ -145,7 +145,7 @@ func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}
 }
 
-func (o formatterOption) applyCSVOption(w *CSVWriter) {
+func (o formatterOption) applyDelimitedOption(w *DelimitedWriter) {
 	w.Formatter = o.formatter
 }
 
@@ -161,12 +161,12 @@ type unnamedFieldNamerOption struct {
 	namer spanvalue.UnnamedFieldNamer
 }
 
-// WithUnnamedFieldNamer sets the unnamed-field naming policy for CSV and JSONL writers.
+// WithUnnamedFieldNamer sets the unnamed-field naming policy for delimited and JSONL writers.
 func WithUnnamedFieldNamer(namer spanvalue.UnnamedFieldNamer) NameOption {
 	return unnamedFieldNamerOption{namer: namer}
 }
 
-func (o unnamedFieldNamerOption) applyCSVOption(w *CSVWriter) {
+func (o unnamedFieldNamerOption) applyDelimitedOption(w *DelimitedWriter) {
 	w.UnnamedFieldNamer = o.namer
 }
 
@@ -174,21 +174,24 @@ func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
 	w.UnnamedFieldNamer = o.namer
 }
 
-// WithHeader sets whether CSVWriter writes a header before data rows.
-func WithHeader(header bool) CSVOption {
-	return csvOptionFunc(func(w *CSVWriter) {
+// WithHeader sets whether DelimitedWriter writes a header before data rows.
+func WithHeader(header bool) DelimitedOption {
+	return delimitedOptionFunc(func(w *DelimitedWriter) {
 		w.Header = header
 	})
 }
 
-// CSVWriter writes rows as CSV-style delimited text. Call Flush after the final write.
-type CSVWriter struct {
+// DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
+type DelimitedWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
 	// Comma is the field delimiter. The zero value selects ','. Set it before
 	// the first write; use '\t' for TSV output. Any non-zero delimiter must be
 	// a valid encoding/csv delimiter: a valid rune other than '"', '\r', '\n',
 	// or utf8.RuneError.
+	//
+	// Deprecated: prefer the delimiter argument to NewDelimitedWriter or
+	// NewDelimitedWriterWithOptions.
 	Comma rune
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached header names.
@@ -203,15 +206,20 @@ type CSVWriter struct {
 	wroteData           bool
 }
 
+// CSVWriter writes rows as CSV-style delimited text.
+//
+// Deprecated: use DelimitedWriter.
+type CSVWriter = DelimitedWriter
+
 // NewCSVWriter returns a CSV writer optionally initialized from result-set metadata.
+//
+// Deprecated: use NewDelimitedWriter with delimiter 0.
 func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
-	w := newCSVWriter(out)
-	w.setMetadata(firstMetadata(metadata))
-	return w
+	return NewDelimitedWriter(out, 0, metadata...)
 }
 
-func newCSVWriter(out io.Writer) *CSVWriter {
-	return &CSVWriter{
+func newDelimitedWriter(out io.Writer) *DelimitedWriter {
+	return &DelimitedWriter{
 		Formatter:         spanvalue.SimpleFormatConfig(),
 		Header:            true,
 		UnnamedFieldNamer: spanvalue.IndexedUnnamedFieldNamer,
@@ -221,27 +229,28 @@ func newCSVWriter(out io.Writer) *CSVWriter {
 
 // NewDelimitedWriter returns a CSV-style writer using delimiter as the field
 // delimiter. Pass '\t' for TSV output.
-func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
-	w := NewCSVWriter(out, metadata...)
+func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *DelimitedWriter {
+	w := newDelimitedWriter(out)
 	w.Comma = delimiter
+	w.setMetadata(firstMetadata(metadata))
 	return w
 }
 
 // NewDelimitedWriterWithOptions returns a CSV-style writer using delimiter as
 // the field delimiter and configured by options. Pass '\t' for TSV output.
-func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...CSVOption) *CSVWriter {
-	w := newCSVWriter(out)
+func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
+	w := newDelimitedWriter(out)
 	w.Comma = delimiter
 	for _, opt := range options {
 		if opt != nil {
-			opt.applyCSVOption(w)
+			opt.applyDelimitedOption(w)
 		}
 	}
 	return w
 }
 
-// WriteRow writes one CSV row, initializing the schema from row metadata if needed.
-func (w *CSVWriter) WriteRow(row *spanner.Row) error {
+// WriteRow writes one delimited row, initializing the schema from row metadata if needed.
+func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 	columnNames, values, err := rowData(row)
 	if err != nil {
 		return err
@@ -249,10 +258,10 @@ func (w *CSVWriter) WriteRow(row *spanner.Row) error {
 	return w.WriteValues(columnNames, values)
 }
 
-// Prepare initializes the CSV schema from result-set metadata before the first
+// Prepare initializes the delimited schema from result-set metadata before the first
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
-func (w *CSVWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	columnNames, err := prepareColumnNames(metadata)
 	if err != nil {
 		return err
@@ -260,8 +269,8 @@ func (w *CSVWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.initOrValidateColumnNames(columnNames)
 }
 
-// WriteHeader writes the CSV header once using the initialized column names.
-func (w *CSVWriter) WriteHeader() error {
+// WriteHeader writes the delimited header once using the initialized column names.
+func (w *DelimitedWriter) WriteHeader() error {
 	if w.wroteHeader {
 		return nil
 	}
@@ -288,14 +297,14 @@ func (w *CSVWriter) WriteHeader() error {
 	return nil
 }
 
-func (w *CSVWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
+func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
 	}
 	return w.WriteGCVs(values)
 }
 
-func (w *CSVWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
+func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	csvWriter, err := w.csvWriter()
 	if err != nil {
 		return err
@@ -322,12 +331,12 @@ func (w *CSVWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	return nil
 }
 
-func (w *CSVWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
+func (w *DelimitedWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
 	w.columnNames = metadataColumnNames(metadata)
 	w.resolvedColumnNames = nil
 }
 
-func (w *CSVWriter) initOrValidateColumnNames(columnNames []string) error {
+func (w *DelimitedWriter) initOrValidateColumnNames(columnNames []string) error {
 	initialized := len(w.columnNames) == 0
 	if err := initOrValidateColumnNames(&w.columnNames, columnNames); err != nil {
 		return err
@@ -338,14 +347,14 @@ func (w *CSVWriter) initOrValidateColumnNames(columnNames []string) error {
 	return nil
 }
 
-func (w *CSVWriter) formatter() *spanvalue.FormatConfig {
+func (w *DelimitedWriter) formatter() *spanvalue.FormatConfig {
 	if w.Formatter != nil {
 		return w.Formatter
 	}
 	return spanvalue.SimpleFormatConfig()
 }
 
-func (w *CSVWriter) csvWriter() (*csv.Writer, error) {
+func (w *DelimitedWriter) csvWriter() (*csv.Writer, error) {
 	delimiter := w.effectiveDelimiter()
 	if w.writer != nil {
 		if w.delimiter != delimiter {
@@ -365,7 +374,7 @@ func (w *CSVWriter) csvWriter() (*csv.Writer, error) {
 	return w.writer, nil
 }
 
-func (w *CSVWriter) effectiveDelimiter() rune {
+func (w *DelimitedWriter) effectiveDelimiter() rune {
 	return effectiveDelimiter(w.Comma)
 }
 
@@ -385,9 +394,9 @@ func validDelimiter(delimiter rune) bool {
 		delimiter != utf8.RuneError
 }
 
-// Flush flushes buffered CSV or TSV data to the underlying writer. It does not
+// Flush flushes buffered delimited data to the underlying writer. It does not
 // close the underlying writer.
-func (w *CSVWriter) Flush() error {
+func (w *DelimitedWriter) Flush() error {
 	if w.writer == nil {
 		return nil
 	}
@@ -395,7 +404,7 @@ func (w *CSVWriter) Flush() error {
 	return w.writer.Error()
 }
 
-func (w *CSVWriter) resolvedNames() ([]string, error) {
+func (w *DelimitedWriter) resolvedNames() ([]string, error) {
 	if len(w.resolvedColumnNames) != 0 || len(w.columnNames) == 0 {
 		return w.resolvedColumnNames, nil
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -94,8 +94,7 @@ type NameOption interface {
 	JSONLOption
 }
 
-// CSVOption configures a CSVWriter created by NewCSVWriterWithOptions or
-// NewDelimitedWriterWithOptions.
+// CSVOption configures a CSVWriter created by NewDelimitedWriterWithOptions.
 type CSVOption interface {
 	applyCSVOption(*CSVWriter)
 }
@@ -208,17 +207,6 @@ type CSVWriter struct {
 func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *CSVWriter {
 	w := newCSVWriter(out)
 	w.setMetadata(firstMetadata(metadata))
-	return w
-}
-
-// NewCSVWriterWithOptions returns a CSV writer configured by options.
-func NewCSVWriterWithOptions(out io.Writer, options ...CSVOption) *CSVWriter {
-	w := newCSVWriter(out)
-	for _, opt := range options {
-		if opt != nil {
-			opt.applyCSVOption(w)
-		}
-	}
 	return w
 }
 
@@ -725,17 +713,6 @@ func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
 	w.quotedTable = quotedTable
 	w.quotedTableInput = w.Table
 	return quotedTable, nil
-}
-
-// FormatCSVRow formats one row as a CSV record without a trailing newline.
-func FormatCSVRow(fc *spanvalue.FormatConfig, row *spanner.Row) (string, error) {
-	return FormatDelimitedRow(fc, row, 0)
-}
-
-// FormatCSVValues formats one row represented as column names plus GCV values
-// as a CSV record without a trailing newline.
-func FormatCSVValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue) (string, error) {
-	return FormatDelimitedValues(fc, columnNames, values, 0)
 }
 
 // FormatDelimitedRow formats one row as a CSV-style delimited record without a

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -132,7 +132,7 @@ func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWithOptions(t *testing.T) {
+func TestDelimitedWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -979,12 +979,12 @@ func TestRowDataAndOneRowFormatHelpers(t *testing.T) {
 		t.Fatalf("RowData() column names mismatch (-want +got):\n%s", diff)
 	}
 
-	csvRow, err := FormatCSVValues(nil, columnNames, values)
+	csvRow, err := FormatDelimitedValues(nil, columnNames, values, 0)
 	if err != nil {
-		t.Fatalf("FormatCSVValues() error = %v", err)
+		t.Fatalf("FormatDelimitedValues() error = %v", err)
 	}
 	if want := `42,"comma, ok"`; csvRow != want {
-		t.Fatalf("FormatCSVValues() = %q, want %q", csvRow, want)
+		t.Fatalf("FormatDelimitedValues() = %q, want %q", csvRow, want)
 	}
 
 	tsvRow, err := FormatDelimitedRow(nil, row, '\t')

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -251,6 +251,60 @@ func TestCSVWriterPrepare(t *testing.T) {
 	}
 }
 
+func TestJSONLWriterPrepare(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriter(&out)
+	if err := w.Prepare(metadataWithColumnNames("", "age")); err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Alice"),
+		gcvctor.Int64Value(42),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+
+	want := "{\"_0\":\"Alice\",\"age\":42}\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("JSONL output mismatch (-want +got):\n%s", diff)
+	}
+
+	err := w.Prepare(metadataWithColumnNames("", "score"))
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("Prepare() mismatch error = %v, want ErrColumnNamesMismatch", err)
+	}
+}
+
+func TestSQLInsertWriterPrepare(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewSQLInsertWriter(&out, "users")
+	if err := w.Prepare(metadataWithColumnNames("id", "name")); err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(42),
+		gcvctor.StringValue("Alice"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+
+	want := "INSERT INTO `users` (`id`, `name`) VALUES (42, \"Alice\");\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+	}
+
+	err := w.Prepare(metadataWithColumnNames("id", "full_name"))
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("Prepare() mismatch error = %v, want ErrColumnNamesMismatch", err)
+	}
+}
+
 func TestWritersPrepareWithoutMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -8,18 +8,22 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/apstndb/spanvalue/internal"
 	"github.com/google/go-cmp/cmp"
 )
 
 var (
-	_ Writer  = (*CSVWriter)(nil)
-	_ Writer  = (*JSONLWriter)(nil)
-	_ Writer  = (*SQLInsertWriter)(nil)
-	_ Flusher = (*CSVWriter)(nil)
-	_ Flusher = (*JSONLWriter)(nil)
-	_ Flusher = (*SQLInsertWriter)(nil)
+	_ Writer      = (*CSVWriter)(nil)
+	_ Writer      = (*JSONLWriter)(nil)
+	_ Writer      = (*SQLInsertWriter)(nil)
+	_ Flusher     = (*CSVWriter)(nil)
+	_ Flusher     = (*JSONLWriter)(nil)
+	_ Flusher     = (*SQLInsertWriter)(nil)
+	_ FlushWriter = (*CSVWriter)(nil)
+	_ FlushWriter = (*JSONLWriter)(nil)
+	_ FlushWriter = (*SQLInsertWriter)(nil)
 )
 
 func metadataWithColumnNames(names ...string) *sppb.ResultSetMetadata {
@@ -128,6 +132,34 @@ func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
 	}
 }
 
+func TestCSVWriterWithOptions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriterWithOptions(
+		&out,
+		'\t',
+		WithMetadata(metadataWithColumnNames("name", "age")),
+		WithFormatter(spanvalue.LiteralFormatConfig()),
+		WithHeader(false),
+		WithUnnamedFieldNamer(nil),
+	)
+
+	err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Alice"),
+		gcvctor.Int64Value(42),
+	})
+	if err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushCSVWriter(t, w)
+
+	want := "\"\"\"Alice\"\"\"\t42\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("delimited output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestCSVWriterWriteValuesZeroCommaUsesDefault(t *testing.T) {
 	t.Parallel()
 
@@ -188,6 +220,67 @@ func TestCSVWriterWriteValuesCommaChangeAfterWrite(t *testing.T) {
 	)
 	if !errors.Is(err, ErrDelimiterAfterWrite) {
 		t.Fatalf("WriteValues() after Comma change error = %v, want ErrDelimiterAfterWrite", err)
+	}
+}
+
+func TestCSVWriterPrepare(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewCSVWriter(&out)
+	if err := w.Prepare(metadataWithColumnNames("name", "age")); err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Alice"),
+		gcvctor.Int64Value(42),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushCSVWriter(t, w)
+
+	want := "name,age\nAlice,42\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+
+	err := w.Prepare(metadataWithColumnNames("name", "score"))
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("Prepare() mismatch error = %v, want ErrColumnNamesMismatch", err)
+	}
+}
+
+func TestWritersPrepareWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prepare func(*sppb.ResultSetMetadata) error
+	}{
+		{
+			name:    "csv",
+			prepare: NewCSVWriter(&bytes.Buffer{}).Prepare,
+		},
+		{
+			name:    "jsonl",
+			prepare: NewJSONLWriter(&bytes.Buffer{}).Prepare,
+		},
+		{
+			name:    "sql",
+			prepare: NewSQLInsertWriter(&bytes.Buffer{}, "users").Prepare,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.prepare(nil)
+			if !errors.Is(err, ErrMissingColumnNames) {
+				t.Fatalf("Prepare(nil) error = %v, want ErrMissingColumnNames", err)
+			}
+		})
 	}
 }
 
@@ -491,6 +584,29 @@ func TestJSONLWriterWriteRow(t *testing.T) {
 	}
 }
 
+func TestJSONLWriterWithOptions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriterWithOptions(
+		&out,
+		WithMetadata(metadataWithColumnNames("", "age")),
+		WithUnnamedFieldNamer(nil),
+	)
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(42),
+		gcvctor.Int64Value(7),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+
+	want := "{\"\":42,\"age\":7}\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("JSONL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestJSONLWriterWriteGCVsAfterWriteRow(t *testing.T) {
 	t.Parallel()
 
@@ -620,6 +736,30 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 				t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestSQLInsertWriterWithOptions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewSQLInsertWriterWithOptions(
+		&out,
+		"users",
+		WithMetadata(metadataWithColumnNames("id", "name")),
+		WithFormatter(spanvalue.LiteralFormatConfig()),
+	)
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(42),
+		gcvctor.StringValue("Alice"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+
+	want := "INSERT INTO `users` (`id`, `name`) VALUES (42, \"Alice\");\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -766,5 +906,60 @@ func TestSQLInsertWriterWriteGCVsEmptyTableName(t *testing.T) {
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
 	if !errors.Is(err, ErrEmptyTableName) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrEmptyTableName", err)
+	}
+}
+
+func TestRowDataAndOneRowFormatHelpers(t *testing.T) {
+	t.Parallel()
+
+	row, err := spanner.NewRow([]string{"id", "note"}, []interface{}{int64(42), "comma, ok"})
+	if err != nil {
+		t.Fatalf("spanner.NewRow() error = %v", err)
+	}
+
+	columnNames, values, err := RowData(row)
+	if err != nil {
+		t.Fatalf("RowData() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"id", "note"}, columnNames); diff != "" {
+		t.Fatalf("RowData() column names mismatch (-want +got):\n%s", diff)
+	}
+
+	csvRow, err := FormatCSVValues(nil, columnNames, values)
+	if err != nil {
+		t.Fatalf("FormatCSVValues() error = %v", err)
+	}
+	if want := `42,"comma, ok"`; csvRow != want {
+		t.Fatalf("FormatCSVValues() = %q, want %q", csvRow, want)
+	}
+
+	tsvRow, err := FormatDelimitedRow(nil, row, '\t')
+	if err != nil {
+		t.Fatalf("FormatDelimitedRow() error = %v", err)
+	}
+	if want := "42\tcomma, ok"; tsvRow != want {
+		t.Fatalf("FormatDelimitedRow() = %q, want %q", tsvRow, want)
+	}
+
+	jsonRow, err := FormatJSONLRow(nil, row, spanvalue.IndexedUnnamedFieldNamer)
+	if err != nil {
+		t.Fatalf("FormatJSONLRow() error = %v", err)
+	}
+	if want := `{"id":42,"note":"comma, ok"}`; jsonRow != want {
+		t.Fatalf("FormatJSONLRow() = %q, want %q", jsonRow, want)
+	}
+}
+
+func TestFormatDelimitedValuesInvalidDelimiter(t *testing.T) {
+	t.Parallel()
+
+	_, err := FormatDelimitedValues(
+		nil,
+		[]string{"name"},
+		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
+		'\n',
+	)
+	if !errors.Is(err, ErrInvalidDelimiter) {
+		t.Fatalf("FormatDelimitedValues() error = %v, want ErrInvalidDelimiter", err)
 	}
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	_ Writer      = (*CSVWriter)(nil)
+	_ Writer      = (*DelimitedWriter)(nil)
 	_ Writer      = (*JSONLWriter)(nil)
 	_ Writer      = (*SQLInsertWriter)(nil)
-	_ Flusher     = (*CSVWriter)(nil)
+	_ Flusher     = (*DelimitedWriter)(nil)
 	_ Flusher     = (*JSONLWriter)(nil)
 	_ Flusher     = (*SQLInsertWriter)(nil)
-	_ FlushWriter = (*CSVWriter)(nil)
+	_ FlushWriter = (*DelimitedWriter)(nil)
 	_ FlushWriter = (*JSONLWriter)(nil)
 	_ FlushWriter = (*SQLInsertWriter)(nil)
 )
@@ -39,18 +39,35 @@ func metadataWithColumnNames(names ...string) *sppb.ResultSetMetadata {
 	}
 }
 
-func flushCSVWriter(t *testing.T, w *CSVWriter) {
+func flushDelimitedWriter(t *testing.T, w *DelimitedWriter) {
 	t.Helper()
 	if err := w.Flush(); err != nil {
 		t.Fatalf("Flush() error = %v", err)
 	}
 }
 
-func TestCSVWriterWriteValues(t *testing.T) {
+func TestNewCSVWriterCompatibility(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewCSVWriter(&out, metadataWithColumnNames("name"))
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "name\nAlice\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDelimitedWriterWriteValues(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, 0)
 
 	err := w.WriteValues(
 		[]string{"name", ""},
@@ -73,7 +90,7 @@ func TestCSVWriterWriteValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteValues() second call error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,_0\nAlice,<null>\nBob,7\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -81,23 +98,23 @@ func TestCSVWriterWriteValues(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
+func TestDelimitedWriterWriteValuesWithCustomDelimiter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name string
-		new  func(out *bytes.Buffer) *CSVWriter
+		new  func(out *bytes.Buffer) *DelimitedWriter
 	}{
 		{
 			name: "constructor",
-			new: func(out *bytes.Buffer) *CSVWriter {
+			new: func(out *bytes.Buffer) *DelimitedWriter {
 				return NewDelimitedWriter(out, '\t')
 			},
 		},
 		{
-			name: "field",
-			new: func(out *bytes.Buffer) *CSVWriter {
-				w := NewCSVWriter(out)
+			name: "deprecated comma field",
+			new: func(out *bytes.Buffer) *DelimitedWriter {
+				w := NewDelimitedWriter(out, 0)
 				w.Comma = '\t'
 				return w
 			},
@@ -122,7 +139,7 @@ func TestCSVWriterWriteValuesWithCustomComma(t *testing.T) {
 			if err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
-			flushCSVWriter(t, w)
+			flushDelimitedWriter(t, w)
 
 			want := "name\tnote\twith_tab\nAlice\tcomma, ok\t\"tab\tok\"\n"
 			if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -152,7 +169,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "\"\"\"Alice\"\"\"\t42\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -160,7 +177,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteValuesZeroCommaUsesDefault(t *testing.T) {
+func TestDelimitedWriterWriteValuesZeroDelimiterUsesDefault(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -176,7 +193,7 @@ func TestCSVWriterWriteValuesZeroCommaUsesDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteValues() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,note\nAlice,\"comma, ok\"\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -184,7 +201,7 @@ func TestCSVWriterWriteValuesZeroCommaUsesDefault(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteValuesInvalidComma(t *testing.T) {
+func TestDelimitedWriterWriteValuesInvalidDelimiter(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -199,7 +216,7 @@ func TestCSVWriterWriteValuesInvalidComma(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteValuesCommaChangeAfterWrite(t *testing.T) {
+func TestDelimitedWriterWriteValuesDelimiterChangeAfterWrite(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -219,15 +236,15 @@ func TestCSVWriterWriteValuesCommaChangeAfterWrite(t *testing.T) {
 		[]spanner.GenericColumnValue{gcvctor.StringValue("Bob")},
 	)
 	if !errors.Is(err, ErrDelimiterAfterWrite) {
-		t.Fatalf("WriteValues() after Comma change error = %v, want ErrDelimiterAfterWrite", err)
+		t.Fatalf("WriteValues() after delimiter change error = %v, want ErrDelimiterAfterWrite", err)
 	}
 }
 
-func TestCSVWriterPrepare(t *testing.T) {
+func TestDelimitedWriterPrepare(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewDelimitedWriter(&out, 0)
 	if err := w.Prepare(metadataWithColumnNames("name", "age")); err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -238,7 +255,7 @@ func TestCSVWriterPrepare(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,age\nAlice,42\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -314,7 +331,7 @@ func TestWritersPrepareWithoutMetadata(t *testing.T) {
 	}{
 		{
 			name:    "csv",
-			prepare: NewCSVWriter(&bytes.Buffer{}).Prepare,
+			prepare: NewDelimitedWriter(&bytes.Buffer{}, 0).Prepare,
 		},
 		{
 			name:    "jsonl",
@@ -338,11 +355,11 @@ func TestWritersPrepareWithoutMetadata(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteGCVsWithMetadata(t *testing.T) {
+func TestDelimitedWriterWriteGCVsWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.StringValue("Alice"),
@@ -351,7 +368,7 @@ func TestCSVWriterWriteGCVsWithMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,age\nAlice,42\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -359,11 +376,11 @@ func TestCSVWriterWriteGCVsWithMetadata(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteRow(t *testing.T) {
+func TestDelimitedWriterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewDelimitedWriter(&out, 0)
 
 	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
 	if err != nil {
@@ -373,7 +390,7 @@ func TestCSVWriterWriteRow(t *testing.T) {
 	if err := w.WriteRow(row); err != nil {
 		t.Fatalf("WriteRow() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "id,_0\n42,hello\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -381,16 +398,16 @@ func TestCSVWriterWriteRow(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteHeaderWithMetadata(t *testing.T) {
+func TestDelimitedWriterWriteHeaderWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,age\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -426,11 +443,11 @@ func TestUnbufferedWritersFlushIsNoop(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteHeaderThenWriteGCVs(t *testing.T) {
+func TestDelimitedWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -442,7 +459,7 @@ func TestCSVWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}
-	flushCSVWriter(t, w)
+	flushDelimitedWriter(t, w)
 
 	want := "name,age\nAlice,42\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
@@ -450,11 +467,11 @@ func TestCSVWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteHeaderWithoutMetadata(t *testing.T) {
+func TestDelimitedWriterWriteHeaderWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewDelimitedWriter(&out, 0)
 
 	err := w.WriteHeader()
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -462,11 +479,11 @@ func TestCSVWriterWriteHeaderWithoutMetadata(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteHeaderAfterData(t *testing.T) {
+func TestDelimitedWriterWriteHeaderAfterData(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
 	w.Header = false
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -482,11 +499,11 @@ func TestCSVWriterWriteHeaderAfterData(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteGCVsWithoutMetadata(t *testing.T) {
+func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewDelimitedWriter(&out, 0)
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -494,19 +511,19 @@ func TestCSVWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
+func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewCSVWriter(nil).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+	err := NewDelimitedWriter(nil, 0).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrNilOutputWriter", err)
 	}
 }
 
-func TestCSVWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
+func TestDelimitedWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewCSVWriter(nil).WriteHeader()
+	err := NewDelimitedWriter(nil, 0).WriteHeader()
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteHeader() error = %v, want ErrNilOutputWriter", err)
 	}
@@ -522,7 +539,7 @@ func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := NewCSVWriter(nil, metadataWithColumnNames("name"))
+				w := NewDelimitedWriter(nil, 0, metadataWithColumnNames("name"))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
@@ -564,7 +581,7 @@ func TestWritersReturnErrNilRow(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				return NewCSVWriter(&bytes.Buffer{}).WriteRow(nil)
+				return NewDelimitedWriter(&bytes.Buffer{}, 0).WriteRow(nil)
 			},
 		},
 		{
@@ -593,11 +610,11 @@ func TestWritersReturnErrNilRow(t *testing.T) {
 	}
 }
 
-func TestCSVWriterWriteValuesColumnNamesMismatch(t *testing.T) {
+func TestDelimitedWriterWriteValuesColumnNamesMismatch(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out)
+	w := NewDelimitedWriter(&out, 0)
 
 	if err := w.WriteValues(
 		[]string{"name"},

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -46,7 +46,7 @@ func flushDelimitedWriter(t *testing.T, w *DelimitedWriter) {
 	}
 }
 
-func TestNewCSVWriterCompatibility(t *testing.T) {
+func TestNewCSVWriterHelper(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -67,7 +67,7 @@ func TestDelimitedWriterWriteValues(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 
 	err := w.WriteValues(
 		[]string{"name", ""},
@@ -114,7 +114,7 @@ func TestDelimitedWriterWriteValuesWithCustomDelimiter(t *testing.T) {
 		{
 			name: "deprecated comma field",
 			new: func(out *bytes.Buffer) *DelimitedWriter {
-				w := NewDelimitedWriter(out, 0)
+				w := NewDelimitedWriter(out, Comma)
 				w.Comma = '\t'
 				return w
 			},
@@ -177,7 +177,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	}
 }
 
-func TestDelimitedWriterWriteValuesZeroDelimiterUsesDefault(t *testing.T) {
+func TestDelimitedWriterWriteValuesZeroDelimiterUsesCommaForCompatibility(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -230,7 +230,7 @@ func TestDelimitedWriterWriteValuesDelimiterChangeAfterWrite(t *testing.T) {
 		t.Fatalf("WriteValues() error = %v", err)
 	}
 
-	w.Comma = ','
+	w.Comma = Comma
 	err = w.WriteValues(
 		[]string{"name"},
 		[]spanner.GenericColumnValue{gcvctor.StringValue("Bob")},
@@ -244,7 +244,7 @@ func TestDelimitedWriterPrepare(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 	if err := w.Prepare(metadataWithColumnNames("name", "age")); err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -331,7 +331,7 @@ func TestWritersPrepareWithoutMetadata(t *testing.T) {
 	}{
 		{
 			name:    "csv",
-			prepare: NewDelimitedWriter(&bytes.Buffer{}, 0).Prepare,
+			prepare: NewDelimitedWriter(&bytes.Buffer{}, Comma).Prepare,
 		},
 		{
 			name:    "jsonl",
@@ -359,7 +359,7 @@ func TestDelimitedWriterWriteGCVsWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.StringValue("Alice"),
@@ -380,7 +380,7 @@ func TestDelimitedWriterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 
 	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
 	if err != nil {
@@ -402,7 +402,7 @@ func TestDelimitedWriterWriteHeaderWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -447,7 +447,7 @@ func TestDelimitedWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -471,7 +471,7 @@ func TestDelimitedWriterWriteHeaderWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 
 	err := w.WriteHeader()
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -483,7 +483,7 @@ func TestDelimitedWriterWriteHeaderAfterData(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
 	w.Header = false
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -503,7 +503,7 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -514,7 +514,7 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(nil, 0).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+	err := NewDelimitedWriter(nil, Comma).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrNilOutputWriter", err)
 	}
@@ -523,7 +523,7 @@ func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 func TestDelimitedWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(nil, 0).WriteHeader()
+	err := NewDelimitedWriter(nil, Comma).WriteHeader()
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteHeader() error = %v, want ErrNilOutputWriter", err)
 	}
@@ -539,7 +539,7 @@ func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := NewDelimitedWriter(nil, 0, metadataWithColumnNames("name"))
+				w := NewDelimitedWriter(nil, Comma, metadataWithColumnNames("name"))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
@@ -581,7 +581,7 @@ func TestWritersReturnErrNilRow(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				return NewDelimitedWriter(&bytes.Buffer{}, 0).WriteRow(nil)
+				return NewDelimitedWriter(&bytes.Buffer{}, Comma).WriteRow(nil)
 			},
 		},
 		{
@@ -614,7 +614,7 @@ func TestDelimitedWriterWriteValuesColumnNamesMismatch(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := NewDelimitedWriter(&out, Comma)
 
 	if err := w.WriteValues(
 		[]string{"name"},
@@ -996,7 +996,7 @@ func TestRowDataAndOneRowFormatHelpers(t *testing.T) {
 		t.Fatalf("RowData() column names mismatch (-want +got):\n%s", diff)
 	}
 
-	csvRow, err := FormatDelimitedValues(nil, columnNames, values, 0)
+	csvRow, err := FormatDelimitedValues(nil, columnNames, values, Comma)
 	if err != nil {
 		t.Fatalf("FormatDelimitedValues() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- make `DelimitedWriter` the primary CSV-style writer type while keeping `CSVWriter` and `DelimitedWriter.Comma` as deprecated compatibility APIs
- keep `NewCSVWriter` as a non-deprecated thin helper for comma-delimited CSV output and add `writer.Comma` for explicit delimiter calls
- add WithOptions constructors and shared writer options for explicit setup without mutating fields after construction
- add FlushWriter, Prepare methods, RowData, and one-row delimited / JSONL formatting helpers
- document the Writer / FlushWriter lifecycle, CSV helper role, deprecated compatibility APIs, and non-streaming helper usage

## Follow-up
- Future breaking constructor cleanup is tracked in #84
- Non-breaking API discoverability work is tracked in #85
- Mutable formatter global cleanup is tracked in #86

## Verification
- go test ./writer
- make check
- git diff --check origin/main
- GitHub Actions: build / lint passed
- Copilot review on latest head: generated no new comments
- Gemini review on latest head: no feedback