### PR TITLE
SQL insert kinds and gcvctor nullable input helpers (#79, #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ func writeJSONL(out io.Writer, rows []*spanner.Row) error {
 }
 ```
 
-SQL INSERT output:
+SQL INSERT output uses Spanner GoogleSQL quoting. Use
+`writer.WithSQLInsertKind` for `INSERT OR IGNORE` or `INSERT OR UPDATE`; see
+[INSERT DML syntax](https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax).
 
 ```go
 func writeInserts(out io.Writer, table string, rows []*spanner.Row) error {

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -30,6 +30,7 @@
 // Nullable Go inputs are split by shape in the function name:
 //
 //   - [BoolFromPtr], [Int64FromPtr], and related *FromPtr helpers take *T; nil means SQL NULL.
+//   - [BytesFromSlice] takes []byte; nil means SQL NULL (slices are already reference types).
 //   - [BoolFromNullable], [Int64FromNullable], and related *FromNullable helpers take
 //     [cloud.google.com/go/spanner.NullBool], [cloud.google.com/go/spanner.NullInt64], and
 //     other client null wrappers; Valid == false means SQL NULL.

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -27,6 +27,17 @@
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //
+// Nullable Go inputs are split by shape in the function name:
+//
+//   - [BoolFromPtr], [Int64FromPtr], and related *FromPtr helpers take *T; nil means SQL NULL.
+//   - [BoolFromNullable], [Int64FromNullable], and related *FromNullable helpers take
+//     [cloud.google.com/go/spanner.NullBool], [cloud.google.com/go/spanner.NullInt64], and
+//     other client null wrappers; Valid == false means SQL NULL.
+//
+// Use *FromPtr for optional fields modeled as Go pointers. Use *FromNullable when the value
+// already comes from the Spanner client library. For explicit typed NULL without an input
+// value, keep using [NullOf] or [NullFromCode].
+//
 // [NumericValueChecked] and [PGNumericValueChecked] return errors on nil [*big.Rat] input
 // instead of panicking. The legacy [NumericValue] and [PGNumericValue] helpers keep their
 // original signatures and return typed SQL NULL values on nil input.

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -1,0 +1,146 @@
+package gcvctor
+
+import (
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/google/uuid"
+)
+
+// BoolFromPtr returns a BOOL GenericColumnValue. A nil pointer yields typed SQL NULL.
+func BoolFromPtr(p *bool) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_BOOL)
+	}
+	return BoolValue(*p)
+}
+
+// Int64FromPtr returns an INT64 GenericColumnValue. A nil pointer yields typed SQL NULL.
+func Int64FromPtr(p *int64) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_INT64)
+	}
+	return Int64Value(*p)
+}
+
+// Float64FromPtr returns a FLOAT64 GenericColumnValue. A nil pointer yields typed SQL NULL.
+func Float64FromPtr(p *float64) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_FLOAT64)
+	}
+	return Float64Value(*p)
+}
+
+// Float32FromPtr returns a FLOAT32 GenericColumnValue. A nil pointer yields typed SQL NULL.
+func Float32FromPtr(p *float32) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_FLOAT32)
+	}
+	return Float32Value(*p)
+}
+
+// StringFromPtr returns a STRING GenericColumnValue. A nil pointer yields typed SQL NULL.
+func StringFromPtr(p *string) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_STRING)
+	}
+	return StringValue(*p)
+}
+
+// BytesFromPtr returns a BYTES GenericColumnValue. A nil pointer yields typed SQL NULL.
+func BytesFromPtr(p *[]byte) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_BYTES)
+	}
+	return BytesValue(*p)
+}
+
+// DateFromPtr returns a DATE GenericColumnValue. A nil pointer yields typed SQL NULL.
+func DateFromPtr(p *civil.Date) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_DATE)
+	}
+	return DateValue(*p)
+}
+
+// TimestampFromPtr returns a TIMESTAMP GenericColumnValue. A nil pointer yields typed SQL NULL.
+func TimestampFromPtr(p *time.Time) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_TIMESTAMP)
+	}
+	return TimestampValue(*p)
+}
+
+// UUIDFromPtr returns a UUID GenericColumnValue. A nil pointer yields typed SQL NULL.
+func UUIDFromPtr(p *uuid.UUID) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_UUID)
+	}
+	return UUIDValue(*p)
+}
+
+// BoolFromNullable returns a BOOL GenericColumnValue from a Spanner null wrapper.
+func BoolFromNullable(n spanner.NullBool) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_BOOL)
+	}
+	return BoolValue(n.Bool)
+}
+
+// Int64FromNullable returns an INT64 GenericColumnValue from a Spanner null wrapper.
+func Int64FromNullable(n spanner.NullInt64) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_INT64)
+	}
+	return Int64Value(n.Int64)
+}
+
+// Float64FromNullable returns a FLOAT64 GenericColumnValue from a Spanner null wrapper.
+func Float64FromNullable(n spanner.NullFloat64) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_FLOAT64)
+	}
+	return Float64Value(n.Float64)
+}
+
+// Float32FromNullable returns a FLOAT32 GenericColumnValue from a Spanner null wrapper.
+func Float32FromNullable(n spanner.NullFloat32) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_FLOAT32)
+	}
+	return Float32Value(n.Float32)
+}
+
+// StringFromNullable returns a STRING GenericColumnValue from a Spanner null wrapper.
+func StringFromNullable(n spanner.NullString) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_STRING)
+	}
+	return StringValue(n.StringVal)
+}
+
+// DateFromNullable returns a DATE GenericColumnValue from a Spanner null wrapper.
+func DateFromNullable(n spanner.NullDate) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_DATE)
+	}
+	return DateValue(n.Date)
+}
+
+// TimestampFromNullable returns a TIMESTAMP GenericColumnValue from a Spanner null wrapper.
+func TimestampFromNullable(n spanner.NullTime) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_TIMESTAMP)
+	}
+	return TimestampValue(n.Time)
+}
+
+// UUIDFromNullable returns a UUID GenericColumnValue from a Spanner null wrapper.
+func UUIDFromNullable(n spanner.NullUUID) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_UUID)
+	}
+	return UUIDValue(n.UUID)
+}

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -49,12 +49,12 @@ func StringFromPtr(p *string) spanner.GenericColumnValue {
 	return StringValue(*p)
 }
 
-// BytesFromPtr returns a BYTES GenericColumnValue. A nil pointer yields typed SQL NULL.
-func BytesFromPtr(p *[]byte) spanner.GenericColumnValue {
-	if p == nil {
+// BytesFromSlice returns a BYTES GenericColumnValue. A nil slice yields typed SQL NULL.
+func BytesFromSlice(v []byte) spanner.GenericColumnValue {
+	if v == nil {
 		return NullFromCode(sppb.TypeCode_BYTES)
 	}
-	return BytesValue(*p)
+	return BytesValue(v)
 }
 
 // DateFromPtr returns a DATE GenericColumnValue. A nil pointer yields typed SQL NULL.

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -76,7 +76,7 @@ func wantDate(d civil.Date) spanner.GenericColumnValue {
 func wantTimestamp(ts time.Time) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(sppb.TypeCode_TIMESTAMP),
-		Value: structpb.NewStringValue(ts.Format(time.RFC3339Nano)),
+		Value: structpb.NewStringValue(ts.UTC().Format(time.RFC3339Nano)),
 	}
 }
 

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -1,0 +1,95 @@
+package gcvctor_test
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestFromPtrNullableScalars(t *testing.T) {
+	t.Parallel()
+
+	i := int64(42)
+	s := "hello"
+	f := 1.5
+	b := true
+	d := civil.Date{Year: 2026, Month: 5, Day: 28}
+	ts := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	u := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	raw := []byte{1, 2}
+
+	tests := []struct {
+		name string
+		got  spanner.GenericColumnValue
+		want spanner.GenericColumnValue
+	}{
+		{"Int64FromPtr value", gcvctor.Int64FromPtr(&i), gcvctor.Int64Value(42)},
+		{"Int64FromPtr null", gcvctor.Int64FromPtr(nil), nullFromCode(sppb.TypeCode_INT64)},
+		{"StringFromPtr value", gcvctor.StringFromPtr(&s), gcvctor.StringValue("hello")},
+		{"StringFromPtr null", gcvctor.StringFromPtr(nil), nullFromCode(sppb.TypeCode_STRING)},
+		{"Float64FromPtr value", gcvctor.Float64FromPtr(&f), gcvctor.Float64Value(1.5)},
+		{"BoolFromPtr value", gcvctor.BoolFromPtr(&b), gcvctor.BoolValue(true)},
+		{"DateFromPtr value", gcvctor.DateFromPtr(&d), gcvctor.DateValue(d)},
+		{"TimestampFromPtr value", gcvctor.TimestampFromPtr(&ts), gcvctor.TimestampValue(ts)},
+		{"UUIDFromPtr value", gcvctor.UUIDFromPtr(&u), gcvctor.UUIDValue(u)},
+		{"BytesFromPtr value", gcvctor.BytesFromPtr(&raw), gcvctor.BytesValue(raw)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.got, protocmp.Transform()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFromNullableScalars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  spanner.GenericColumnValue
+		want spanner.GenericColumnValue
+	}{
+		{
+			name: "Int64FromNullable value",
+			got:  gcvctor.Int64FromNullable(spanner.NullInt64{Int64: 7, Valid: true}),
+			want: gcvctor.Int64Value(7),
+		},
+		{
+			name: "Int64FromNullable null",
+			got:  gcvctor.Int64FromNullable(spanner.NullInt64{}),
+			want: nullFromCode(sppb.TypeCode_INT64),
+		},
+		{
+			name: "StringFromNullable value",
+			got:  gcvctor.StringFromNullable(spanner.NullString{StringVal: "x", Valid: true}),
+			want: gcvctor.StringValue("x"),
+		},
+		{
+			name: "StringFromNullable null",
+			got:  gcvctor.StringFromNullable(spanner.NullString{}),
+			want: nullFromCode(sppb.TypeCode_STRING),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.got, protocmp.Transform()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func nullFromCode(code sppb.TypeCode) spanner.GenericColumnValue {
+	return gcvctor.NullFromCode(code)
+}

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -1,45 +1,128 @@
 package gcvctor_test
 
 import (
+	"encoding/base64"
+	"strconv"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestFromPtrNullableScalars(t *testing.T) {
+func wantNull(code sppb.TypeCode) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(code),
+		Value: structpb.NewNullValue(),
+	}
+}
+
+func wantBool(v bool) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_BOOL),
+		Value: structpb.NewBoolValue(v),
+	}
+}
+
+func wantInt64(v int64) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_INT64),
+		Value: structpb.NewStringValue(strconv.FormatInt(v, 10)),
+	}
+}
+
+func wantFloat64(v float64) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_FLOAT64),
+		Value: structpb.NewNumberValue(v),
+	}
+}
+
+func wantFloat32(v float32) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_FLOAT32),
+		Value: structpb.NewNumberValue(float64(v)),
+	}
+}
+
+func wantString(v string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_STRING),
+		Value: structpb.NewStringValue(v),
+	}
+}
+
+func wantBytes(v []byte) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_BYTES),
+		Value: structpb.NewStringValue(base64.StdEncoding.EncodeToString(v)),
+	}
+}
+
+func wantDate(d civil.Date) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_DATE),
+		Value: structpb.NewStringValue(d.String()),
+	}
+}
+
+func wantTimestamp(ts time.Time) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_TIMESTAMP),
+		Value: structpb.NewStringValue(ts.Format(time.RFC3339Nano)),
+	}
+}
+
+func wantUUID(id uuid.UUID) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_UUID),
+		Value: structpb.NewStringValue(id.String()),
+	}
+}
+
+func TestFromPtrScalars(t *testing.T) {
 	t.Parallel()
 
-	i := int64(42)
-	s := "hello"
-	f := 1.5
 	b := true
+	i := int64(42)
+	f64 := 1.5
+	f32 := float32(2.5)
+	s := "hello"
+	raw := []byte{1, 2}
 	d := civil.Date{Year: 2026, Month: 5, Day: 28}
 	ts := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
 	u := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	raw := []byte{1, 2}
 
 	tests := []struct {
 		name string
 		got  spanner.GenericColumnValue
 		want spanner.GenericColumnValue
 	}{
-		{"Int64FromPtr value", gcvctor.Int64FromPtr(&i), gcvctor.Int64Value(42)},
-		{"Int64FromPtr null", gcvctor.Int64FromPtr(nil), nullFromCode(sppb.TypeCode_INT64)},
-		{"StringFromPtr value", gcvctor.StringFromPtr(&s), gcvctor.StringValue("hello")},
-		{"StringFromPtr null", gcvctor.StringFromPtr(nil), nullFromCode(sppb.TypeCode_STRING)},
-		{"Float64FromPtr value", gcvctor.Float64FromPtr(&f), gcvctor.Float64Value(1.5)},
-		{"BoolFromPtr value", gcvctor.BoolFromPtr(&b), gcvctor.BoolValue(true)},
-		{"DateFromPtr value", gcvctor.DateFromPtr(&d), gcvctor.DateValue(d)},
-		{"TimestampFromPtr value", gcvctor.TimestampFromPtr(&ts), gcvctor.TimestampValue(ts)},
-		{"UUIDFromPtr value", gcvctor.UUIDFromPtr(&u), gcvctor.UUIDValue(u)},
-		{"BytesFromPtr value", gcvctor.BytesFromPtr(&raw), gcvctor.BytesValue(raw)},
+		{"BoolFromPtr value", gcvctor.BoolFromPtr(&b), wantBool(true)},
+		{"BoolFromPtr null", gcvctor.BoolFromPtr(nil), wantNull(sppb.TypeCode_BOOL)},
+		{"Int64FromPtr value", gcvctor.Int64FromPtr(&i), wantInt64(42)},
+		{"Int64FromPtr null", gcvctor.Int64FromPtr(nil), wantNull(sppb.TypeCode_INT64)},
+		{"Float64FromPtr value", gcvctor.Float64FromPtr(&f64), wantFloat64(1.5)},
+		{"Float64FromPtr null", gcvctor.Float64FromPtr(nil), wantNull(sppb.TypeCode_FLOAT64)},
+		{"Float32FromPtr value", gcvctor.Float32FromPtr(&f32), wantFloat32(2.5)},
+		{"Float32FromPtr null", gcvctor.Float32FromPtr(nil), wantNull(sppb.TypeCode_FLOAT32)},
+		{"StringFromPtr value", gcvctor.StringFromPtr(&s), wantString("hello")},
+		{"StringFromPtr null", gcvctor.StringFromPtr(nil), wantNull(sppb.TypeCode_STRING)},
+		{"BytesFromSlice value", gcvctor.BytesFromSlice(raw), wantBytes(raw)},
+		{"BytesFromSlice null", gcvctor.BytesFromSlice(nil), wantNull(sppb.TypeCode_BYTES)},
+		{"DateFromPtr value", gcvctor.DateFromPtr(&d), wantDate(d)},
+		{"DateFromPtr null", gcvctor.DateFromPtr(nil), wantNull(sppb.TypeCode_DATE)},
+		{"TimestampFromPtr value", gcvctor.TimestampFromPtr(&ts), wantTimestamp(ts)},
+		{"TimestampFromPtr null", gcvctor.TimestampFromPtr(nil), wantNull(sppb.TypeCode_TIMESTAMP)},
+		{"UUIDFromPtr value", gcvctor.UUIDFromPtr(&u), wantUUID(u)},
+		{"UUIDFromPtr null", gcvctor.UUIDFromPtr(nil), wantNull(sppb.TypeCode_UUID)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -54,31 +137,31 @@ func TestFromPtrNullableScalars(t *testing.T) {
 func TestFromNullableScalars(t *testing.T) {
 	t.Parallel()
 
+	d := civil.Date{Year: 2026, Month: 5, Day: 28}
+	ts := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	u := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+
 	tests := []struct {
 		name string
 		got  spanner.GenericColumnValue
 		want spanner.GenericColumnValue
 	}{
-		{
-			name: "Int64FromNullable value",
-			got:  gcvctor.Int64FromNullable(spanner.NullInt64{Int64: 7, Valid: true}),
-			want: gcvctor.Int64Value(7),
-		},
-		{
-			name: "Int64FromNullable null",
-			got:  gcvctor.Int64FromNullable(spanner.NullInt64{}),
-			want: nullFromCode(sppb.TypeCode_INT64),
-		},
-		{
-			name: "StringFromNullable value",
-			got:  gcvctor.StringFromNullable(spanner.NullString{StringVal: "x", Valid: true}),
-			want: gcvctor.StringValue("x"),
-		},
-		{
-			name: "StringFromNullable null",
-			got:  gcvctor.StringFromNullable(spanner.NullString{}),
-			want: nullFromCode(sppb.TypeCode_STRING),
-		},
+		{"BoolFromNullable value", gcvctor.BoolFromNullable(spanner.NullBool{Bool: true, Valid: true}), wantBool(true)},
+		{"BoolFromNullable null", gcvctor.BoolFromNullable(spanner.NullBool{}), wantNull(sppb.TypeCode_BOOL)},
+		{"Int64FromNullable value", gcvctor.Int64FromNullable(spanner.NullInt64{Int64: 7, Valid: true}), wantInt64(7)},
+		{"Int64FromNullable null", gcvctor.Int64FromNullable(spanner.NullInt64{}), wantNull(sppb.TypeCode_INT64)},
+		{"Float64FromNullable value", gcvctor.Float64FromNullable(spanner.NullFloat64{Float64: 1.5, Valid: true}), wantFloat64(1.5)},
+		{"Float64FromNullable null", gcvctor.Float64FromNullable(spanner.NullFloat64{}), wantNull(sppb.TypeCode_FLOAT64)},
+		{"Float32FromNullable value", gcvctor.Float32FromNullable(spanner.NullFloat32{Float32: 2.5, Valid: true}), wantFloat32(2.5)},
+		{"Float32FromNullable null", gcvctor.Float32FromNullable(spanner.NullFloat32{}), wantNull(sppb.TypeCode_FLOAT32)},
+		{"StringFromNullable value", gcvctor.StringFromNullable(spanner.NullString{StringVal: "x", Valid: true}), wantString("x")},
+		{"StringFromNullable null", gcvctor.StringFromNullable(spanner.NullString{}), wantNull(sppb.TypeCode_STRING)},
+		{"DateFromNullable value", gcvctor.DateFromNullable(spanner.NullDate{Date: d, Valid: true}), wantDate(d)},
+		{"DateFromNullable null", gcvctor.DateFromNullable(spanner.NullDate{}), wantNull(sppb.TypeCode_DATE)},
+		{"TimestampFromNullable value", gcvctor.TimestampFromNullable(spanner.NullTime{Time: ts, Valid: true}), wantTimestamp(ts)},
+		{"TimestampFromNullable null", gcvctor.TimestampFromNullable(spanner.NullTime{}), wantNull(sppb.TypeCode_TIMESTAMP)},
+		{"UUIDFromNullable value", gcvctor.UUIDFromNullable(spanner.NullUUID{UUID: u, Valid: true}), wantUUID(u)},
+		{"UUIDFromNullable null", gcvctor.UUIDFromNullable(spanner.NullUUID{}), wantNull(sppb.TypeCode_UUID)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -88,8 +171,4 @@ func TestFromNullableScalars(t *testing.T) {
 			}
 		})
 	}
-}
-
-func nullFromCode(code sppb.TypeCode) spanner.GenericColumnValue {
-	return gcvctor.NullFromCode(code)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,9 +18,9 @@
 //
 // [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
 // [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
-// [WithSQLInsertKind] selects the INSERT statement prefix. Variants such as
-// INSERT OR IGNORE and INSERT OR UPDATE use SQLite-style syntax for export tools;
-// they are not valid Spanner GoogleSQL DML (use MERGE for upserts on Spanner).
+// [WithSQLInsertKind] selects the INSERT statement prefix. INSERT OR IGNORE and
+// INSERT OR UPDATE are valid Spanner GoogleSQL DML forms; see the INSERT section
+// in https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
 // Constructors accept options such as [WithMetadata] and [WithFormatter].
 // Each writer's Prepare method initializes schema from result-set metadata
 // (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
@@ -125,17 +125,18 @@ type JSONLOption interface {
 
 // SQLInsertKind selects the INSERT statement prefix written by [SQLInsertWriter].
 //
-// SQLInsertOrIgnore and SQLInsertOrUpdate emit SQLite-style prefixes requested by
-// downstream export tools (issue #79). They are not valid Spanner GoogleSQL DML;
-// do not execute them directly against a Spanner database.
+// Variants follow Spanner GoogleSQL DML: INSERT OR IGNORE skips rows whose primary
+// key already exists; INSERT OR UPDATE inserts or updates by primary key. They
+// cannot be combined with ON CONFLICT in the same statement, and INSERT is not
+// supported in Partitioned DML. See https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
 type SQLInsertKind int
 
 const (
 	// SQLInsert writes plain INSERT INTO statements.
 	SQLInsert SQLInsertKind = iota
-	// SQLInsertOrIgnore writes INSERT OR IGNORE INTO statements (export dialects only).
+	// SQLInsertOrIgnore writes INSERT OR IGNORE INTO statements.
 	SQLInsertOrIgnore
-	// SQLInsertOrUpdate writes INSERT OR UPDATE INTO statements (export dialects only).
+	// SQLInsertOrUpdate writes INSERT OR UPDATE INTO statements.
 	SQLInsertOrUpdate
 )
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,7 +18,9 @@
 //
 // [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
 // [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
-// [WithSQLInsertKind] selects INSERT, INSERT OR IGNORE, or INSERT OR UPDATE prefixes.
+// [WithSQLInsertKind] selects the INSERT statement prefix. Variants such as
+// INSERT OR IGNORE and INSERT OR UPDATE use SQLite-style syntax for export tools;
+// they are not valid Spanner GoogleSQL DML (use MERGE for upserts on Spanner).
 // Constructors accept options such as [WithMetadata] and [WithFormatter].
 // Each writer's Prepare method initializes schema from result-set metadata
 // (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
@@ -122,14 +124,18 @@ type JSONLOption interface {
 }
 
 // SQLInsertKind selects the INSERT statement prefix written by [SQLInsertWriter].
+//
+// SQLInsertOrIgnore and SQLInsertOrUpdate emit SQLite-style prefixes requested by
+// downstream export tools (issue #79). They are not valid Spanner GoogleSQL DML;
+// do not execute them directly against a Spanner database.
 type SQLInsertKind int
 
 const (
 	// SQLInsert writes plain INSERT INTO statements.
 	SQLInsert SQLInsertKind = iota
-	// SQLInsertOrIgnore writes INSERT OR IGNORE INTO statements.
+	// SQLInsertOrIgnore writes INSERT OR IGNORE INTO statements (export dialects only).
 	SQLInsertOrIgnore
-	// SQLInsertOrUpdate writes INSERT OR UPDATE INTO statements.
+	// SQLInsertOrUpdate writes INSERT OR UPDATE INTO statements (export dialects only).
 	SQLInsertOrUpdate
 )
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,6 +18,7 @@
 //
 // [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
 // [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
+// [WithSQLInsertKind] selects INSERT, INSERT OR IGNORE, or INSERT OR UPDATE prefixes.
 // Constructors accept options such as [WithMetadata] and [WithFormatter].
 // Each writer's Prepare method initializes schema from result-set metadata
 // (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
@@ -118,6 +119,42 @@ type DelimitedOption interface {
 // JSONLOption configures a JSONLWriter created by [NewJSONLWriter].
 type JSONLOption interface {
 	applyJSONLOption(*JSONLWriter)
+}
+
+// SQLInsertKind selects the INSERT statement prefix written by [SQLInsertWriter].
+type SQLInsertKind int
+
+const (
+	// SQLInsert writes plain INSERT INTO statements.
+	SQLInsert SQLInsertKind = iota
+	// SQLInsertOrIgnore writes INSERT OR IGNORE INTO statements.
+	SQLInsertOrIgnore
+	// SQLInsertOrUpdate writes INSERT OR UPDATE INTO statements.
+	SQLInsertOrUpdate
+)
+
+func (k SQLInsertKind) insertPrefix() string {
+	switch k {
+	case SQLInsertOrIgnore:
+		return "INSERT OR IGNORE"
+	case SQLInsertOrUpdate:
+		return "INSERT OR UPDATE"
+	default:
+		return "INSERT"
+	}
+}
+
+// WithSQLInsertKind sets the INSERT statement variant for a [SQLInsertWriter].
+func WithSQLInsertKind(kind SQLInsertKind) SQLInsertOption {
+	return sqlInsertKindOption{kind: kind}
+}
+
+type sqlInsertKindOption struct {
+	kind SQLInsertKind
+}
+
+func (o sqlInsertKindOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.insertKind = o.kind
 }
 
 // SQLInsertOption configures a SQLInsertWriter created by [NewSQLInsertWriter].
@@ -560,6 +597,7 @@ type SQLInsertWriter struct {
 	Table     string
 	Formatter *spanvalue.FormatConfig
 
+	insertKind        SQLInsertKind
 	columnNames       []string
 	quotedColumnNames string
 	quotedTable       string
@@ -650,7 +688,8 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w.out, "INSERT INTO %s (%s) VALUES (", quotedTable, quotedColumns); err != nil {
+	prefix := w.insertKind.insertPrefix()
+	if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES (", prefix, quotedTable, quotedColumns); err != nil {
 		return err
 	}
 	for i, val := range formattedValues {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -140,7 +140,7 @@ const (
 	SQLInsertOrUpdate
 )
 
-func (k SQLInsertKind) insertPrefix() string {
+func (k SQLInsertKind) String() string {
 	switch k {
 	case SQLInsert:
 		return "INSERT"
@@ -697,7 +697,7 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if err != nil {
 		return err
 	}
-	prefix := w.insertKind.insertPrefix()
+	prefix := w.insertKind.String()
 	if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES (", prefix, quotedTable, quotedColumns); err != nil {
 		return err
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -142,6 +142,8 @@ const (
 
 func (k SQLInsertKind) insertPrefix() string {
 	switch k {
+	case SQLInsert:
+		return "INSERT"
 	case SQLInsertOrIgnore:
 		return "INSERT OR IGNORE"
 	case SQLInsertOrUpdate:

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -754,6 +754,45 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 	}
 }
 
+func TestSQLInsertWriterInsertKind(t *testing.T) {
+	t.Parallel()
+
+	values := []spanner.GenericColumnValue{gcvctor.Int64Value(42)}
+	columnNames := []string{"id"}
+
+	tests := []struct {
+		name string
+		kind SQLInsertKind
+		want string
+	}{
+		{
+			name: "insert or ignore",
+			kind: SQLInsertOrIgnore,
+			want: "INSERT OR IGNORE INTO `users` (`id`) VALUES (42);\n",
+		},
+		{
+			name: "insert or update",
+			kind: SQLInsertOrUpdate,
+			want: "INSERT OR UPDATE INTO `users` (`id`) VALUES (42);\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w := NewSQLInsertWriter(&out, "users", WithSQLInsertKind(tt.kind))
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, out.String()); diff != "" {
+				t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestSQLInsertWriterWithOptions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- **#79**: Add `SQLInsertKind` and `WithSQLInsertKind` so `SQLInsertWriter` can emit Spanner GoogleSQL `INSERT`, `INSERT OR IGNORE`, and `INSERT OR UPDATE` prefixes ([DML INSERT syntax](https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax)). Multi-row batching remains deferred to a follow-up.
- **#43**: Add `*FromPtr` and `*FromNullable` helpers for common scalar types and document the naming split in `gcvctor` package godoc. `BytesFromSlice` uses a nil `[]byte` for SQL NULL.

## Test plan

- [x] `make check`

Part of #79
Part of #43