### PR TITLE
Breaking API cleanup for v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Call `Flush` after the final row when using `writer.FlushWriter`; see the
 `Writer`, `FlushWriter`, and `Flusher` godoc for the interface lifecycle
 contract.
 
-Options-style constructors are available when setup should be explicit:
+Constructors accept options when setup should be explicit:
 
 ```go
-w := writer.NewDelimitedWriterWithOptions(
+w := writer.NewDelimitedWriter(
 	out,
 	'\t',
 	writer.WithMetadata(meta),
@@ -114,11 +114,9 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 
 TSV output uses the same CSV-style writer with a tab delimiter. `NewCSVWriter`
 is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
-`writer.Comma` when using the generic delimited constructor for CSV output. A
-zero delimiter is accepted for compatibility and selects comma, but new code
-should be explicit. Non-zero delimiters must be valid runes other than `"`,
-`\r`, `\n`, or `utf8.RuneError`. `CSVWriter` and `DelimitedWriter.Comma` remain
-as deprecated compatibility APIs.
+`writer.Comma` when using the generic delimited constructor for CSV output.
+Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
+`utf8.RuneError`.
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {

--- a/doc.go
+++ b/doc.go
@@ -17,8 +17,8 @@
 //
 // Lower-level callbacks and plugin types are intended for custom output formats:
 // [FormatArrayFunc], [FormatStructFieldFunc], [FormatStructParenFunc], [FormatComplexFunc],
-// [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [FormatTypedStruct], and
-// [FormatJSONObjectStruct]. Copy a preset with [FormatConfig.Clone] before changing
+// [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [TypedStructFormat], and
+// [JSONObjectStructFormat]. Copy a preset with [FormatConfig.Clone] before changing
 // callbacks. Convenience formatters such as [FormatRowSpannerCLICompatible] use
 // internal singleton configs; clone a preset constructor result instead of mutating
 // package-level formatter variables.

--- a/doc.go
+++ b/doc.go
@@ -20,8 +20,9 @@
 // [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [TypedStructFormat], and
 // [JSONObjectStructFormat]. Copy a preset with [FormatConfig.Clone] before changing
 // callbacks. Convenience formatters such as [FormatRowSpannerCLICompatible] use
-// internal singleton configs; clone a preset constructor result instead of mutating
-// package-level formatter variables.
+// internal singleton configs; call [FormatConfig.Clone] on a preset from
+// [LiteralFormatConfig], [SimpleFormatConfig], or the other constructors before
+// changing callbacks.
 //
 // # Related packages
 //

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -15,7 +15,7 @@ func TestFormatConfigClone(t *testing.T) {
 	original := &FormatConfig{
 		NullString:           "null",
 		FormatArray:          FormatCompactArray,
-		FormatStruct:         FormatTypedStruct,
+		FormatStruct:         TypedStructFormat(),
 		FormatComplexPlugins: []FormatComplexFunc{plugin},
 		FormatNullable:       FormatNullableSpannerCLICompatible,
 	}

--- a/format_def.go
+++ b/format_def.go
@@ -1,6 +1,10 @@
 package spanvalue
 
-var FormatTypedStruct = FormatStruct{
-	FormatStructParen: formatTypedStructParen,
-	FormatStructField: formatSimpleStructField,
+// TypedStructFormat returns a FormatStruct that formats STRUCT values with
+// typed field names in literal style.
+func TypedStructFormat() FormatStruct {
+	return FormatStruct{
+		FormatStructParen: formatTypedStructParen,
+		FormatStructField: formatSimpleStructField,
+	}
 }

--- a/json.go
+++ b/json.go
@@ -33,7 +33,7 @@ func JSONFormatConfig() *FormatConfig {
 		FormatArray: FormatCompactArray,
 		FormatStruct: FormatStruct{
 			FormatStructField: FormatSimpleStructField,
-			FormatStructParen: FormatJSONObjectStruct,
+			FormatStructParen: JSONObjectStructFormat(nil),
 		},
 		FormatComplexPlugins: []FormatComplexFunc{
 			FormatJSONSimpleValue,
@@ -95,9 +95,12 @@ func IndexedUnnamedFieldNamer(index int) string {
 	return "_" + strconv.Itoa(index)
 }
 
-// FormatJSONObjectStruct formats struct fields as a JSON object with nil namer.
-// Unnamed struct fields produce empty-string keys, matching Spanner's own representation.
-var FormatJSONObjectStruct = NewJSONObjectStructFormatter(nil)
+// JSONObjectStructFormat returns a FormatStructParenFunc that formats struct fields
+// as a JSON object. When namer is nil, unnamed struct fields produce empty-string keys,
+// matching Spanner's own representation.
+func JSONObjectStructFormat(namer UnnamedFieldNamer) FormatStructParenFunc {
+	return NewJSONObjectStructFormatter(namer)
+}
 
 // NewJSONObjectStructFormatter creates a FormatStructParenFunc that formats struct fields
 // as a JSON object with field names as keys. Unnamed fields are assigned names by the

--- a/json_test.go
+++ b/json_test.go
@@ -254,7 +254,7 @@ func TestFormatCompactArray(t *testing.T) {
 	}
 }
 
-func TestFormatJSONObjectStruct(t *testing.T) {
+func TestJSONObjectStructFormat(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -286,9 +286,9 @@ func TestFormatJSONObjectStruct(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := lo.Must(FormatJSONObjectStruct(tt.typ, false, tt.fields))
+			got := lo.Must(JSONObjectStructFormat(nil)(tt.typ, false, tt.fields))
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("FormatJSONObjectStruct mismatch (-want +got):\n%s", diff)
+				t.Errorf("JSONObjectStructFormat mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/literal.go
+++ b/literal.go
@@ -30,7 +30,7 @@ func LiteralFormatConfig() *FormatConfig {
 	return &FormatConfig{
 		NullString:     nullStringUpperCase,
 		FormatArray:    FormatOptionallyTypedArray,
-		FormatStruct:   FormatTypedStruct,
+		FormatStruct:   TypedStructFormat(),
 		FormatNullable: formatNullableValueLiteral,
 		FormatComplexPlugins: []FormatComplexFunc{
 			FormatProtoAsCast,

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -23,9 +23,10 @@
 // (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
 // [FormatJSONLRow] support one-row paths.
 //
-// Deprecated: [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
-// [NewSQLInsertWriterWithOptions] are compatibility wrappers around the primary
-// constructors.
+// # Compatibility constructors
+//
+// [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
+// [NewSQLInsertWriterWithOptions] forward to the primary constructors above.
 package writer
 
 import (
@@ -242,7 +243,9 @@ func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOptio
 	return w
 }
 
-// NewDelimitedWriterWithOptions is deprecated. Use [NewDelimitedWriter] instead.
+// NewDelimitedWriterWithOptions forwards to [NewDelimitedWriter].
+//
+// Deprecated: Use [NewDelimitedWriter] instead.
 func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	return NewDelimitedWriter(out, delimiter, options...)
 }
@@ -427,7 +430,9 @@ func NewJSONLWriter(out io.Writer, options ...JSONLOption) *JSONLWriter {
 	return w
 }
 
-// NewJSONLWriterWithOptions is deprecated. Use [NewJSONLWriter] instead.
+// NewJSONLWriterWithOptions forwards to [NewJSONLWriter].
+//
+// Deprecated: Use [NewJSONLWriter] instead.
 func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWriter {
 	return NewJSONLWriter(out, options...)
 }
@@ -573,7 +578,9 @@ func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption)
 	return w
 }
 
-// NewSQLInsertWriterWithOptions is deprecated. Use [NewSQLInsertWriter] instead.
+// NewSQLInsertWriterWithOptions forwards to [NewSQLInsertWriter].
+//
+// Deprecated: Use [NewSQLInsertWriter] instead.
 func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
 	return NewSQLInsertWriter(out, table, options...)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,17 +18,14 @@
 //
 // [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
 // [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
-// [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
-// [NewSQLInsertWriterWithOptions] accept explicit options such as [WithMetadata]
-// and [WithFormatter]. Each writer's Prepare method initializes schema from
-// result-set metadata (for example [DelimitedWriter.Prepare]).
-// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
+// Constructors accept options such as [WithMetadata] and [WithFormatter].
+// Each writer's Prepare method initializes schema from result-set metadata
+// (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
+// [FormatJSONLRow] support one-row paths.
 //
-// # Compatibility API
-//
-// [CSVWriter] is a type alias for [DelimitedWriter]. [DelimitedWriter.Comma]
-// and a zero delimiter passed to [NewDelimitedWriter] select comma for
-// compatibility; prefer [NewCSVWriter] or [NewDelimitedWriter] with [Comma].
+// Deprecated: [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
+// [NewSQLInsertWriterWithOptions] are compatibility wrappers around the primary
+// constructors.
 package writer
 
 import (
@@ -72,8 +69,6 @@ var (
 	ErrHeaderAfterData = errors.New("header after data")
 	// ErrInvalidDelimiter reports that DelimitedWriter received an invalid delimiter.
 	ErrInvalidDelimiter = errors.New("invalid delimiter")
-	// ErrDelimiterAfterWrite reports that DelimitedWriter delimiter changed after the underlying CSV writer was initialized.
-	ErrDelimiterAfterWrite = errors.New("delimiter changed after writer initialization")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -101,7 +96,7 @@ type FlushWriter interface {
 	Flusher
 }
 
-// Option configures any writer type created by a WithOptions constructor.
+// Option configures any writer type created by a writer constructor.
 type Option interface {
 	DelimitedOption
 	JSONLOption
@@ -114,17 +109,17 @@ type NameOption interface {
 	JSONLOption
 }
 
-// DelimitedOption configures a DelimitedWriter created by NewDelimitedWriterWithOptions.
+// DelimitedOption configures a DelimitedWriter created by [NewDelimitedWriter] or [NewCSVWriter].
 type DelimitedOption interface {
 	applyDelimitedOption(*DelimitedWriter)
 }
 
-// JSONLOption configures a JSONLWriter created by NewJSONLWriterWithOptions.
+// JSONLOption configures a JSONLWriter created by [NewJSONLWriter].
 type JSONLOption interface {
 	applyJSONLOption(*JSONLWriter)
 }
 
-// SQLInsertOption configures a SQLInsertWriter created by NewSQLInsertWriterWithOptions.
+// SQLInsertOption configures a SQLInsertWriter created by [NewSQLInsertWriter].
 type SQLInsertOption interface {
 	applySQLInsertOption(*SQLInsertWriter)
 }
@@ -205,14 +200,6 @@ func WithHeader(header bool) DelimitedOption {
 type DelimitedWriter struct {
 	Formatter *spanvalue.FormatConfig
 	Header    bool
-	// Comma is the field delimiter. The zero value selects Comma for
-	// compatibility. Set it before the first write; use '\t' for TSV output.
-	// Any non-zero delimiter must be a valid encoding/csv delimiter: a valid
-	// rune other than '"', '\r', '\n', or utf8.RuneError.
-	//
-	// Deprecated: prefer the delimiter argument to NewDelimitedWriter or
-	// NewDelimitedWriterWithOptions.
-	Comma rune
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached header names.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
@@ -226,15 +213,10 @@ type DelimitedWriter struct {
 	wroteData           bool
 }
 
-// CSVWriter is a compatibility alias for DelimitedWriter.
-//
-// Deprecated: use DelimitedWriter.
-type CSVWriter = DelimitedWriter
-
-// NewCSVWriter returns a CSV writer optionally initialized from result-set metadata.
-// It is a thin helper for NewDelimitedWriter(out, Comma, metadata...).
-func NewCSVWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *DelimitedWriter {
-	return NewDelimitedWriter(out, Comma, metadata...)
+// NewCSVWriter returns a comma-delimited CSV writer configured by options.
+// It is a thin helper for NewDelimitedWriter(out, Comma, opts...).
+func NewCSVWriter(out io.Writer, opts ...DelimitedOption) *DelimitedWriter {
+	return NewDelimitedWriter(out, Comma, opts...)
 }
 
 func newDelimitedWriter(out io.Writer) *DelimitedWriter {
@@ -247,28 +229,22 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 }
 
 // NewDelimitedWriter returns a CSV-style writer using delimiter as the field
-// delimiter. Pass Comma for CSV output or '\t' for TSV output. A zero delimiter
-// is accepted for compatibility and is treated as Comma.
-func NewDelimitedWriter(out io.Writer, delimiter rune, metadata ...*sppb.ResultSetMetadata) *DelimitedWriter {
+// delimiter and configured by options. Pass Comma for CSV output or '\t' for TSV
+// output. Delimiter must be non-zero and a valid encoding/csv delimiter.
+func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
-	w.Comma = delimiter
-	w.setMetadata(firstMetadata(metadata))
-	return w
-}
-
-// NewDelimitedWriterWithOptions returns a CSV-style writer using delimiter as
-// the field delimiter and configured by options. Pass Comma for CSV output or
-// '\t' for TSV output. A zero delimiter is accepted for compatibility and is
-// treated as Comma.
-func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
-	w := newDelimitedWriter(out)
-	w.Comma = delimiter
+	w.delimiter = delimiter
 	for _, opt := range options {
 		if opt != nil {
 			opt.applyDelimitedOption(w)
 		}
 	}
 	return w
+}
+
+// NewDelimitedWriterWithOptions is deprecated. Use [NewDelimitedWriter] instead.
+func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
+	return NewDelimitedWriter(out, delimiter, options...)
 }
 
 // WriteRow writes one delimited row, initializing the schema from row metadata if needed.
@@ -377,11 +353,8 @@ func (w *DelimitedWriter) formatter() *spanvalue.FormatConfig {
 }
 
 func (w *DelimitedWriter) csvWriter() (*csv.Writer, error) {
-	delimiter := w.effectiveDelimiter()
+	delimiter := w.delimiter
 	if w.writer != nil {
-		if w.delimiter != delimiter {
-			return nil, ErrDelimiterAfterWrite
-		}
 		return w.writer, nil
 	}
 	if !validDelimiter(delimiter) {
@@ -394,17 +367,6 @@ func (w *DelimitedWriter) csvWriter() (*csv.Writer, error) {
 	w.writer.Comma = delimiter
 	w.delimiter = delimiter
 	return w.writer, nil
-}
-
-func (w *DelimitedWriter) effectiveDelimiter() rune {
-	return effectiveDelimiter(w.Comma)
-}
-
-func effectiveDelimiter(delimiter rune) rune {
-	if delimiter == 0 {
-		return Comma
-	}
-	return delimiter
 }
 
 func validDelimiter(delimiter rune) bool {
@@ -454,15 +416,8 @@ type JSONLWriter struct {
 	out                 io.Writer
 }
 
-// NewJSONLWriter returns a JSONL writer optionally initialized from result-set metadata.
-func NewJSONLWriter(out io.Writer, metadata ...*sppb.ResultSetMetadata) *JSONLWriter {
-	w := newJSONLWriter(out)
-	w.setMetadata(firstMetadata(metadata))
-	return w
-}
-
-// NewJSONLWriterWithOptions returns a JSONL writer configured by options.
-func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWriter {
+// NewJSONLWriter returns a JSONL writer configured by options.
+func NewJSONLWriter(out io.Writer, options ...JSONLOption) *JSONLWriter {
 	w := newJSONLWriter(out)
 	for _, opt := range options {
 		if opt != nil {
@@ -470,6 +425,11 @@ func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWrit
 		}
 	}
 	return w
+}
+
+// NewJSONLWriterWithOptions is deprecated. Use [NewJSONLWriter] instead.
+func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWriter {
+	return NewJSONLWriter(out, options...)
 }
 
 func newJSONLWriter(out io.Writer) *JSONLWriter {
@@ -602,15 +562,8 @@ type SQLInsertWriter struct {
 	out               io.Writer
 }
 
-// NewSQLInsertWriter returns a SQL INSERT writer optionally initialized from result-set metadata.
-func NewSQLInsertWriter(out io.Writer, table string, metadata ...*sppb.ResultSetMetadata) *SQLInsertWriter {
-	w := newSQLInsertWriter(out, table)
-	w.setMetadata(firstMetadata(metadata))
-	return w
-}
-
-// NewSQLInsertWriterWithOptions returns a SQL INSERT writer configured by options.
-func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+// NewSQLInsertWriter returns a SQL INSERT writer configured by options.
+func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
 	w := newSQLInsertWriter(out, table)
 	for _, opt := range options {
 		if opt != nil {
@@ -618,6 +571,11 @@ func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLIn
 		}
 	}
 	return w
+}
+
+// NewSQLInsertWriterWithOptions is deprecated. Use [NewSQLInsertWriter] instead.
+func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+	return NewSQLInsertWriter(out, table, options...)
 }
 
 func newSQLInsertWriter(out io.Writer, table string) *SQLInsertWriter {
@@ -747,8 +705,7 @@ func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
 }
 
 // FormatDelimitedRow formats one row as a CSV-style delimited record without a
-// trailing newline. Pass Comma for CSV output. A zero delimiter is accepted for
-// compatibility and is treated as Comma.
+// trailing newline. Pass Comma for CSV output.
 func FormatDelimitedRow(fc *spanvalue.FormatConfig, row *spanner.Row, delimiter rune) (string, error) {
 	columnNames, values, err := RowData(row)
 	if err != nil {
@@ -759,8 +716,7 @@ func FormatDelimitedRow(fc *spanvalue.FormatConfig, row *spanner.Row, delimiter 
 
 // FormatDelimitedValues formats one row represented as column names plus GCV
 // values as a CSV-style delimited record without a trailing newline. Pass Comma
-// for CSV output. A zero delimiter is accepted for compatibility and is treated
-// as Comma.
+// for CSV output.
 func FormatDelimitedValues(fc *spanvalue.FormatConfig, columnNames []string, values []spanner.GenericColumnValue, delimiter rune) (string, error) {
 	formattedValues, err := spanvalue.FormatRowColumns(simpleFormatter(fc), columnNames, values)
 	if err != nil {
@@ -806,7 +762,6 @@ func rowData(row *spanner.Row) ([]string, []spanner.GenericColumnValue, error) {
 }
 
 func formatDelimitedRecord(values []string, delimiter rune) (string, error) {
-	delimiter = effectiveDelimiter(delimiter)
 	if !validDelimiter(delimiter) {
 		return "", fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
 	}
@@ -835,15 +790,6 @@ func jsonFormatter(fc *spanvalue.FormatConfig) *spanvalue.FormatConfig {
 		return fc
 	}
 	return spanvalue.JSONFormatConfig()
-}
-
-// firstMetadata keeps the constructors backward-compatible while allowing an
-// optional single metadata argument for eager schema initialization.
-func firstMetadata(metadata []*sppb.ResultSetMetadata) *sppb.ResultSetMetadata {
-	if len(metadata) == 0 {
-		return nil
-	}
-	return metadata[0]
 }
 
 func prepareColumnNames(metadata *sppb.ResultSetMetadata) ([]string, error) {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -127,7 +127,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(
+	w := NewDelimitedWriterWithOptions(
 		&out,
 		'\t',
 		WithMetadata(metadataWithColumnNames("name", "age")),

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -50,7 +50,7 @@ func TestNewCSVWriterHelper(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, metadataWithColumnNames("name"))
+	w := NewCSVWriter(&out, WithMetadata(metadataWithColumnNames("name")))
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
@@ -101,51 +101,25 @@ func TestDelimitedWriterWriteValues(t *testing.T) {
 func TestDelimitedWriterWriteValuesWithCustomDelimiter(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		new  func(out *bytes.Buffer) *DelimitedWriter
-	}{
-		{
-			name: "constructor",
-			new: func(out *bytes.Buffer) *DelimitedWriter {
-				return NewDelimitedWriter(out, '\t')
-			},
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, '\t')
+
+	err := w.WriteValues(
+		[]string{"name", "note", "with_tab"},
+		[]spanner.GenericColumnValue{
+			gcvctor.StringValue("Alice"),
+			gcvctor.StringValue("comma, ok"),
+			gcvctor.StringValue("tab\tok"),
 		},
-		{
-			name: "deprecated comma field",
-			new: func(out *bytes.Buffer) *DelimitedWriter {
-				w := NewDelimitedWriter(out, Comma)
-				w.Comma = '\t'
-				return w
-			},
-		},
+	)
+	if err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
 	}
+	flushDelimitedWriter(t, w)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var out bytes.Buffer
-			w := tt.new(&out)
-
-			err := w.WriteValues(
-				[]string{"name", "note", "with_tab"},
-				[]spanner.GenericColumnValue{
-					gcvctor.StringValue("Alice"),
-					gcvctor.StringValue("comma, ok"),
-					gcvctor.StringValue("tab\tok"),
-				},
-			)
-			if err != nil {
-				t.Fatalf("WriteValues() error = %v", err)
-			}
-			flushDelimitedWriter(t, w)
-
-			want := "name\tnote\twith_tab\nAlice\tcomma, ok\t\"tab\tok\"\n"
-			if diff := cmp.Diff(want, out.String()); diff != "" {
-				t.Fatalf("delimited output mismatch (-want +got):\n%s", diff)
-			}
-		})
+	want := "name\tnote\twith_tab\nAlice\tcomma, ok\t\"tab\tok\"\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("delimited output mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -153,7 +127,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriterWithOptions(
+	w := NewDelimitedWriter(
 		&out,
 		'\t',
 		WithMetadata(metadataWithColumnNames("name", "age")),
@@ -177,7 +151,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	}
 }
 
-func TestDelimitedWriterWriteValuesZeroDelimiterUsesCommaForCompatibility(t *testing.T) {
+func TestDelimitedWriterWriteValuesZeroDelimiterInvalid(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
@@ -190,14 +164,8 @@ func TestDelimitedWriterWriteValuesZeroDelimiterUsesCommaForCompatibility(t *tes
 			gcvctor.StringValue("comma, ok"),
 		},
 	)
-	if err != nil {
-		t.Fatalf("WriteValues() error = %v", err)
-	}
-	flushDelimitedWriter(t, w)
-
-	want := "name,note\nAlice,\"comma, ok\"\n"
-	if diff := cmp.Diff(want, out.String()); diff != "" {
-		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	if !errors.Is(err, ErrInvalidDelimiter) {
+		t.Fatalf("WriteValues() error = %v, want ErrInvalidDelimiter", err)
 	}
 }
 
@@ -213,30 +181,6 @@ func TestDelimitedWriterWriteValuesInvalidDelimiter(t *testing.T) {
 	)
 	if !errors.Is(err, ErrInvalidDelimiter) {
 		t.Fatalf("WriteValues() error = %v, want ErrInvalidDelimiter", err)
-	}
-}
-
-func TestDelimitedWriterWriteValuesDelimiterChangeAfterWrite(t *testing.T) {
-	t.Parallel()
-
-	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, '\t')
-
-	err := w.WriteValues(
-		[]string{"name"},
-		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
-	)
-	if err != nil {
-		t.Fatalf("WriteValues() error = %v", err)
-	}
-
-	w.Comma = Comma
-	err = w.WriteValues(
-		[]string{"name"},
-		[]spanner.GenericColumnValue{gcvctor.StringValue("Bob")},
-	)
-	if !errors.Is(err, ErrDelimiterAfterWrite) {
-		t.Fatalf("WriteValues() after delimiter change error = %v, want ErrDelimiterAfterWrite", err)
 	}
 }
 
@@ -359,7 +303,7 @@ func TestDelimitedWriterWriteGCVsWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.StringValue("Alice"),
@@ -402,7 +346,7 @@ func TestDelimitedWriterWriteHeaderWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -447,7 +391,7 @@ func TestDelimitedWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -483,7 +427,7 @@ func TestDelimitedWriterWriteHeaderAfterData(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, metadataWithColumnNames("name", "age"))
+	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 	w.Header = false
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -539,21 +483,21 @@ func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := NewDelimitedWriter(nil, Comma, metadataWithColumnNames("name"))
+				w := NewDelimitedWriter(nil, Comma, WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
 		{
 			name: "jsonl",
 			run: func() error {
-				w := NewJSONLWriter(nil, metadataWithColumnNames("name"))
+				w := NewJSONLWriter(nil, WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
 		{
 			name: "sql",
 			run: func() error {
-				w := NewSQLInsertWriter(nil, "users", metadataWithColumnNames("name"))
+				w := NewSQLInsertWriter(nil, "users", WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
@@ -739,7 +683,7 @@ func TestJSONLWriterWriteGCVs_MismatchedCachedKeys(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out, metadataWithColumnNames("name", "age"))
+	w := NewJSONLWriter(&out, WithMetadata(metadataWithColumnNames("name", "age")))
 	w.marshaledKeys = [][]byte{[]byte(`"name"`)}
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -972,7 +916,7 @@ func TestSQLInsertWriterWriteGCVsEmptyTableName(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "", metadataWithColumnNames("id"))
+	w := NewSQLInsertWriter(&out, "", WithMetadata(metadataWithColumnNames("id")))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
 	if !errors.Is(err, ErrEmptyTableName) {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -968,13 +968,49 @@ func TestRowDataAndOneRowFormatHelpers(t *testing.T) {
 func TestFormatDelimitedValuesInvalidDelimiter(t *testing.T) {
 	t.Parallel()
 
-	_, err := FormatDelimitedValues(
-		nil,
-		[]string{"name"},
-		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
-		'\n',
-	)
-	if !errors.Is(err, ErrInvalidDelimiter) {
-		t.Fatalf("FormatDelimitedValues() error = %v, want ErrInvalidDelimiter", err)
+	values := []spanner.GenericColumnValue{gcvctor.StringValue("Alice")}
+	columnNames := []string{"name"}
+
+	tests := []struct {
+		name      string
+		delimiter rune
+		format    func(rune) error
+	}{
+		{
+			name:      "newline in FormatDelimitedValues",
+			delimiter: '\n',
+			format: func(delim rune) error {
+				_, err := FormatDelimitedValues(nil, columnNames, values, delim)
+				return err
+			},
+		},
+		{
+			name:      "zero in FormatDelimitedValues",
+			delimiter: 0,
+			format: func(delim rune) error {
+				_, err := FormatDelimitedValues(nil, columnNames, values, delim)
+				return err
+			},
+		},
+		{
+			name:      "zero in FormatDelimitedRow",
+			delimiter: 0,
+			format: func(delim rune) error {
+				row, err := spanner.NewRow(columnNames, []interface{}{"Alice"})
+				if err != nil {
+					return err
+				}
+				_, err = FormatDelimitedRow(nil, row, delim)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.format(tt.delimiter); !errors.Is(err, ErrInvalidDelimiter) {
+				t.Fatalf("format error = %v, want ErrInvalidDelimiter", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Collapse writer options into primary constructors (`NewDelimitedWriter`, `NewCSVWriter`, `NewJSONLWriter`, `NewSQLInsertWriter`) and keep `*WithOptions` as deprecated forwarding wrappers.
- Remove `CSVWriter`, `DelimitedWriter.Comma`, and zero-delimiter compatibility; delimiter `0` returns `ErrInvalidDelimiter`.
- Replace mutable `FormatTypedStruct` and `FormatJSONObjectStruct` package variables with `TypedStructFormat()` and `JSONObjectStructFormat`.

## Migration (v0.4.0)

### `spanvalue` formatters

| Before | After |
|--------|-------|
| `spanvalue.FormatTypedStruct` | `spanvalue.TypedStructFormat()` |
| `spanvalue.FormatJSONObjectStruct` | `spanvalue.JSONObjectStructFormat(nil)` |

### `writer` constructors

```go
// Before
w := writer.NewDelimitedWriter(out, writer.Comma, metadata)
w := writer.NewJSONLWriter(out, metadata)
w := writer.NewSQLInsertWriter(out, table, metadata)

// After
w := writer.NewDelimitedWriter(out, writer.Comma, writer.WithMetadata(metadata))
w := writer.NewJSONLWriter(out, writer.WithMetadata(metadata))
w := writer.NewSQLInsertWriter(out, table, writer.WithMetadata(metadata))
```

`NewDelimitedWriterWithOptions`, `NewJSONLWriterWithOptions`, and `NewSQLInsertWriterWithOptions` remain as deprecated wrappers forwarding to the primary constructors.

### Removed

- `type CSVWriter` — use `*writer.DelimitedWriter` or `writer.NewCSVWriter`
- `DelimitedWriter.Comma` — set delimiter at construction time
- Delimiter `0` — use `NewCSVWriter(out)` or `NewDelimitedWriter(out, writer.Comma)` (`ErrInvalidDelimiter` otherwise)

## Test plan

- [x] `make check`

Closes #84
Closes #86


Made with [Cursor](https://cursor.com)