### PR TITLE
Improve API discoverability before the next minor release

### DIFF
--- a/common.go
+++ b/common.go
@@ -184,20 +184,20 @@ type Formatter interface {
 	GetNullString() string
 }
 
-// FormatConfig controls how Spanner values are formatted. Constructor functions
+// FormatConfig controls how Spanner values are formatted. Preset constructors
 // such as [LiteralFormatConfig] return a fresh instance with non-nil callbacks
-// for the fields they use. When a field is nil, [FormatConfig.FormatColumn]
-// falls back to built-in behavior only where documented below.
+// for the value kinds they support. [FormatConfig.FormatColumn] calls FormatArray,
+// FormatStruct, and FormatNullable directly; a nil callback panics when that
+// branch runs unless a [FormatComplexFunc] plugin handles the value first.
 //
-// Nil field defaults:
-//   - FormatArray: built-in array formatting is not used when nil; ARRAY values
-//     require a non-nil FormatArray in practice because presets always set one.
+// Nil field behavior:
+//   - FormatArray: required for ARRAY values.
 //   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
-//     for STRUCT values; presets set both.
-//   - FormatComplexPlugins: no plugins run.
-//   - FormatNullable: required for non-NULL scalar values in [FormatConfig.formatSimpleColumn].
-//     NULL scalars use [FormatConfig.GetNullString] before FormatNullable is called.
-//     A nil FormatNullable panics when formatting a non-NULL scalar; presets always set one.
+//     for STRUCT values.
+//   - FormatComplexPlugins: nil or empty means no plugins run.
+//   - FormatNullable: required for non-NULL scalars reached through
+//     [FormatConfig.FormatColumn]. NULL scalars use [FormatConfig.GetNullString]
+//     before FormatNullable is called.
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
 type FormatConfig struct {

--- a/common.go
+++ b/common.go
@@ -195,7 +195,9 @@ type Formatter interface {
 //   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
 //     for STRUCT values; presets set both.
 //   - FormatComplexPlugins: no plugins run.
-//   - FormatNullable: scalar NULL values use NullString.
+//   - FormatNullable: required for non-NULL scalar values in [FormatConfig.formatSimpleColumn].
+//     NULL scalars use [FormatConfig.GetNullString] before FormatNullable is called.
+//     A nil FormatNullable panics when formatting a non-NULL scalar; presets always set one.
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
 type FormatConfig struct {

--- a/common.go
+++ b/common.go
@@ -184,6 +184,20 @@ type Formatter interface {
 	GetNullString() string
 }
 
+// FormatConfig controls how Spanner values are formatted. Constructor functions
+// such as [LiteralFormatConfig] return a fresh instance with non-nil callbacks
+// for the fields they use. When a field is nil, [FormatConfig.FormatColumn]
+// falls back to built-in behavior only where documented below.
+//
+// Nil field defaults:
+//   - FormatArray: built-in array formatting is not used when nil; ARRAY values
+//     require a non-nil FormatArray in practice because presets always set one.
+//   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
+//     for STRUCT values; presets set both.
+//   - FormatComplexPlugins: no plugins run.
+//   - FormatNullable: scalar NULL values use NullString.
+//
+// Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
 type FormatConfig struct {
 	NullString           string
 	FormatArray          FormatArrayFunc

--- a/common.go
+++ b/common.go
@@ -191,9 +191,11 @@ type Formatter interface {
 // branch runs unless a [FormatComplexFunc] plugin handles the value first.
 //
 // Nil field behavior:
-//   - FormatArray: required for ARRAY values.
+//   - FormatArray: required for non-NULL ARRAY values. NULL ARRAY values use
+//     [FormatConfig.GetNullString] before FormatArray is called.
 //   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
-//     for STRUCT values.
+//     for non-NULL STRUCT values. NULL STRUCT values use [FormatConfig.GetNullString]
+//     before struct callbacks run.
 //   - FormatComplexPlugins: nil or empty means no plugins run.
 //   - FormatNullable: required for non-NULL scalars reached through
 //     [FormatConfig.FormatColumn]. NULL scalars use [FormatConfig.GetNullString]

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,9 @@
 // [FormatArrayFunc], [FormatStructFieldFunc], [FormatStructParenFunc], [FormatComplexFunc],
 // [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [FormatTypedStruct], and
 // [FormatJSONObjectStruct]. Copy a preset with [FormatConfig.Clone] before changing
-// callbacks; do not mutate shared instances returned by convenience formatters.
+// callbacks. Convenience formatters such as [FormatRowSpannerCLICompatible] use
+// internal singleton configs; clone a preset constructor result instead of mutating
+// package-level formatter variables.
 //
 // # Related packages
 //

--- a/doc.go
+++ b/doc.go
@@ -3,13 +3,27 @@
 // and `*spanner.Row` values for full rows ([cloud.google.com/go/spanner.Row]), into strings for SQL literals, JSON,
 // Spanner CLI–compatible text, and related styles.
 //
+// # Primary API
+//
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
 // [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig], and [JSONFormatConfig] to pick
-// a preset. [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then
-// built-in ARRAY, STRUCT, and scalar formatting. Convenience entry points include
-// [FormatRowLiteral], [FormatColumnLiteral], [FormatRowJSONObject], and
-// [FormatRowSpannerCLICompatible].
+// a preset. Customize a preset with [FormatConfig.Clone]. [FormatConfig.FormatColumn] runs
+// [FormatComplexFunc] plugins first, then built-in ARRAY, STRUCT, and scalar formatting.
+// Convenience entry points include [FormatRowLiteral], [FormatColumnLiteral],
+// [FormatRowJSONObject], and [FormatRowSpannerCLICompatible]. Identifier quoting helpers are
+// [QuoteIdentifier] and [QuoteQualifiedIdentifier].
 //
-// To build [cloud.google.com/go/spanner.GenericColumnValue] values from Go types, see the sibling package
-// [github.com/apstndb/spanvalue/gcvctor].
+// # Advanced extension API
+//
+// Lower-level callbacks and plugin types are intended for custom output formats:
+// [FormatArrayFunc], [FormatStructFieldFunc], [FormatStructParenFunc], [FormatComplexFunc],
+// [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [FormatTypedStruct], and
+// [FormatJSONObjectStruct]. Copy a preset with [FormatConfig.Clone] before changing
+// callbacks; do not mutate shared instances returned by convenience formatters.
+//
+// # Related packages
+//
+// To build [cloud.google.com/go/spanner.GenericColumnValue] values from Go types, see
+// [github.com/apstndb/spanvalue/gcvctor]. For streaming row export, see
+// [github.com/apstndb/spanvalue/writer].
 package spanvalue

--- a/example_test.go
+++ b/example_test.go
@@ -7,20 +7,29 @@ import (
 
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
-	"github.com/samber/lo"
 )
 
 func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
 	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
 	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 
-	structElem := lo.Must(gcvctor.StructValueOf(
+	structElem, err := gcvctor.StructValueOf(
 		[]string{"id", "region"},
 		[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("east")},
-	))
-	arrayOfStruct := lo.Must(gcvctor.ArrayValue(structElem))
+	)
+	if err != nil {
+		panic(err)
+	}
+	arrayOfStruct, err := gcvctor.ArrayValue(structElem)
+	if err != nil {
+		panic(err)
+	}
 
-	fmt.Println(lo.Must(fc.FormatToplevelColumn(arrayOfStruct)))
+	out, err := fc.FormatToplevelColumn(arrayOfStruct)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
 	// Output:
 	// [(1, east)]
 }

--- a/example_test.go
+++ b/example_test.go
@@ -7,20 +7,22 @@ import (
 
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/samber/lo"
 )
 
 func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
 	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
 	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 
-	value := must(gcvctor.StructValueOf(
+	structElem := lo.Must(gcvctor.StructValueOf(
 		[]string{"id", "region"},
 		[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("east")},
 	))
+	arrayOfStruct := lo.Must(gcvctor.ArrayValue(structElem))
 
-	fmt.Println(must(fc.FormatToplevelColumn(value)))
+	fmt.Println(must(fc.FormatToplevelColumn(arrayOfStruct)))
 	// Output:
-	// (1, east)
+	// [(1, east)]
 }
 
 func must[T any](v T, err error) T {

--- a/example_test.go
+++ b/example_test.go
@@ -20,14 +20,7 @@ func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
 	))
 	arrayOfStruct := lo.Must(gcvctor.ArrayValue(structElem))
 
-	fmt.Println(must(fc.FormatToplevelColumn(arrayOfStruct)))
+	fmt.Println(lo.Must(fc.FormatToplevelColumn(arrayOfStruct)))
 	// Output:
 	// [(1, east)]
-}
-
-func must[T any](v T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-	return v
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,31 @@
+package spanvalue_test
+
+import (
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+)
+
+func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
+
+	value := must(gcvctor.StructValueOf(
+		[]string{"id", "region"},
+		[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("east")},
+	))
+
+	fmt.Println(must(fc.FormatToplevelColumn(value)))
+	// Output:
+	// (1, east)
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/format_config.go
+++ b/format_config.go
@@ -11,7 +11,7 @@ func (fc *FormatConfig) Clone() *FormatConfig {
 		return nil
 	}
 	clone := *fc
-	if len(fc.FormatComplexPlugins) > 0 {
+	if fc.FormatComplexPlugins != nil {
 		clone.FormatComplexPlugins = slices.Clone(fc.FormatComplexPlugins)
 	}
 	return &clone

--- a/format_config.go
+++ b/format_config.go
@@ -1,0 +1,18 @@
+package spanvalue
+
+import "slices"
+
+// Clone returns a shallow copy of fc with a copied FormatComplexPlugins slice.
+// The returned config is independent for field assignment and plugin list
+// mutation; callback values themselves are shared with the source.
+// Clone returns nil when fc is nil.
+func (fc *FormatConfig) Clone() *FormatConfig {
+	if fc == nil {
+		return nil
+	}
+	clone := *fc
+	if len(fc.FormatComplexPlugins) > 0 {
+		clone.FormatComplexPlugins = slices.Clone(fc.FormatComplexPlugins)
+	}
+	return &clone
+}

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -32,12 +32,12 @@ func TestFormatConfigClone(t *testing.T) {
 	}
 
 	clone.NullString = "changed"
-	clone.FormatComplexPlugins = nil
+	clone.FormatComplexPlugins[0] = nil
 	if original.NullString == "changed" {
 		t.Fatal("mutating clone.NullString changed original")
 	}
-	if original.FormatComplexPlugins == nil {
-		t.Fatal("mutating clone.FormatComplexPlugins replaced original slice")
+	if original.FormatComplexPlugins[0] == nil {
+		t.Fatal("mutating clone.FormatComplexPlugins element changed original")
 	}
 
 	if got := (*FormatConfig)(nil).Clone(); got != nil {

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -1,0 +1,46 @@
+package spanvalue
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestFormatConfigClone(t *testing.T) {
+	t.Parallel()
+
+	plugin := FormatComplexFunc(func(Formatter, spanner.GenericColumnValue, bool) (string, error) {
+		return "", ErrFallthrough
+	})
+	original := &FormatConfig{
+		NullString:           "null",
+		FormatArray:          FormatCompactArray,
+		FormatStruct:         FormatTypedStruct,
+		FormatComplexPlugins: []FormatComplexFunc{plugin},
+		FormatNullable:       FormatNullableSpannerCLICompatible,
+	}
+
+	clone := original.Clone()
+	if clone == original {
+		t.Fatal("Clone() returned the same pointer")
+	}
+	if clone.NullString != original.NullString {
+		t.Fatalf("NullString = %q, want %q", clone.NullString, original.NullString)
+	}
+	if len(clone.FormatComplexPlugins) != len(original.FormatComplexPlugins) {
+		t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(clone.FormatComplexPlugins), len(original.FormatComplexPlugins))
+	}
+
+	clone.NullString = "changed"
+	clone.FormatComplexPlugins = nil
+	if original.NullString == "changed" {
+		t.Fatal("mutating clone.NullString changed original")
+	}
+	if original.FormatComplexPlugins == nil {
+		t.Fatal("mutating clone.FormatComplexPlugins replaced original slice")
+	}
+
+	if got := (*FormatConfig)(nil).Clone(); got != nil {
+		t.Fatalf("Clone(nil) = %v, want nil", got)
+	}
+}

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -31,11 +31,7 @@ func TestFormatConfigClone(t *testing.T) {
 		t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(clone.FormatComplexPlugins), len(original.FormatComplexPlugins))
 	}
 
-	clone.NullString = "changed"
 	clone.FormatComplexPlugins[0] = nil
-	if original.NullString == "changed" {
-		t.Fatal("mutating clone.NullString changed original")
-	}
 	if original.FormatComplexPlugins[0] == nil {
 		t.Fatal("mutating clone.FormatComplexPlugins element changed original")
 	}

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -44,3 +44,48 @@ func TestFormatConfigClone(t *testing.T) {
 		t.Fatalf("Clone(nil) = %v, want nil", got)
 	}
 }
+
+func TestFormatConfigClonePluginAppendIsolation(t *testing.T) {
+	t.Parallel()
+
+	plugin := FormatComplexFunc(func(Formatter, spanner.GenericColumnValue, bool) (string, error) {
+		return "", ErrFallthrough
+	})
+	other := FormatComplexFunc(func(Formatter, spanner.GenericColumnValue, bool) (string, error) {
+		return "other", nil
+	})
+
+	t.Run("non-empty plugins", func(t *testing.T) {
+		t.Parallel()
+
+		original := &FormatConfig{
+			FormatComplexPlugins: []FormatComplexFunc{plugin},
+		}
+		clone := original.Clone()
+
+		clone.FormatComplexPlugins = append(clone.FormatComplexPlugins, other)
+		if len(original.FormatComplexPlugins) != 1 {
+			t.Fatalf("append on clone changed original len: got %d want 1", len(original.FormatComplexPlugins))
+		}
+		if len(clone.FormatComplexPlugins) != 2 {
+			t.Fatalf("clone len = %d, want 2", len(clone.FormatComplexPlugins))
+		}
+	})
+
+	t.Run("empty non-nil plugins", func(t *testing.T) {
+		t.Parallel()
+
+		original := &FormatConfig{
+			FormatComplexPlugins: make([]FormatComplexFunc, 0, 2),
+		}
+		clone := original.Clone()
+
+		clone.FormatComplexPlugins = append(clone.FormatComplexPlugins, other)
+		if len(original.FormatComplexPlugins) != 0 {
+			t.Fatalf("append on clone changed original len: got %d want 0", len(original.FormatComplexPlugins))
+		}
+		if len(clone.FormatComplexPlugins) != 1 {
+			t.Fatalf("clone len = %d, want 1", len(clone.FormatComplexPlugins))
+		}
+	})
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -14,10 +14,20 @@
 // implement FlushWriter. If an adapter exposes a Close method, that Close
 // method should call Flush; Flush does not close the underlying io.Writer.
 //
-// WithOptions constructors collect setup such as FormatConfig, metadata, and
-// unnamed-field naming policy before the first write. Prepare initializes a
-// concrete writer from result-set metadata after construction. RowData and the
-// Format* helpers support one-row non-streaming paths.
+// # Primary API
+//
+// [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
+// [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
+// [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
+// [NewSQLInsertWriterWithOptions] accept explicit options such as [WithMetadata]
+// and [WithFormatter]. [Prepare] initializes schema from result-set metadata.
+// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
+//
+// # Compatibility API
+//
+// [CSVWriter] is a type alias for [DelimitedWriter]. [DelimitedWriter.Comma]
+// and a zero delimiter passed to [NewDelimitedWriter] select comma for
+// compatibility; prefer [NewCSVWriter] or [NewDelimitedWriter] with [Comma].
 package writer
 
 import (

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -20,7 +20,8 @@
 // [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
 // [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
 // [NewSQLInsertWriterWithOptions] accept explicit options such as [WithMetadata]
-// and [WithFormatter]. [Prepare] initializes schema from result-set metadata.
+// and [WithFormatter]. Each writer's Prepare method initializes schema from
+// result-set metadata (for example [DelimitedWriter.Prepare]).
 // [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
 //
 // # Compatibility API


### PR DESCRIPTION
## Summary

- Add `FormatConfig.Clone` and tests so callers can customize presets without mutating shared config instances.
- Document `FormatConfig` nil-field defaults and split package godoc into primary vs advanced extension APIs.
- Add an example for tuple-style `STRUCT` output from `SpannerCLICompatibleFormatConfig` (addresses #81).
- Document writer primary vs compatibility APIs in package godoc.

Source-compatible only; breaking writer and formatter cleanup remains for a future minor (#84, #86).

## Test plan

- [x] `make check`
- [x] Example test for tuple-style STRUCT formatting

Closes #85


Made with [Cursor](https://cursor.com)