### PR TITLE
writer: WithRowType, WithColumnNames, and WriteStructValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ if err := iter.Do(func(row *spanner.Row) error {
 return w.Flush()
 ```
 
-Schema registration (`WithRowType`, `WithColumnNames`, `Prepare*`) is required only
-for some write APIs (for example `WriteStructValues`, `WriteGCVs`, or a header with no
-data rows); see the `writer` package godoc section "When With* and Prepare* are required".
+Schema registration is required only for some paths—for example field types for
+`WriteStructValues`, column names for `WriteGCVs` (types stay in each GCV; `WithRowType`
+can still supply names), or a delimited header with no data rows. See `go doc writer`
+section "When With* and Prepare* are required".
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ w := writer.NewDelimitedWriter(
 )
 ```
 
-Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (names from
-`RowType` only). Stream rows with `WriteGCVs`, `WriteProtoValues` (row type schema
-required), or `WriteRow`. When metadata is known after construction, call
-`Prepare` or `PrepareRowType` on the concrete writer. For non-streaming paths, use
+Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
+`metadata.GetRowType()`, including field types for `WriteProtoValues`; other
+metadata fields are unused). Stream rows with `WriteGCVs`, `WriteProtoValues`, or
+`WriteRow`. When schema is known after construction, call `PrepareRowType`,
+`PrepareColumnNames`, or the deprecated `Prepare` on the concrete writer. See the
+`writer` package documentation for the schema and row-input model. For non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Call `Flush` after the final row when using `writer.FlushWriter`; see the
 contract.
 
 With the [Spanner client](https://pkg.go.dev/cloud.google.com/go/spanner#section-readme),
-stream `Query` or `Read` results with `WriteRow` (each `*spanner.Row` already carries
-typed column values; the writer picks up column names from the first row):
+stream `Query` or `Read` results with `WriteRow` (no `With*` / `Prepare*` when rows
+are present; `WithHeader(true)` writes the CSV/TSV header from the first row—see
+`go doc writer` for zero-row header exports):
 
 ```go
 iter := txn.Query(ctx, stmt)
@@ -96,12 +97,9 @@ if err := iter.Do(func(row *spanner.Row) error {
 return w.Flush()
 ```
 
-Use `WithRowType`, `WithMetadata`, or `PrepareRowType` when you need a registered
-field-type schema (for example `WriteStructValues`). When the row type comes from
-`iter.Metadata`, call `PrepareRowType` after the first `iter.Next()` once metadata is
-available, or pass a row type you already know at construction time. `Prepare(metadata)`
-is deprecated; prefer `PrepareRowType` or `With*` options. Stream rows with `WriteGCVs`,
-`WriteStructValues`, or `WriteRow`.
+Schema registration (`WithRowType`, `WithColumnNames`, `Prepare*`) is required only
+for some write APIs (for example `WriteStructValues`, `WriteGCVs`, or a header with no
+data rows); see the `writer` package godoc section "When With* and Prepare* are required".
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
 `metadata.GetRowType()`, including field types for `WriteProtoValues`; other
 metadata fields are unused). Stream rows with `WriteGCVs`, `WriteProtoValues`, or
 `WriteRow`. When schema is known after construction, call `PrepareRowType`,
-`PrepareColumnNames`, or the deprecated `Prepare` on the concrete writer. See the
+`PrepareMetadata`, `PrepareColumnNames`, or the deprecated `Prepare` on the
+concrete writer. See the
 `writer` package documentation for the schema and row-input model. For non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:

--- a/README.md
+++ b/README.md
@@ -60,9 +60,12 @@ return w.Flush()
 
 ## Streaming row exports
 
-The `writer` package accepts `*spanner.Row` values directly through `WriteRow`.
-Use `writer.Writer` when an adapter only needs row streaming. Use
-`writer.FlushWriter` when an adapter owns both row streaming and finalization.
+The `writer` package streams rows at several levels: `WriteRow` for
+`*spanner.Row` (Spanner client), `WriteStructValues` for `[]*structpb.Value` with
+a registered field-type schema (spannerpb + structpb at the boundary), and
+`WriteGCVs` when values are already `GenericColumnValue`. Use `writer.Writer`
+when an adapter only needs `WriteRow`. Use `writer.FlushWriter` when an adapter
+owns both row streaming and finalization.
 `DelimitedWriter` and `JSONLWriter` preserve explicit duplicate column names.
 Empty column names are the only names passed to `UnnamedFieldNamer`, and
 generated names avoid collisions with existing explicit names. Set
@@ -86,11 +89,13 @@ w := writer.NewDelimitedWriter(
 ```
 
 Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
-`metadata.GetRowType()`, including field types for `WriteProtoValues`; other
-metadata fields are unused). Stream rows with `WriteGCVs`, `WriteProtoValues`, or
-`WriteRow`. Prefer registering schema at construction; when it is known later,
-use `PrepareRowType` or `PrepareColumnNames` (or `PrepareRowType(meta.GetRowType())`
-when you only have metadata). See the `writer` package documentation. For non-streaming paths, use
+`metadata.GetRowType()` as column names plus field types; other metadata fields
+are unused). Stream rows with `WriteGCVs`, `WriteStructValues`, or `WriteRow`.
+Prefer registering schema at construction; when it is known later, use
+`PrepareRowType` or `PrepareColumnNames` (or `PrepareRowType(meta.GetRowType())`
+when you only have metadata). Delimited, JSONL, and SQL encodings differ after
+spanvalue formats each column; see the `writer` package documentation. For
+non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ Call `Flush` after the final row when using `writer.FlushWriter`; see the
 contract.
 
 With the [Spanner client](https://pkg.go.dev/cloud.google.com/go/spanner#section-readme),
-stream `Query` or `Read` results with `WriteRow` (no `With*` / `Prepare*` when rows
-are present; `WithHeader(true)` writes the CSV/TSV header from the first row—see
-`go doc writer` for zero-row header exports):
+export through a `RowIterator` with `WriteRow` and `writer.WithHeader(true)` (default).
+
+When every query returns at least one row, `iter.Do` is enough—`WriteRow` picks up
+column names from the first row and writes the header before the first data row:
 
 ```go
 iter := txn.Query(ctx, stmt)
@@ -93,6 +94,51 @@ if err := iter.Do(func(row *spanner.Row) error {
 	return w.WriteRow(row)
 }); err != nil {
 	return err
+}
+return w.Flush()
+```
+
+When the result may be empty but you still want a CSV/TSV header, use `iter.Next`.
+After the first `Next`, Spanner sets `iter.Metadata` (row or `iterator.Done`);
+register names with `PrepareRowType`, then stream rows. `Flush` writes a pending
+header when no data row was emitted:
+
+```go
+iter := txn.Query(ctx, stmt)
+defer iter.Stop()
+
+w := writer.NewDelimitedWriter(
+	out,
+	'\t',
+	writer.WithFormatter(cfg),
+	writer.WithHeader(true),
+)
+
+row, err := iter.Next()
+if err != nil && err != iterator.Done {
+	return err
+}
+if iter.Metadata != nil {
+	if err := w.PrepareRowType(iter.Metadata.GetRowType()); err != nil {
+		return err
+	}
+}
+if err == nil {
+	if err := w.WriteRow(row); err != nil {
+		return err
+	}
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := w.WriteRow(row); err != nil {
+			return err
+		}
+	}
 }
 return w.Flush()
 ```

--- a/README.md
+++ b/README.md
@@ -76,38 +76,31 @@ Call `Flush` after the final row when using `writer.FlushWriter`; see the
 contract.
 
 With the [Spanner client](https://pkg.go.dev/cloud.google.com/go/spanner#section-readme),
-schema usually comes from a `RowIterator` after `Query` or `Read`:
+stream `Query` or `Read` results with `WriteRow` (each `*spanner.Row` already carries
+typed column values; the writer picks up column names from the first row):
 
 ```go
-rowIter := txn.Query(ctx, stmt)
-defer rowIter.Stop()
+iter := txn.Query(ctx, stmt)
 
 w := writer.NewDelimitedWriter(
 	out,
 	'\t',
-	writer.WithRowType(rowIter.Metadata.GetRowType()),
-	// or writer.WithMetadata(rowIter.Metadata),
 	writer.WithFormatter(cfg),
 	writer.WithHeader(true), // false for headerless CSV/TSV
 )
-for {
-	row, err := rowIter.Next()
-	if err == iterator.Done {
-		break
-	}
-	if err != nil {
-		return err
-	}
-	if err := w.WriteRow(row); err != nil {
-		return err
-	}
+if err := iter.Do(func(row *spanner.Row) error {
+	return w.WriteRow(row)
+}); err != nil {
+	return err
 }
 return w.Flush()
 ```
 
-If the writer is created before the query, call `PrepareRowType(rowIter.Metadata.GetRowType())`
-(or `PrepareColumnNames`) once the iterator is open. `Prepare(metadata)` is deprecated;
-prefer `PrepareRowType` or `With*` options. Stream rows with `WriteGCVs`,
+Use `WithRowType`, `WithMetadata`, or `PrepareRowType` when you need a registered
+field-type schema (for example `WriteStructValues`). When the row type comes from
+`iter.Metadata`, call `PrepareRowType` after the first `iter.Next()` once metadata is
+available, or pass a row type you already know at construction time. `Prepare(metadata)`
+is deprecated; prefer `PrepareRowType` or `With*` options. Stream rows with `WriteGCVs`,
 `WriteStructValues`, or `WriteRow`.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For

--- a/README.md
+++ b/README.md
@@ -75,27 +75,40 @@ Call `Flush` after the final row when using `writer.FlushWriter`; see the
 `Writer`, `FlushWriter`, and `Flusher` godoc for the interface lifecycle
 contract.
 
-Constructors accept options when setup should be explicit:
+With the [Spanner client](https://pkg.go.dev/cloud.google.com/go/spanner#section-readme),
+schema usually comes from a `RowIterator` after `Query` or `Read`:
 
 ```go
+rowIter := txn.Query(ctx, stmt)
+defer rowIter.Stop()
+
 w := writer.NewDelimitedWriter(
 	out,
 	'\t',
-	writer.WithRowType(meta.GetRowType()), // or WithColumnNames(names) or WithMetadata(meta)
+	writer.WithRowType(rowIter.Metadata.GetRowType()),
+	// or writer.WithMetadata(rowIter.Metadata),
 	writer.WithFormatter(cfg),
-	writer.WithHeader(true),  // false for headerless CSV/TSV
-	writer.WithUnnamedFieldNamer(nil),
+	writer.WithHeader(true), // false for headerless CSV/TSV
 )
+for {
+	row, err := rowIter.Next()
+	if err == iterator.Done {
+		break
+	}
+	if err != nil {
+		return err
+	}
+	if err := w.WriteRow(row); err != nil {
+		return err
+	}
+}
+return w.Flush()
 ```
 
-Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
-`metadata.GetRowType()` as column names plus field types; other metadata fields
-are unused). Stream rows with `WriteGCVs`, `WriteStructValues`, or `WriteRow`.
-Register schema at construction with `WithRowType`, `WithColumnNames`, or
-`WithMetadata`, or call `PrepareRowType` / `PrepareColumnNames` after the query
-when the writer was created first (`PrepareRowType(metadata.GetRowType())` when you
-have metadata). `Prepare(metadata)` is deprecated; prefer `PrepareRowType` or
-`With*` options.
+If the writer is created before the query, call `PrepareRowType(rowIter.Metadata.GetRowType())`
+(or `PrepareColumnNames`) once the iterator is open. `Prepare(metadata)` is deprecated;
+prefer `PrepareRowType` or `With*` options. Stream rows with `WriteGCVs`,
+`WriteStructValues`, or `WriteRow`.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ w := writer.NewDelimitedWriter(
 Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
 `metadata.GetRowType()` as column names plus field types; other metadata fields
 are unused). Stream rows with `WriteGCVs`, `WriteStructValues`, or `WriteRow`.
-Prefer registering schema at construction with `WithRowType`, `WithColumnNames`,
-or `WithMetadata`. Deprecated `Prepare(metadata)` remains for late-bound metadata.
+Register schema at construction with `WithRowType`, `WithColumnNames`, or
+`WithMetadata`, or call `PrepareRowType` / `PrepareColumnNames` after the query
+when the writer was created first. Deprecated `Prepare(metadata)` delegates to
+`PrepareRowType(metadata.GetRowType())`.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
 are unused). Stream rows with `WriteGCVs`, `WriteStructValues`, or `WriteRow`.
 Register schema at construction with `WithRowType`, `WithColumnNames`, or
 `WithMetadata`, or call `PrepareRowType` / `PrepareColumnNames` after the query
-when the writer was created first. Deprecated `Prepare(metadata)` delegates to
-`PrepareRowType(metadata.GetRowType())`.
+when the writer was created first (`PrepareRowType(metadata.GetRowType())` when you
+have metadata). `Prepare(metadata)` is deprecated; prefer `PrepareRowType` or
+`With*` options.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ w := writer.NewDelimitedWriter(
 Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
 `metadata.GetRowType()` as column names plus field types; other metadata fields
 are unused). Stream rows with `WriteGCVs`, `WriteStructValues`, or `WriteRow`.
-Prefer registering schema at construction; when it is known later, use
-`PrepareRowType` or `PrepareColumnNames` (or `PrepareRowType(meta.GetRowType())`
-when you only have metadata). Delimited, JSONL, and SQL encodings differ after
+Prefer registering schema at construction with `WithRowType`, `WithColumnNames`,
+or `WithMetadata`. Deprecated `Prepare(metadata)` remains for late-bound metadata.
+Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`

--- a/README.md
+++ b/README.md
@@ -97,10 +97,8 @@ if err := iter.Do(func(row *spanner.Row) error {
 return w.Flush()
 ```
 
-Schema registration is required only for some paths—for example field types for
-`WriteStructValues`, column names for `WriteGCVs` (types stay in each GCV; `WithRowType`
-can still supply names), or a delimited header with no data rows. See `go doc writer`
-section "When With* and Prepare* are required".
+Which schema to pre-register depends on the write API (names only vs names and types);
+see `go doc writer`, section "Column names and field types".
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -78,15 +78,17 @@ Constructors accept options when setup should be explicit:
 w := writer.NewDelimitedWriter(
 	out,
 	'\t',
-	writer.WithMetadata(meta),
+	writer.WithRowType(meta.GetRowType()), // or WithColumnNames(names) or WithMetadata(meta)
 	writer.WithFormatter(cfg),
-	writer.WithHeader(true),
+	writer.WithHeader(true),  // false for headerless CSV/TSV
 	writer.WithUnnamedFieldNamer(nil),
 )
 ```
 
-When metadata is known after construction but before rows are streamed, call
-`Prepare(metadata)` on the concrete writer. For non-streaming paths, use
+Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (names from
+`RowType` only). Stream rows with `WriteGCVs`, `WriteProtoValues` (row type schema
+required), or `WriteRow`. When metadata is known after construction, call
+`Prepare` or `PrepareRowType` on the concrete writer. For non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ w := writer.NewDelimitedWriter(
 Register schema with `WithRowType`, `WithColumnNames`, or `WithMetadata` (stores
 `metadata.GetRowType()`, including field types for `WriteProtoValues`; other
 metadata fields are unused). Stream rows with `WriteGCVs`, `WriteProtoValues`, or
-`WriteRow`. When schema is known after construction, call `PrepareRowType`,
-`PrepareMetadata`, `PrepareColumnNames`, or the deprecated `Prepare` on the
-concrete writer. See the
-`writer` package documentation for the schema and row-input model. For non-streaming paths, use
+`WriteRow`. Prefer registering schema at construction; when it is known later,
+use `PrepareRowType` or `PrepareColumnNames` (or `PrepareRowType(meta.GetRowType())`
+when you only have metadata). See the `writer` package documentation. For non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:
 

--- a/common.go
+++ b/common.go
@@ -70,15 +70,6 @@ func typeValueToGCV(typ *sppb.Type, value *structpb.Value) spanner.GenericColumn
 	return spanner.GenericColumnValue{Type: typ, Value: value}
 }
 
-// GenericColumnValueOf builds a GenericColumnValue from a type and protobuf value.
-// typ must be non-nil.
-func GenericColumnValueOf(typ *sppb.Type, value *structpb.Value) (spanner.GenericColumnValue, error) {
-	if typ == nil {
-		return spanner.GenericColumnValue{}, ErrNilStructField
-	}
-	return typeValueToGCV(typ, value), nil
-}
-
 func simpleGCVToNullable(value spanner.GenericColumnValue) (NullableValue, error) {
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_BOOL:

--- a/common.go
+++ b/common.go
@@ -70,6 +70,15 @@ func typeValueToGCV(typ *sppb.Type, value *structpb.Value) spanner.GenericColumn
 	return spanner.GenericColumnValue{Type: typ, Value: value}
 }
 
+// GenericColumnValueOf builds a GenericColumnValue from a type and protobuf value.
+// typ must be non-nil.
+func GenericColumnValueOf(typ *sppb.Type, value *structpb.Value) (spanner.GenericColumnValue, error) {
+	if typ == nil {
+		return spanner.GenericColumnValue{}, ErrNilStructField
+	}
+	return typeValueToGCV(typ, value), nil
+}
+
 func simpleGCVToNullable(value spanner.GenericColumnValue) (NullableValue, error) {
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_BOOL:

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -34,21 +34,27 @@
 // column lists). Some paths also register per-column *sppb.Type values so rows
 // can be streamed as []*structpb.Value without fabricating metadata wrappers.
 //
-// With the [cloud.google.com/go/spanner] client, a typical read path starts from
-// [cloud.google.com/go/spanner.RowIterator] after Query or Read. Use
-// rowIter.Metadata.GetRowType() for [WithRowType] and [PrepareRowType], or pass
-// rowIter.Metadata to [WithMetadata] (other metadata fields are ignored).
+// With the [cloud.google.com/go/spanner] client, stream [Writer.WriteRow] after
+// Query or Read: each *spanner.Row already carries typed GenericColumnValue cells,
+// and the writer records column names from the first row. That path does not need
+// [cloud.google.com/go/spanner.RowIterator].Metadata or [WithRowType].
 //
-// Register schema with those options when the writer is constructed, or with
-// [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames] after
-// the iterator is opened when the writer was created first. [WithRowType] and
-// [WithMetadata] store names plus field types (internal columnSchema) and are
-// required for [WriteStructValues]. [WithColumnNames] stores names only; types
+// Register a field-type schema with [WithRowType], [WithMetadata], or
+// [DelimitedWriter.PrepareRowType] for [WriteStructValues] or when column names must
+// be fixed before the first data row. Pass a *sppb.StructType from application
+// schema at construction, or from iter.Metadata.GetRowType after the first
+// [cloud.google.com/go/spanner.RowIterator.Next] (Spanner populates metadata then,
+// not when the iterator is created). When the writer exists before the query, call
+// [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames] once the
+// row type or names are available.
+//
+// [WithRowType] and [WithMetadata] store names plus field types (internal columnSchema)
+// and are required for [WriteStructValues]. [WithColumnNames] stores names only; types
 // come from each GCV in [WriteGCVs].
 //
 // [DelimitedWriter.Prepare] is formally deprecated (see its Deprecated note);
-// use PrepareRowType(rowIter.Metadata.GetRowType()), PrepareColumnNames, or With
-// options at construction.
+// use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames], or
+// [WithRowType] / [WithColumnNames] / [WithMetadata] instead.
 //
 // Row write layers (high to low):
 //
@@ -60,8 +66,8 @@
 // Delimited, JSONL, and SQL writers use different output encodings after spanvalue
 // formats each column; there is no shared "formatted row" interface.
 //
-// spanvalue formats cells from Type+Value pairs internally. rowIter.Metadata is
-// only a carrier for RowType when registering schema, not used while formatting.
+// spanvalue formats cells from Type+Value pairs internally. Result-set metadata is
+// only a carrier for RowType when registering schema, not used while formatting rows.
 //
 // DelimitedWriter defaults to emitting a header row. Use [WithHeader] with false
 // for headerless CSV/TSV when names are registered but must not appear as the
@@ -229,8 +235,8 @@ type metadataOption struct {
 
 // WithMetadata initializes a writer schema from metadata.GetRowType(), including
 // field types for [WriteStructValues]. Other metadata fields are ignored.
-// With the Spanner client, pass rowIter.Metadata. Equivalent to
-// WithRowType(rowIter.Metadata.GetRowType()).
+// Equivalent to [WithRowType](metadata.GetRowType()). When metadata comes from a
+// [cloud.google.com/go/spanner.RowIterator], it is available after the first Next.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -251,9 +257,9 @@ type rowTypeOption struct {
 	rowType *sppb.StructType
 }
 
-// WithRowType initializes a writer schema from a Spanner row type.
-// With the Spanner client, pass rowIter.Metadata.GetRowType() from a
-// [cloud.google.com/go/spanner.RowIterator].
+// WithRowType initializes a writer schema from a Spanner row type (names and field
+// types). Use application schema at construction, or iter.Metadata.GetRowType after
+// the first [cloud.google.com/go/spanner.RowIterator.Next], not before.
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -407,7 +413,8 @@ func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...Del
 	return NewDelimitedWriter(out, delimiter, options...)
 }
 
-// WriteRow writes one delimited row, initializing the schema from row metadata if needed.
+// WriteRow writes one delimited row. Column names are taken from the row and
+// registered on the first write when not already set.
 func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 	columnNames, values, err := rowData(row)
 	if err != nil {
@@ -419,16 +426,15 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the delimited schema from result-set metadata before the first
 // row is written.
 //
-// Deprecated: Use [DelimitedWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
-// [DelimitedWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or
-// [WithMetadata] instead.
+// Deprecated: Use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames],
+// [WithRowType], [WithColumnNames], or [WithMetadata] instead.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the delimited schema from a row type before the first
-// row is written. With the Spanner client, pass rowIter.Metadata.GetRowType() after
-// opening a [cloud.google.com/go/spanner.RowIterator]. If a schema is already
+// row is written. When the row type comes from a [cloud.google.com/go/spanner.RowIterator],
+// use iter.Metadata.GetRowType after the first Next. If a schema is already
 // initialized, column names must match.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
@@ -665,14 +671,15 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [JSONLWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
-// [JSONLWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
+// Deprecated: Use [JSONLWriter.PrepareRowType], [JSONLWriter.PrepareColumnNames],
+// [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the JSONL schema from a row type before the first row is written.
-// With the Spanner client, pass rowIter.Metadata.GetRowType() from a RowIterator.
+// When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use
+// iter.Metadata.GetRowType after the first Next.
 func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -863,14 +870,15 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Use [SQLInsertWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
-// [SQLInsertWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
+// Deprecated: Use [SQLInsertWriter.PrepareRowType], [SQLInsertWriter.PrepareColumnNames],
+// [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
-// With the Spanner client, pass rowIter.Metadata.GetRowType() from a RowIterator.
+// When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use
+// iter.Metadata.GetRowType after the first Next.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -22,10 +22,42 @@
 // INSERT OR UPDATE are valid Spanner GoogleSQL DML forms; see the INSERT section
 // in https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
 // Constructors accept options such as [WithRowType], [WithColumnNames],
-// [WithMetadata], and [WithFormatter]. [WithMetadata] uses only metadata row type
-// field names (and types for [DelimitedWriter.WriteProtoValues]); formatting
-// still reads types from each GCV when using [DelimitedWriter.WriteGCVs].
+// [WithMetadata], and [WithFormatter]. When schema is known only after
+// construction, call the matching Prepare method on the concrete writer.
 // [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
+//
+// # Schema registration and row input
+//
+// Writers need column names for labeling output (CSV headers, JSON keys, INSERT
+// column lists). Some call paths also need a Spanner row type (field types) to
+// build rows from []*structpb.Value without pre-built GCVs.
+//
+// Register schema at construction or with Prepare:
+//
+//   - [WithRowType] / [DelimitedWriter.PrepareRowType]: stores *sppb.StructType
+//     (names plus field types). Required for [DelimitedWriter.WriteProtoValues]
+//     and the JSONL/SQL equivalents.
+//   - [WithColumnNames] / [DelimitedWriter.PrepareColumnNames]: stores names only.
+//     Row types come from each GCV when using WriteGCVs.
+//   - [WithMetadata] / [DelimitedWriter.Prepare]: stores metadata.GetRowType()
+//     (same as WithRowType). Other ResultSetMetadata fields are ignored.
+//     [DelimitedWriter.Prepare] is deprecated; prefer PrepareRowType or
+//     PrepareColumnNames.
+//
+// Per-row writes:
+//
+//   - WriteRow / WriteValues: full *spanner.Row or explicit names plus GCVs.
+//   - WriteGCVs: column names must be set; each GCV supplies Type and Value.
+//   - WriteProtoValues: row type must be set; values are []*structpb.Value
+//     paired with fields[i].Type (nil type is an error).
+//
+// Formatting always uses GCV Type and Value at format time. ResultSetMetadata is
+// not consulted while formatting a row; it is only a convenient carrier for
+// RowType when callers already have query metadata.
+//
+// DelimitedWriter defaults to emitting a header row. Use [WithHeader] with false
+// for headerless CSV/TSV when names are registered but must not appear as the
+// first output line.
 //
 // # Compatibility constructors
 //
@@ -187,7 +219,9 @@ type metadataOption struct {
 	metadata *sppb.ResultSetMetadata
 }
 
-// WithMetadata initializes a writer schema from result-set metadata row type.
+// WithMetadata initializes a writer schema from metadata.GetRowType(), including
+// field types for WriteProtoValues. Other metadata fields are ignored.
+// Prefer [WithRowType] when metadata is not available.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -358,12 +392,15 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the delimited schema from result-set metadata before the first
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
+//
+// Deprecated: Use [DelimitedWriter.PrepareRowType] with metadata.GetRowType(), or
+// [DelimitedWriter.PrepareColumnNames] when the caller has column names only.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the delimited schema from a row type before the first
-// row is written.
+// row is written. If a schema is already initialized, column names must match.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	columnNames, err := prepareRowType(rowType)
 	if err != nil {
@@ -373,6 +410,19 @@ func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 		return err
 	}
 	w.setRowType(rowType)
+	return nil
+}
+
+// PrepareColumnNames initializes the delimited schema from column names before the
+// first row is written. If a schema is already initialized, names must match.
+func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
+	if len(names) == 0 {
+		return ErrMissingColumnNames
+	}
+	if err := w.initOrValidateColumnNames(names); err != nil {
+		return err
+	}
+	w.setColumnNames(names)
 	return nil
 }
 
@@ -580,6 +630,9 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the JSONL schema from result-set metadata before the first
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
+//
+// Deprecated: Use [JSONLWriter.PrepareRowType] with metadata.GetRowType(), or
+// [JSONLWriter.PrepareColumnNames] when the caller has column names only.
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
@@ -594,6 +647,18 @@ func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 		return err
 	}
 	w.setRowType(rowType)
+	return nil
+}
+
+// PrepareColumnNames initializes the JSONL schema from column names before the first row is written.
+func (w *JSONLWriter) PrepareColumnNames(names []string) error {
+	if len(names) == 0 {
+		return ErrMissingColumnNames
+	}
+	if err := w.initOrValidateColumnNames(names); err != nil {
+		return err
+	}
+	w.setColumnNames(names)
 	return nil
 }
 
@@ -757,6 +822,9 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the SQL INSERT schema from result-set metadata before the
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
+//
+// Deprecated: Use [SQLInsertWriter.PrepareRowType] with metadata.GetRowType(), or
+// [SQLInsertWriter.PrepareColumnNames] when the caller has column names only.
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
@@ -771,6 +839,15 @@ func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 		return err
 	}
 	w.setRowType(rowType)
+	return nil
+}
+
+// PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
+func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
+	if _, err := w.initOrValidateQuotedColumns(names); err != nil {
+		return err
+	}
+	w.setColumnNames(names)
 	return nil
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -39,10 +39,10 @@
 //     and the JSONL/SQL equivalents.
 //   - [WithColumnNames] / [DelimitedWriter.PrepareColumnNames]: stores names only.
 //     Row types come from each GCV when using WriteGCVs.
-//   - [WithMetadata] / [DelimitedWriter.Prepare]: stores metadata.GetRowType()
-//     (same as WithRowType). Other ResultSetMetadata fields are ignored.
-//     [DelimitedWriter.Prepare] is deprecated; prefer PrepareRowType or
-//     PrepareColumnNames.
+//   - [WithMetadata] / [DelimitedWriter.PrepareMetadata]: stores
+//     metadata.GetRowType() (same as WithRowType). Other ResultSetMetadata
+//     fields are ignored. [DelimitedWriter.Prepare] is deprecated; prefer
+//     PrepareMetadata, PrepareRowType, or PrepareColumnNames.
 //
 // Per-row writes:
 //
@@ -393,9 +393,16 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [DelimitedWriter.PrepareRowType] with metadata.GetRowType(), or
-// [DelimitedWriter.PrepareColumnNames] when the caller has column names only.
+// Deprecated: Use [DelimitedWriter.PrepareMetadata], [DelimitedWriter.PrepareRowType],
+// or [DelimitedWriter.PrepareColumnNames].
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareMetadata(metadata)
+}
+
+// PrepareMetadata initializes the delimited schema from result-set metadata before
+// the first row is written. Only metadata.GetRowType() is used; other metadata
+// fields are ignored. If a schema is already initialized, column names must match.
+func (w *DelimitedWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -462,7 +469,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType] or [PrepareRowType].
+// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
 func (w *DelimitedWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {
@@ -631,9 +638,15 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [JSONLWriter.PrepareRowType] with metadata.GetRowType(), or
-// [JSONLWriter.PrepareColumnNames] when the caller has column names only.
+// Deprecated: Use [JSONLWriter.PrepareMetadata], [JSONLWriter.PrepareRowType],
+// or [JSONLWriter.PrepareColumnNames].
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareMetadata(metadata)
+}
+
+// PrepareMetadata initializes the JSONL schema from result-set metadata before the
+// first row is written. Only metadata.GetRowType() is used.
+func (w *JSONLWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -670,7 +683,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType] or [PrepareRowType].
+// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
 func (w *JSONLWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {
@@ -823,9 +836,15 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Use [SQLInsertWriter.PrepareRowType] with metadata.GetRowType(), or
-// [SQLInsertWriter.PrepareColumnNames] when the caller has column names only.
+// Deprecated: Use [SQLInsertWriter.PrepareMetadata], [SQLInsertWriter.PrepareRowType],
+// or [SQLInsertWriter.PrepareColumnNames].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareMetadata(metadata)
+}
+
+// PrepareMetadata initializes the SQL INSERT schema from result-set metadata before
+// the first row is written. Only metadata.GetRowType() is used.
+func (w *SQLInsertWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -860,7 +879,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType] or [PrepareRowType].
+// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
 func (w *SQLInsertWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -9,83 +9,36 @@
 // names avoid collisions with existing names. DelimitedWriter buffers through
 // encoding/csv, so callers must call Flush after the final write.
 //
-// Use [Writer] when an adapter only streams [cloud.google.com/go/spanner.Row]
-// values from the Spanner client. Use [DelimitedWriter.WriteStructValues] on a concrete writer
-// when the row is already represented as []*structpb.Value plus a registered
-// field-type schema (spannerpb + structpb only at the writer boundary). Use
-// [DelimitedWriter.WriteGCVs] when each cell is already a GenericColumnValue.
-// [FlushWriter] covers writers that need finalization; call Flush after the
-// last row. Flush does not close the underlying io.Writer.
+// [Writer] streams *spanner.Row values; concrete writers also offer WriteValues,
+// WriteGCVs, and WriteStructValues. [FlushWriter] adds Flush (required for buffered
+// DelimitedWriter). Flush does not close the underlying io.Writer.
 //
-// # Primary API
+// # Constructors
 //
-// [DelimitedWriter], [NewDelimitedWriter], [NewCSVWriter], [JSONLWriter],
-// [NewJSONLWriter], [SQLInsertWriter], and [NewSQLInsertWriter] stream rows.
-// [WithSQLInsertKind] selects the INSERT statement prefix. INSERT OR IGNORE and
-// INSERT OR UPDATE are valid Spanner GoogleSQL DML forms; see the INSERT section
-// in https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
-// Constructors accept options such as [WithRowType], [WithColumnNames],
-// [WithMetadata], and [WithFormatter].
-// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
+// [NewDelimitedWriter], [NewCSVWriter], [NewJSONLWriter], and [NewSQLInsertWriter]
+// accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
+// INSERT prefix (see Spanner INSERT DML syntax). [RowData], [FormatDelimitedRow], and
+// [FormatJSONLRow] format a single row without a writer.
 //
-// # Schema registration and row input
+// # Column names and field types
 //
-// Writers need column names for CSV headers, JSON keys, and INSERT column lists.
-// Some write APIs also need registered *sppb.Type values (see below).
+// Each write API either supplies schema on every call or expects it in the writer:
 //
-// # When With* and Prepare* are required
+//   - WriteRow, WriteValues: column names and GCV types per call; no registration.
+//   - WriteGCVs: register column names before the first row; types from each GCV.
+//   - WriteStructValues: register column names and field types before the first row.
 //
-// [WithRowType], [WithMetadata], [WithColumnNames], [PrepareRowType], and
-// [PrepareColumnNames] are optional unless the write API cannot supply schema
-// by itself:
+// Pre-register at construction with With* or later with Prepare* on the concrete writer.
+// Names only: [WithColumnNames], PrepareColumnNames. Names and types: [WithRowType],
+// [WithMetadata], PrepareRowType. [WithMetadata] uses metadata.GetRowType(); from a
+// [cloud.google.com/go/spanner.RowIterator], Metadata is set after the first Next.
+// [DelimitedWriter.Prepare] is deprecated.
 //
-//   - [Writer.WriteRow]: not required when at least one row is written. Each *spanner.Row
-//     supplies column names and typed GenericColumnValue cells; the writer records names
-//     from the first row. See [WithHeader] for CSV/TSV header behavior on [DelimitedWriter].
-//   - WriteValues: not required. Every call passes column names plus GCVs and may
-//     initialize the writer on the first row.
-//   - WriteGCVs: column names must already be registered ([WithColumnNames],
-//     [WithRowType], [PrepareColumnNames], [PrepareRowType], or an earlier WriteRow/
-//     WriteValues). Formatting uses each GCV's Type. Registered field types from
-//     [WithRowType] are not read on this path but stay on the writer for
-//     [WriteStructValues].
-//   - WriteStructValues: [WithRowType], [WithMetadata], or [PrepareRowType] is
-//     required so field types are registered ([ErrMissingFieldTypes] otherwise).
+// [DelimitedWriter] defaults to a CSV/TSV header before the first data row once names
+// are known ([WithHeader]). With no data rows, register names then [DelimitedWriter.WriteHeader].
+// [WithHeader](false) omits the automatic header.
 //
-// Register names or types before the first data row when you use WriteStructValues,
-// create the writer before Query/Read, or need a delimited header with zero data rows
-// (see [WithHeader]). At construction use [WithRowType] or [WithColumnNames]; later use
-// Prepare* once names or types are known. When the row type comes from a
-// [cloud.google.com/go/spanner.RowIterator], read iter.Metadata after the first
-// Next (not when the iterator is created).
-//
-// [DelimitedWriter.Prepare] is formally deprecated (see its Deprecated note);
-// use [PrepareRowType], [PrepareColumnNames], or With* options instead.
-//
-// Row write layers (high to low):
-//
-//   - [Writer.WriteRow]: *spanner.Row from the Spanner client.
-//   - WriteValues: column names plus []GenericColumnValue per call.
-//   - WriteGCVs: []GenericColumnValue; column names must be registered; types per GCV.
-//   - WriteStructValues: []*structpb.Value; field types must be registered.
-//
-// Delimited, JSONL, and SQL writers use different output encodings after spanvalue
-// formats each column; there is no shared "formatted row" interface.
-//
-// spanvalue formats cells from Type+Value pairs internally. [WriteGCVs] and
-// WriteValues use each GCV's Type at format time; [columnSchema].types is for
-// [WriteStructValues] only. [WithMetadata] is only a carrier for GetRowType when registering.
-//
-// # Delimited headers
-//
-// [DelimitedWriter] defaults to [WithHeader](true). When header output is enabled,
-// the header line is written automatically immediately before the first data row,
-// once column names are known (typically from the first [Writer.WriteRow]).
-// [WithHeader](false) skips that automatic header for headerless CSV/TSV.
-//
-// WriteRow alone does not require [WithColumnNames] when rows are present. For an
-// empty result with a header, register names via [WithColumnNames], [PrepareColumnNames],
-// or [WithRowType], then call [DelimitedWriter.WriteHeader] before [Flush].
+// Delimited, JSONL, and SQL encodings differ after spanvalue formats each column.
 //
 // # Compatibility constructors
 //
@@ -143,11 +96,8 @@ var (
 
 // Writer writes Spanner rows to an output stream.
 //
-// WriteRow does not require [WithRowType], [WithColumnNames], or Prepare*; concrete
-// writers read column names and values from each row. See the package doc section
-// "When With* and Prepare* are required" for other write APIs.
-//
-// Writer intentionally models row streaming only. Some concrete writers also
+// WriteRow supplies column names and values on each call; see package doc
+// "Column names and field types". Writer intentionally models row streaming only. Some concrete writers also
 // implement [Flusher]; callers that own the full write lifecycle must call
 // Flush after the final row when it is available. Factories that may return a
 // buffered writer should return a concrete type or [FlushWriter], not Writer
@@ -251,11 +201,8 @@ type metadataOption struct {
 	metadata *sppb.ResultSetMetadata
 }
 
-// WithMetadata initializes column names and field types from metadata.GetRowType().
-// Same semantics as [WithRowType]: names for labeling and WriteGCVs; types for
-// [WriteStructValues] (WriteGCVs uses each GCV's Type). Other metadata fields are
-// ignored. When metadata comes from a [cloud.google.com/go/spanner.RowIterator], it is
-// available after the first Next.
+// WithMetadata registers names and types from metadata.GetRowType(); same as
+// [WithRowType]. Other metadata fields are ignored.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -276,11 +223,7 @@ type rowTypeOption struct {
 	rowType *sppb.StructType
 }
 
-// WithRowType registers column names and field types. Required for WriteStructValues.
-// For WriteGCVs and WriteValues, registered names are used and each GCV supplies its
-// own Type (schema.types is not consulted). Optional for WriteRow when rows are
-// present. Use application schema at construction, or iter.Metadata.GetRowType after
-// the first RowIterator Next.
+// WithRowType registers column names and field types at construction.
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -301,10 +244,7 @@ type columnNamesOption struct {
 	names []string
 }
 
-// WithColumnNames registers column names only and clears registered field types.
-// Use before the first WriteGCVs unless names came from WriteRow or WriteValues.
-// [WithRowType] is an alternative that also records field types for WriteStructValues.
-// Not required for WriteRow or WriteValues; cell types on WriteGCVs come from each GCV.
+// WithColumnNames registers column names only and clears any registered field types.
 func WithColumnNames(names []string) Option {
 	return columnNamesOption{names: slices.Clone(names)}
 }
@@ -359,20 +299,8 @@ func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
 	w.UnnamedFieldNamer = o.namer
 }
 
-// WithHeader sets whether [DelimitedWriter] emits a CSV/TSV header line. The default
-// is true ([NewDelimitedWriter], [NewCSVWriter]).
-//
-// When header is true and at least one data row is written, the header is output
-// automatically immediately before the first data row, after column names are known
-// (for example from the first [DelimitedWriter.WriteRow]). No separate With* registration
-// is needed for that case.
-//
-// When header is true but no data rows are written, register column names with
-// [WithColumnNames], [PrepareColumnNames], or [WithRowType], then call
-// [DelimitedWriter.WriteHeader] before [Flush].
-//
-// WithHeader(false) suppresses the automatic header on the first data row. Column names
-// may still be registered or taken from WriteRow for correct field order in headerless export.
+// WithHeader sets whether [DelimitedWriter] writes a header before the first data row
+// (default true). With no data rows, register column names then call [DelimitedWriter.WriteHeader].
 func WithHeader(header bool) DelimitedOption {
 	return delimitedOptionFunc(func(w *DelimitedWriter) {
 		w.Header = header
@@ -452,10 +380,7 @@ func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...Del
 	return NewDelimitedWriter(out, delimiter, options...)
 }
 
-// WriteRow writes one delimited row. Does not require With* or Prepare* when at least
-// one row is written; column names come from the row. When [DelimitedWriter.Header] is
-// true (default), the CSV/TSV header is written before the first data row. For zero data
-// rows with a header, register names and call [DelimitedWriter.WriteHeader]; see [WithHeader].
+// WriteRow writes one delimited row; see package doc "Column names and field types".
 func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 	columnNames, values, err := rowData(row)
 	if err != nil {
@@ -467,24 +392,17 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the delimited schema from result-set metadata before the first
 // row is written.
 //
-// Deprecated: Use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames],
-// [WithRowType], [WithColumnNames], or [WithMetadata] instead.
+// Deprecated: Use [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames].
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType registers column names and field types before the first row.
-// Same role as [WithRowType]: names for WriteGCVs/WriteValues/headers; types for
-// WriteStructValues only (WriteGCVs still uses each GCV's Type). Not required for
-// WriteRow when rows are present. When the row type comes from a RowIterator, use
-// iter.Metadata.GetRowType after the first Next.
+// PrepareRowType registers column names and field types; same as [WithRowType].
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareColumnNames registers column names before the first row. Same role as
-// [WithColumnNames]; use before WriteGCVs or when emitting a header with no data rows.
-// Not required for WriteRow or WriteValues.
+// PrepareColumnNames registers column names only; same as [WithColumnNames].
 func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
@@ -512,10 +430,7 @@ func (w *DelimitedWriter) prepareColumnNames(names []string) error {
 	return nil
 }
 
-// WriteHeader writes the CSV/TSV header line once. Column names must already be registered
-// ([WithColumnNames], [PrepareColumnNames], [WithRowType], or an earlier WriteRow).
-// Use when [WithHeader](true) and the export has no data rows, or to emit the header
-// before streaming without relying on the first data row.
+// WriteHeader writes the CSV/TSV header once; column names must already be registered.
 func (w *DelimitedWriter) WriteHeader() error {
 	if w.wroteHeader {
 		return nil
@@ -543,8 +458,7 @@ func (w *DelimitedWriter) WriteHeader() error {
 	return nil
 }
 
-// WriteValues writes one row from column names and GCVs. Does not require With* or
-// Prepare*; names are passed on each call and may initialize the writer on the first row.
+// WriteValues writes one row from column names and GCVs.
 func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
@@ -552,9 +466,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 	return w.WriteGCVs(values)
 }
 
-// WriteGCVs writes one row from GCVs. Column names must already be registered
-// ([WithColumnNames], [WithRowType], [PrepareColumnNames], [PrepareRowType], or an
-// earlier WriteRow/WriteValues). Formatting uses each GCV's Type, not schema.types.
+// WriteGCVs writes one row from GCVs; see package doc "Column names and field types".
 func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	csvWriter, err := w.csvWriter()
 	if err != nil {
@@ -582,8 +494,8 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	return nil
 }
 
-// WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// WriteStructValues writes one row from []*structpb.Value; see package doc
+// "Column names and field types".
 func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -34,15 +34,20 @@
 // column lists). Some paths also register per-column *sppb.Type values so rows
 // can be streamed as []*structpb.Value without fabricating metadata wrappers.
 //
-// Register schema with [WithRowType], [WithColumnNames], or [WithMetadata] when
-// the writer is constructed, or with [DelimitedWriter.PrepareRowType] /
-// [DelimitedWriter.PrepareColumnNames] after a query when names or types were
-// not known earlier. [WithRowType] and [WithMetadata] store names plus field
-// types (internal columnSchema) and are required for [WriteStructValues].
-// [WithColumnNames] stores names only; types come from each GCV in [WriteGCVs].
+// With the [cloud.google.com/go/spanner] client, a typical read path starts from
+// [cloud.google.com/go/spanner.RowIterator] after Query or Read. Use
+// rowIter.Metadata.GetRowType() for [WithRowType] and [PrepareRowType], or pass
+// rowIter.Metadata to [WithMetadata] (other metadata fields are ignored).
+//
+// Register schema with those options when the writer is constructed, or with
+// [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames] after
+// the iterator is opened when the writer was created first. [WithRowType] and
+// [WithMetadata] store names plus field types (internal columnSchema) and are
+// required for [WriteStructValues]. [WithColumnNames] stores names only; types
+// come from each GCV in [WriteGCVs].
 //
 // [DelimitedWriter.Prepare] is formally deprecated (see its Deprecated note);
-// use PrepareRowType(metadata.GetRowType()), PrepareColumnNames, or With
+// use PrepareRowType(rowIter.Metadata.GetRowType()), PrepareColumnNames, or With
 // options at construction.
 //
 // Row write layers (high to low):
@@ -55,7 +60,7 @@
 // Delimited, JSONL, and SQL writers use different output encodings after spanvalue
 // formats each column; there is no shared "formatted row" interface.
 //
-// spanvalue formats cells from Type+Value pairs internally. ResultSetMetadata is
+// spanvalue formats cells from Type+Value pairs internally. rowIter.Metadata is
 // only a carrier for RowType when registering schema, not used while formatting.
 //
 // DelimitedWriter defaults to emitting a header row. Use [WithHeader] with false
@@ -224,7 +229,8 @@ type metadataOption struct {
 
 // WithMetadata initializes a writer schema from metadata.GetRowType(), including
 // field types for [WriteStructValues]. Other metadata fields are ignored.
-// Equivalent to WithRowType(metadata.GetRowType()).
+// With the Spanner client, pass rowIter.Metadata. Equivalent to
+// WithRowType(rowIter.Metadata.GetRowType()).
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -246,7 +252,8 @@ type rowTypeOption struct {
 }
 
 // WithRowType initializes a writer schema from a Spanner row type.
-// When the schema comes from a query result, pass metadata.GetRowType().
+// With the Spanner client, pass rowIter.Metadata.GetRowType() from a
+// [cloud.google.com/go/spanner.RowIterator].
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -412,7 +419,7 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // Prepare initializes the delimited schema from result-set metadata before the first
 // row is written.
 //
-// Deprecated: Use [DelimitedWriter.PrepareRowType] with metadata.GetRowType(),
+// Deprecated: Use [DelimitedWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
 // [DelimitedWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or
 // [WithMetadata] instead.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
@@ -420,8 +427,9 @@ func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 }
 
 // PrepareRowType initializes the delimited schema from a row type before the first
-// row is written. When only result-set metadata is available, pass
-// metadata.GetRowType(). If a schema is already initialized, column names must match.
+// row is written. With the Spanner client, pass rowIter.Metadata.GetRowType() after
+// opening a [cloud.google.com/go/spanner.RowIterator]. If a schema is already
+// initialized, column names must match.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -657,14 +665,14 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [JSONLWriter.PrepareRowType] with metadata.GetRowType(),
+// Deprecated: Use [JSONLWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
 // [JSONLWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the JSONL schema from a row type before the first row is written.
-// When only result-set metadata is available, pass metadata.GetRowType().
+// With the Spanner client, pass rowIter.Metadata.GetRowType() from a RowIterator.
 func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -855,14 +863,14 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Use [SQLInsertWriter.PrepareRowType] with metadata.GetRowType(),
+// Deprecated: Use [SQLInsertWriter.PrepareRowType] with rowIter.Metadata.GetRowType(),
 // [SQLInsertWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
-// When only result-set metadata is available, pass metadata.GetRowType().
+// With the Spanner client, pass rowIter.Metadata.GetRowType() from a RowIterator.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -34,9 +34,9 @@
 // [cloud.google.com/go/spanner.RowIterator], Metadata is set after the first Next.
 // [DelimitedWriter.Prepare] is deprecated.
 //
-// [DelimitedWriter] defaults to a CSV/TSV header before the first data row once names
-// are known ([WithHeader]). With no data rows, register names then [DelimitedWriter.WriteHeader].
-// [WithHeader](false) omits the automatic header.
+// [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
+// before the first data row, or on [DelimitedWriter.Flush] when no data row was written.
+// [WithHeader](false) omits the header. [DelimitedWriter.WriteHeader] forces the header earlier.
 //
 // Delimited, JSONL, and SQL encodings differ after spanvalue formats each column.
 //
@@ -299,8 +299,9 @@ func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
 	w.UnnamedFieldNamer = o.namer
 }
 
-// WithHeader sets whether [DelimitedWriter] writes a header before the first data row
-// (default true). With no data rows, register column names then call [DelimitedWriter.WriteHeader].
+// WithHeader sets whether [DelimitedWriter] emits a CSV/TSV header (default true).
+// The header is written before the first data row, or on [DelimitedWriter.Flush] if only
+// names were registered. See [DelimitedWriter.WriteHeader] to emit it earlier.
 func WithHeader(header bool) DelimitedOption {
 	return delimitedOptionFunc(func(w *DelimitedWriter) {
 		w.Header = header
@@ -431,6 +432,7 @@ func (w *DelimitedWriter) prepareColumnNames(names []string) error {
 }
 
 // WriteHeader writes the CSV/TSV header once; column names must already be registered.
+// When [DelimitedWriter.Header] is true, [DelimitedWriter.Flush] also writes a pending header.
 func (w *DelimitedWriter) WriteHeader() error {
 	if w.wroteHeader {
 		return nil
@@ -558,9 +560,18 @@ func validDelimiter(delimiter rune) bool {
 		delimiter != utf8.RuneError
 }
 
-// Flush flushes buffered delimited data to the underlying writer. It does not
-// close the underlying writer.
+// Flush flushes buffered delimited data to the underlying writer. When [DelimitedWriter.Header]
+// is true, column names are registered, and no header was written yet, Flush writes the
+// header first (including zero-row exports). Flush does not close the underlying writer.
 func (w *DelimitedWriter) Flush() error {
+	if w.Header && !w.wroteHeader {
+		if len(w.schema.names) == 0 {
+			return ErrMissingColumnNames
+		}
+		if err := w.WriteHeader(); err != nil {
+			return err
+		}
+	}
 	if w.writer == nil {
 		return nil
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -34,13 +34,15 @@
 // column lists). Some paths also register per-column *sppb.Type values so rows
 // can be streamed as []*structpb.Value without fabricating metadata wrappers.
 //
-// Register schema with [WithRowType], [WithColumnNames], or [WithMetadata] at
-// construction. [WithRowType] and [WithMetadata] store names plus field types
-// (internal columnSchema) and are required for [WriteStructValues].
+// Register schema with [WithRowType], [WithColumnNames], or [WithMetadata] when
+// the writer is constructed, or with [DelimitedWriter.PrepareRowType] /
+// [DelimitedWriter.PrepareColumnNames] after a query when names or types were
+// not known earlier. [WithRowType] and [WithMetadata] store names plus field
+// types (internal columnSchema) and are required for [WriteStructValues].
 // [WithColumnNames] stores names only; types come from each GCV in [WriteGCVs].
 //
-// [DelimitedWriter.Prepare] is deprecated late-binding for result-set metadata
-// only; prefer constructing the writer with With options when possible.
+// [DelimitedWriter.Prepare] is deprecated; use PrepareRowType or
+// PrepareColumnNames, or With options at construction.
 //
 // Row write layers (high to low):
 //
@@ -409,9 +411,22 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
+// Deprecated: Use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames],
+// or With options at construction.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.prepareRowType(rowTypeFromMetadata(metadata))
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the delimited schema from a row type before the first
+// row is written. If a schema is already initialized, column names must match.
+func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
+	return w.prepareRowType(rowType)
+}
+
+// PrepareColumnNames initializes the delimited schema from column names before the
+// first row is written. If a schema is already initialized, names must match.
+func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
+	return w.prepareColumnNames(names)
 }
 
 func (w *DelimitedWriter) prepareRowType(rowType *sppb.StructType) error {
@@ -423,6 +438,17 @@ func (w *DelimitedWriter) prepareRowType(rowType *sppb.StructType) error {
 		return err
 	}
 	w.setRowType(rowType)
+	return nil
+}
+
+func (w *DelimitedWriter) prepareColumnNames(names []string) error {
+	if len(names) == 0 {
+		return ErrMissingColumnNames
+	}
+	if err := w.initOrValidateColumnNames(names); err != nil {
+		return err
+	}
+	w.setColumnNames(names)
 	return nil
 }
 
@@ -462,7 +488,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType] or [WithMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
@@ -628,9 +654,20 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
+// Deprecated: Use [JSONLWriter.PrepareRowType], [JSONLWriter.PrepareColumnNames],
+// or With options at construction.
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.prepareRowType(rowTypeFromMetadata(metadata))
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the JSONL schema from a row type before the first row is written.
+func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
+	return w.prepareRowType(rowType)
+}
+
+// PrepareColumnNames initializes the JSONL schema from column names before the first row is written.
+func (w *JSONLWriter) PrepareColumnNames(names []string) error {
+	return w.prepareColumnNames(names)
 }
 
 func (w *JSONLWriter) prepareRowType(rowType *sppb.StructType) error {
@@ -645,6 +682,17 @@ func (w *JSONLWriter) prepareRowType(rowType *sppb.StructType) error {
 	return nil
 }
 
+func (w *JSONLWriter) prepareColumnNames(names []string) error {
+	if len(names) == 0 {
+		return ErrMissingColumnNames
+	}
+	if err := w.initOrValidateColumnNames(names); err != nil {
+		return err
+	}
+	w.setColumnNames(names)
+	return nil
+}
+
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
@@ -653,7 +701,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType] or [WithMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
@@ -803,9 +851,20 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
+// Deprecated: Use [SQLInsertWriter.PrepareRowType], [SQLInsertWriter.PrepareColumnNames],
+// or With options at construction.
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.prepareRowType(rowTypeFromMetadata(metadata))
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
+func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
+	return w.prepareRowType(rowType)
+}
+
+// PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
+func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
+	return w.prepareColumnNames(names)
 }
 
 func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
@@ -841,7 +900,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType] or [WithMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -21,10 +21,11 @@
 // [WithSQLInsertKind] selects the INSERT statement prefix. INSERT OR IGNORE and
 // INSERT OR UPDATE are valid Spanner GoogleSQL DML forms; see the INSERT section
 // in https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
-// Constructors accept options such as [WithMetadata] and [WithFormatter].
-// Each writer's Prepare method initializes schema from result-set metadata
-// (for example [DelimitedWriter.Prepare]). [RowData], [FormatDelimitedRow], and
-// [FormatJSONLRow] support one-row paths.
+// Constructors accept options such as [WithRowType], [WithColumnNames],
+// [WithMetadata], and [WithFormatter]. [WithMetadata] uses only metadata row type
+// field names (and types for [DelimitedWriter.WriteProtoValues]); formatting
+// still reads types from each GCV when using [DelimitedWriter.WriteGCVs].
+// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
 //
 // # Compatibility constructors
 //
@@ -45,6 +46,7 @@ import (
 	"cloud.google.com/go/spanner"
 	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/internal"
@@ -73,6 +75,10 @@ var (
 	ErrHeaderAfterData = errors.New("header after data")
 	// ErrInvalidDelimiter reports that DelimitedWriter received an invalid delimiter.
 	ErrInvalidDelimiter = errors.New("invalid delimiter")
+	// ErrMissingRowType reports that WriteProtoValues requires a row type schema.
+	ErrMissingRowType = errors.New("missing row type schema")
+	// ErrMismatchedProtoValueCount reports that WriteProtoValues value count does not match the row type.
+	ErrMismatchedProtoValueCount = errors.New("mismatched proto value count")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -181,21 +187,64 @@ type metadataOption struct {
 	metadata *sppb.ResultSetMetadata
 }
 
-// WithMetadata initializes a writer schema from result-set metadata.
+// WithMetadata initializes a writer schema from result-set metadata row type.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
 
 func (o metadataOption) applyDelimitedOption(w *DelimitedWriter) {
-	w.setMetadata(o.metadata)
+	w.setRowType(rowTypeFromMetadata(o.metadata))
 }
 
 func (o metadataOption) applyJSONLOption(w *JSONLWriter) {
-	w.setMetadata(o.metadata)
+	w.setRowType(rowTypeFromMetadata(o.metadata))
 }
 
 func (o metadataOption) applySQLInsertOption(w *SQLInsertWriter) {
-	w.setMetadata(o.metadata)
+	w.setRowType(rowTypeFromMetadata(o.metadata))
+}
+
+type rowTypeOption struct {
+	rowType *sppb.StructType
+}
+
+// WithRowType initializes a writer schema from a Spanner row type.
+func WithRowType(rowType *sppb.StructType) Option {
+	return rowTypeOption{rowType: rowType}
+}
+
+func (o rowTypeOption) applyDelimitedOption(w *DelimitedWriter) {
+	w.setRowType(o.rowType)
+}
+
+func (o rowTypeOption) applyJSONLOption(w *JSONLWriter) {
+	w.setRowType(o.rowType)
+}
+
+func (o rowTypeOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.setRowType(o.rowType)
+}
+
+type columnNamesOption struct {
+	names []string
+}
+
+// WithColumnNames initializes a writer schema from column names only.
+// Use [DelimitedWriter.WriteGCVs] (or other WriteGCVs methods) so each row supplies types in GCVs.
+func WithColumnNames(names []string) Option {
+	return columnNamesOption{names: slices.Clone(names)}
+}
+
+func (o columnNamesOption) applyDelimitedOption(w *DelimitedWriter) {
+	w.setColumnNames(o.names)
+}
+
+func (o columnNamesOption) applyJSONLOption(w *JSONLWriter) {
+	w.setColumnNames(o.names)
+}
+
+func (o columnNamesOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.setColumnNames(o.names)
 }
 
 type formatterOption struct {
@@ -252,6 +301,7 @@ type DelimitedWriter struct {
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
 
 	columnNames         []string
+	rowType             *sppb.StructType
 	resolvedColumnNames []string
 	out                 io.Writer
 	writer              *csv.Writer
@@ -309,11 +359,21 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	columnNames, err := prepareColumnNames(metadata)
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the delimited schema from a row type before the first
+// row is written.
+func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
+	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
 	}
-	return w.initOrValidateColumnNames(columnNames)
+	if err := w.initOrValidateColumnNames(columnNames); err != nil {
+		return err
+	}
+	w.setRowType(rowType)
+	return nil
 }
 
 // WriteHeader writes the delimited header once using the initialized column names.
@@ -351,6 +411,16 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 	return w.WriteGCVs(values)
 }
 
+// WriteProtoValues writes one row from protobuf values using the row type schema
+// registered by [WithRowType] or [PrepareRowType].
+func (w *DelimitedWriter) WriteProtoValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromRowType(w.rowType, values)
+	if err != nil {
+		return err
+	}
+	return w.WriteGCVs(gcvs)
+}
+
 func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	csvWriter, err := w.csvWriter()
 	if err != nil {
@@ -378,8 +448,15 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	return nil
 }
 
-func (w *DelimitedWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
-	w.columnNames = metadataColumnNames(metadata)
+func (w *DelimitedWriter) setRowType(rowType *sppb.StructType) {
+	w.rowType = rowType
+	w.columnNames = columnNamesFromRowType(rowType)
+	w.resolvedColumnNames = nil
+}
+
+func (w *DelimitedWriter) setColumnNames(names []string) {
+	w.rowType = nil
+	w.columnNames = slices.Clone(names)
 	w.resolvedColumnNames = nil
 }
 
@@ -460,6 +537,7 @@ type JSONLWriter struct {
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
 
 	columnNames         []string
+	rowType             *sppb.StructType
 	resolvedColumnNames []string
 	marshaledKeys       [][]byte
 	out                 io.Writer
@@ -503,11 +581,20 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	columnNames, err := prepareColumnNames(metadata)
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the JSONL schema from a row type before the first row is written.
+func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
+	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
 	}
-	return w.initOrValidateColumnNames(columnNames)
+	if err := w.initOrValidateColumnNames(columnNames); err != nil {
+		return err
+	}
+	w.setRowType(rowType)
+	return nil
 }
 
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
@@ -515,6 +602,16 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 		return err
 	}
 	return w.WriteGCVs(values)
+}
+
+// WriteProtoValues writes one row from protobuf values using the row type schema
+// registered by [WithRowType] or [PrepareRowType].
+func (w *JSONLWriter) WriteProtoValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromRowType(w.rowType, values)
+	if err != nil {
+		return err
+	}
+	return w.WriteGCVs(gcvs)
 }
 
 func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
@@ -549,8 +646,16 @@ func (w *JSONLWriter) Flush() error {
 	return nil
 }
 
-func (w *JSONLWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
-	w.columnNames = metadataColumnNames(metadata)
+func (w *JSONLWriter) setRowType(rowType *sppb.StructType) {
+	w.rowType = rowType
+	w.columnNames = columnNamesFromRowType(rowType)
+	w.resolvedColumnNames = nil
+	w.marshaledKeys = nil
+}
+
+func (w *JSONLWriter) setColumnNames(names []string) {
+	w.rowType = nil
+	w.columnNames = slices.Clone(names)
 	w.resolvedColumnNames = nil
 	w.marshaledKeys = nil
 }
@@ -607,6 +712,7 @@ type SQLInsertWriter struct {
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
+	rowType           *sppb.StructType
 	columnNames       []string
 	quotedColumnNames string
 	quotedTable       string
@@ -652,12 +758,20 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	columnNames, err := prepareColumnNames(metadata)
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
+// PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
+func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
+	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
 	}
-	_, err = w.initOrValidateQuotedColumns(columnNames)
-	return err
+	if _, err := w.initOrValidateQuotedColumns(columnNames); err != nil {
+		return err
+	}
+	w.setRowType(rowType)
+	return nil
 }
 
 func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
@@ -666,6 +780,16 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 		return err
 	}
 	return w.writeGCVs(values, quotedColumns)
+}
+
+// WriteProtoValues writes one row from protobuf values using the row type schema
+// registered by [WithRowType] or [PrepareRowType].
+func (w *SQLInsertWriter) WriteProtoValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromRowType(w.rowType, values)
+	if err != nil {
+		return err
+	}
+	return w.WriteGCVs(gcvs)
 }
 
 func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
@@ -715,8 +839,15 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	return err
 }
 
-func (w *SQLInsertWriter) setMetadata(metadata *sppb.ResultSetMetadata) {
-	w.columnNames = metadataColumnNames(metadata)
+func (w *SQLInsertWriter) setRowType(rowType *sppb.StructType) {
+	w.rowType = rowType
+	w.columnNames = columnNamesFromRowType(rowType)
+	w.quotedColumnNames = ""
+}
+
+func (w *SQLInsertWriter) setColumnNames(names []string) {
+	w.rowType = nil
+	w.columnNames = slices.Clone(names)
 	w.quotedColumnNames = ""
 }
 
@@ -847,24 +978,56 @@ func jsonFormatter(fc *spanvalue.FormatConfig) *spanvalue.FormatConfig {
 	return spanvalue.JSONFormatConfig()
 }
 
-func prepareColumnNames(metadata *sppb.ResultSetMetadata) ([]string, error) {
-	columnNames := metadataColumnNames(metadata)
+func prepareRowType(rowType *sppb.StructType) ([]string, error) {
+	columnNames := columnNamesFromRowType(rowType)
 	if len(columnNames) == 0 {
 		return nil, ErrMissingColumnNames
 	}
 	return columnNames, nil
 }
 
-func metadataColumnNames(metadata *sppb.ResultSetMetadata) []string {
-	if metadata == nil || metadata.GetRowType() == nil {
+func rowTypeFromMetadata(metadata *sppb.ResultSetMetadata) *sppb.StructType {
+	if metadata == nil {
 		return nil
 	}
-	fields := metadata.GetRowType().GetFields()
+	return metadata.GetRowType()
+}
+
+func columnNamesFromRowType(rowType *sppb.StructType) []string {
+	if rowType == nil {
+		return nil
+	}
+	fields := rowType.GetFields()
 	names := make([]string, len(fields))
 	for i, field := range fields {
-		names[i] = field.GetName()
+		if field != nil {
+			names[i] = field.GetName()
+		}
 	}
 	return names
+}
+
+func gcvsFromRowType(rowType *sppb.StructType, values []*structpb.Value) ([]spanner.GenericColumnValue, error) {
+	if rowType == nil {
+		return nil, ErrMissingRowType
+	}
+	fields := rowType.GetFields()
+	if len(values) != len(fields) {
+		return nil, fmt.Errorf("%w: got %d values for %d fields", ErrMismatchedProtoValueCount, len(values), len(fields))
+	}
+	gcvs := make([]spanner.GenericColumnValue, len(values))
+	for i, value := range values {
+		field := fields[i]
+		if field == nil {
+			return nil, fmt.Errorf("column %d: %w", i, spanvalue.ErrNilStructField)
+		}
+		gcv, err := spanvalue.GenericColumnValueOf(field.GetType(), value)
+		if err != nil {
+			return nil, fmt.Errorf("column %d: %w", i, err)
+		}
+		gcvs[i] = gcv
+	}
+	return gcvs, nil
 }
 
 // initOrValidateColumnNames initializes dst from the first non-empty

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -41,8 +41,9 @@
 // types (internal columnSchema) and are required for [WriteStructValues].
 // [WithColumnNames] stores names only; types come from each GCV in [WriteGCVs].
 //
-// [DelimitedWriter.Prepare] is deprecated; use PrepareRowType or
-// PrepareColumnNames, or With options at construction.
+// [DelimitedWriter.Prepare] is formally deprecated (see its Deprecated note);
+// use PrepareRowType(metadata.GetRowType()), PrepareColumnNames, or With
+// options at construction.
 //
 // Row write layers (high to low):
 //
@@ -222,8 +223,8 @@ type metadataOption struct {
 }
 
 // WithMetadata initializes a writer schema from metadata.GetRowType(), including
-// field types for WriteStructValues. Other metadata fields are ignored.
-// Prefer [WithRowType] when metadata is not available.
+// field types for [WriteStructValues]. Other metadata fields are ignored.
+// Equivalent to WithRowType(metadata.GetRowType()).
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -245,6 +246,7 @@ type rowTypeOption struct {
 }
 
 // WithRowType initializes a writer schema from a Spanner row type.
+// When the schema comes from a query result, pass metadata.GetRowType().
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -408,17 +410,18 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 }
 
 // Prepare initializes the delimited schema from result-set metadata before the first
-// row is written. If a schema is already initialized, Prepare verifies that the
-// metadata column names match the existing schema.
+// row is written.
 //
-// Deprecated: Use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames],
-// or With options at construction.
+// Deprecated: Use [DelimitedWriter.PrepareRowType] with metadata.GetRowType(),
+// [DelimitedWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or
+// [WithMetadata] instead.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the delimited schema from a row type before the first
-// row is written. If a schema is already initialized, column names must match.
+// row is written. When only result-set metadata is available, pass
+// metadata.GetRowType(). If a schema is already initialized, column names must match.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -654,13 +657,14 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [JSONLWriter.PrepareRowType], [JSONLWriter.PrepareColumnNames],
-// or With options at construction.
+// Deprecated: Use [JSONLWriter.PrepareRowType] with metadata.GetRowType(),
+// [JSONLWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the JSONL schema from a row type before the first row is written.
+// When only result-set metadata is available, pass metadata.GetRowType().
 func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -851,13 +855,14 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Use [SQLInsertWriter.PrepareRowType], [SQLInsertWriter.PrepareColumnNames],
-// or With options at construction.
+// Deprecated: Use [SQLInsertWriter.PrepareRowType] with metadata.GetRowType(),
+// [SQLInsertWriter.PrepareColumnNames], [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
+// When only result-set metadata is available, pass metadata.GetRowType().
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -44,9 +44,11 @@
 //     from the first row. See [WithHeader] for CSV/TSV header behavior on [DelimitedWriter].
 //   - WriteValues: not required. Every call passes column names plus GCVs and may
 //     initialize the writer on the first row.
-//   - WriteGCVs: column names must already be set via [WithColumnNames],
-//     [PrepareColumnNames], or an earlier WriteRow/WriteValues. Types come from each
-//     GCV; [WithRowType] is not used on this path.
+//   - WriteGCVs: column names must already be registered ([WithColumnNames],
+//     [WithRowType], [PrepareColumnNames], [PrepareRowType], or an earlier WriteRow/
+//     WriteValues). Formatting uses each GCV's Type. Registered field types from
+//     [WithRowType] are not read on this path but stay on the writer for
+//     [WriteStructValues].
 //   - WriteStructValues: [WithRowType], [WithMetadata], or [PrepareRowType] is
 //     required so field types are registered ([ErrMissingFieldTypes] otherwise).
 //
@@ -64,14 +66,15 @@
 //
 //   - [Writer.WriteRow]: *spanner.Row from the Spanner client.
 //   - WriteValues: column names plus []GenericColumnValue per call.
-//   - WriteGCVs: []GenericColumnValue; column names must be registered.
+//   - WriteGCVs: []GenericColumnValue; column names must be registered; types per GCV.
 //   - WriteStructValues: []*structpb.Value; field types must be registered.
 //
 // Delimited, JSONL, and SQL writers use different output encodings after spanvalue
 // formats each column; there is no shared "formatted row" interface.
 //
-// spanvalue formats cells from Type+Value pairs internally. Result-set metadata is
-// only a carrier for RowType when registering schema, not used while formatting rows.
+// spanvalue formats cells from Type+Value pairs internally. [WriteGCVs] and
+// WriteValues use each GCV's Type at format time; [columnSchema].types is for
+// [WriteStructValues] only. [WithMetadata] is only a carrier for GetRowType when registering.
 //
 // # Delimited headers
 //
@@ -248,10 +251,11 @@ type metadataOption struct {
 	metadata *sppb.ResultSetMetadata
 }
 
-// WithMetadata initializes a writer schema from metadata.GetRowType(), including
-// field types for [WriteStructValues]. Other metadata fields are ignored.
-// Equivalent to [WithRowType](metadata.GetRowType()). When metadata comes from a
-// [cloud.google.com/go/spanner.RowIterator], it is available after the first Next.
+// WithMetadata initializes column names and field types from metadata.GetRowType().
+// Same semantics as [WithRowType]: names for labeling and WriteGCVs; types for
+// [WriteStructValues] (WriteGCVs uses each GCV's Type). Other metadata fields are
+// ignored. When metadata comes from a [cloud.google.com/go/spanner.RowIterator], it is
+// available after the first Next.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
@@ -272,9 +276,11 @@ type rowTypeOption struct {
 	rowType *sppb.StructType
 }
 
-// WithRowType registers column names and field types. Required for WriteStructValues;
-// not required for WriteRow, WriteValues, or WriteGCVs. Use application schema at
-// construction, or iter.Metadata.GetRowType after the first RowIterator Next.
+// WithRowType registers column names and field types. Required for WriteStructValues.
+// For WriteGCVs and WriteValues, registered names are used and each GCV supplies its
+// own Type (schema.types is not consulted). Optional for WriteRow when rows are
+// present. Use application schema at construction, or iter.Metadata.GetRowType after
+// the first RowIterator Next.
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -295,9 +301,10 @@ type columnNamesOption struct {
 	names []string
 }
 
-// WithColumnNames registers column names only. Required before the first WriteGCVs
-// unless an earlier WriteRow or WriteValues initialized names. Not required for
-// WriteRow or WriteValues. Types on the WriteGCVs path come from each GCV.
+// WithColumnNames registers column names only and clears registered field types.
+// Use before the first WriteGCVs unless names came from WriteRow or WriteValues.
+// [WithRowType] is an alternative that also records field types for WriteStructValues.
+// Not required for WriteRow or WriteValues; cell types on WriteGCVs come from each GCV.
 func WithColumnNames(names []string) Option {
 	return columnNamesOption{names: slices.Clone(names)}
 }
@@ -467,8 +474,10 @@ func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 }
 
 // PrepareRowType registers column names and field types before the first row.
-// Same role as [WithRowType]; required for WriteStructValues, not for WriteRow or WriteValues.
-// When the row type comes from a RowIterator, use iter.Metadata.GetRowType after the first Next.
+// Same role as [WithRowType]: names for WriteGCVs/WriteValues/headers; types for
+// WriteStructValues only (WriteGCVs still uses each GCV's Type). Not required for
+// WriteRow when rows are present. When the row type comes from a RowIterator, use
+// iter.Metadata.GetRowType after the first Next.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -544,7 +553,8 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteGCVs writes one row from GCVs. Column names must already be registered
-// ([WithColumnNames], [PrepareColumnNames], or an earlier WriteRow/WriteValues).
+// ([WithColumnNames], [WithRowType], [PrepareColumnNames], [PrepareRowType], or an
+// earlier WriteRow/WriteValues). Formatting uses each GCV's Type, not schema.types.
 func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	csvWriter, err := w.csvWriter()
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -30,38 +30,42 @@
 //
 // # Schema registration and row input
 //
-// Writers need column names for labeling output (CSV headers, JSON keys, INSERT
-// column lists). Some paths also register per-column *sppb.Type values so rows
-// can be streamed as []*structpb.Value without fabricating metadata wrappers.
+// Writers need column names for CSV headers, JSON keys, and INSERT column lists.
+// Some write APIs also need registered *sppb.Type values (see below).
 //
-// With the [cloud.google.com/go/spanner] client, stream [Writer.WriteRow] after
-// Query or Read: each *spanner.Row already carries typed GenericColumnValue cells,
-// and the writer records column names from the first row. That path does not need
-// [cloud.google.com/go/spanner.RowIterator].Metadata or [WithRowType].
+// # When With* and Prepare* are required
 //
-// Register a field-type schema with [WithRowType], [WithMetadata], or
-// [DelimitedWriter.PrepareRowType] for [WriteStructValues] or when column names must
-// be fixed before the first data row. Pass a *sppb.StructType from application
-// schema at construction, or from iter.Metadata.GetRowType after the first
-// [cloud.google.com/go/spanner.RowIterator.Next] (Spanner populates metadata then,
-// not when the iterator is created). When the writer exists before the query, call
-// [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames] once the
-// row type or names are available.
+// [WithRowType], [WithMetadata], [WithColumnNames], [PrepareRowType], and
+// [PrepareColumnNames] are optional unless the write API cannot supply schema
+// by itself:
 //
-// [WithRowType] and [WithMetadata] store names plus field types (internal columnSchema)
-// and are required for [WriteStructValues]. [WithColumnNames] stores names only; types
-// come from each GCV in [WriteGCVs].
+//   - [Writer.WriteRow]: not required when at least one row is written. Each *spanner.Row
+//     supplies column names and typed GenericColumnValue cells; the writer records names
+//     from the first row. See [WithHeader] for CSV/TSV header behavior on [DelimitedWriter].
+//   - WriteValues: not required. Every call passes column names plus GCVs and may
+//     initialize the writer on the first row.
+//   - WriteGCVs: column names must already be set via [WithColumnNames],
+//     [PrepareColumnNames], or an earlier WriteRow/WriteValues. Types come from each
+//     GCV; [WithRowType] is not used on this path.
+//   - WriteStructValues: [WithRowType], [WithMetadata], or [PrepareRowType] is
+//     required so field types are registered ([ErrMissingFieldTypes] otherwise).
+//
+// Register names or types before the first data row when you use WriteStructValues,
+// create the writer before Query/Read, or need a delimited header with zero data rows
+// (see [WithHeader]). At construction use [WithRowType] or [WithColumnNames]; later use
+// Prepare* once names or types are known. When the row type comes from a
+// [cloud.google.com/go/spanner.RowIterator], read iter.Metadata after the first
+// Next (not when the iterator is created).
 //
 // [DelimitedWriter.Prepare] is formally deprecated (see its Deprecated note);
-// use [DelimitedWriter.PrepareRowType], [DelimitedWriter.PrepareColumnNames], or
-// [WithRowType] / [WithColumnNames] / [WithMetadata] instead.
+// use [PrepareRowType], [PrepareColumnNames], or With* options instead.
 //
 // Row write layers (high to low):
 //
-//   - [Writer.WriteRow]: Spanner client row (*spanner.Row).
-//   - WriteValues: explicit column names plus GCVs (may initialize names per row).
-//   - [WriteGCVs]: registered column names; each GCV carries Type and Value.
-//   - [DelimitedWriter.WriteStructValues]: registered field types; []*structpb.Value per row.
+//   - [Writer.WriteRow]: *spanner.Row from the Spanner client.
+//   - WriteValues: column names plus []GenericColumnValue per call.
+//   - WriteGCVs: []GenericColumnValue; column names must be registered.
+//   - WriteStructValues: []*structpb.Value; field types must be registered.
 //
 // Delimited, JSONL, and SQL writers use different output encodings after spanvalue
 // formats each column; there is no shared "formatted row" interface.
@@ -69,9 +73,16 @@
 // spanvalue formats cells from Type+Value pairs internally. Result-set metadata is
 // only a carrier for RowType when registering schema, not used while formatting rows.
 //
-// DelimitedWriter defaults to emitting a header row. Use [WithHeader] with false
-// for headerless CSV/TSV when names are registered but must not appear as the
-// first output line.
+// # Delimited headers
+//
+// [DelimitedWriter] defaults to [WithHeader](true). When header output is enabled,
+// the header line is written automatically immediately before the first data row,
+// once column names are known (typically from the first [Writer.WriteRow]).
+// [WithHeader](false) skips that automatic header for headerless CSV/TSV.
+//
+// WriteRow alone does not require [WithColumnNames] when rows are present. For an
+// empty result with a header, register names via [WithColumnNames], [PrepareColumnNames],
+// or [WithRowType], then call [DelimitedWriter.WriteHeader] before [Flush].
 //
 // # Compatibility constructors
 //
@@ -128,6 +139,10 @@ var (
 )
 
 // Writer writes Spanner rows to an output stream.
+//
+// WriteRow does not require [WithRowType], [WithColumnNames], or Prepare*; concrete
+// writers read column names and values from each row. See the package doc section
+// "When With* and Prepare* are required" for other write APIs.
 //
 // Writer intentionally models row streaming only. Some concrete writers also
 // implement [Flusher]; callers that own the full write lifecycle must call
@@ -257,9 +272,9 @@ type rowTypeOption struct {
 	rowType *sppb.StructType
 }
 
-// WithRowType initializes a writer schema from a Spanner row type (names and field
-// types). Use application schema at construction, or iter.Metadata.GetRowType after
-// the first [cloud.google.com/go/spanner.RowIterator.Next], not before.
+// WithRowType registers column names and field types. Required for WriteStructValues;
+// not required for WriteRow, WriteValues, or WriteGCVs. Use application schema at
+// construction, or iter.Metadata.GetRowType after the first RowIterator Next.
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -280,8 +295,9 @@ type columnNamesOption struct {
 	names []string
 }
 
-// WithColumnNames initializes a writer schema from column names only.
-// Use [DelimitedWriter.WriteGCVs] (or other WriteGCVs methods) so each row supplies types in GCVs.
+// WithColumnNames registers column names only. Required before the first WriteGCVs
+// unless an earlier WriteRow or WriteValues initialized names. Not required for
+// WriteRow or WriteValues. Types on the WriteGCVs path come from each GCV.
 func WithColumnNames(names []string) Option {
 	return columnNamesOption{names: slices.Clone(names)}
 }
@@ -336,7 +352,20 @@ func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
 	w.UnnamedFieldNamer = o.namer
 }
 
-// WithHeader sets whether DelimitedWriter writes a header before data rows.
+// WithHeader sets whether [DelimitedWriter] emits a CSV/TSV header line. The default
+// is true ([NewDelimitedWriter], [NewCSVWriter]).
+//
+// When header is true and at least one data row is written, the header is output
+// automatically immediately before the first data row, after column names are known
+// (for example from the first [DelimitedWriter.WriteRow]). No separate With* registration
+// is needed for that case.
+//
+// When header is true but no data rows are written, register column names with
+// [WithColumnNames], [PrepareColumnNames], or [WithRowType], then call
+// [DelimitedWriter.WriteHeader] before [Flush].
+//
+// WithHeader(false) suppresses the automatic header on the first data row. Column names
+// may still be registered or taken from WriteRow for correct field order in headerless export.
 func WithHeader(header bool) DelimitedOption {
 	return delimitedOptionFunc(func(w *DelimitedWriter) {
 		w.Header = header
@@ -361,9 +390,12 @@ func (s *columnSchema) applyNamesOnly(names []string) {
 }
 
 // DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
+// Header controls automatic header output; see [WithHeader] and [DelimitedWriter.WriteHeader].
 type DelimitedWriter struct {
 	Formatter *spanvalue.FormatConfig
-	Header    bool
+	// Header enables a header line before the first data row when true (default).
+	// See [WithHeader].
+	Header bool
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached header names.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
@@ -413,8 +445,10 @@ func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...Del
 	return NewDelimitedWriter(out, delimiter, options...)
 }
 
-// WriteRow writes one delimited row. Column names are taken from the row and
-// registered on the first write when not already set.
+// WriteRow writes one delimited row. Does not require With* or Prepare* when at least
+// one row is written; column names come from the row. When [DelimitedWriter.Header] is
+// true (default), the CSV/TSV header is written before the first data row. For zero data
+// rows with a header, register names and call [DelimitedWriter.WriteHeader]; see [WithHeader].
 func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 	columnNames, values, err := rowData(row)
 	if err != nil {
@@ -432,16 +466,16 @@ func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType initializes the delimited schema from a row type before the first
-// row is written. When the row type comes from a [cloud.google.com/go/spanner.RowIterator],
-// use iter.Metadata.GetRowType after the first Next. If a schema is already
-// initialized, column names must match.
+// PrepareRowType registers column names and field types before the first row.
+// Same role as [WithRowType]; required for WriteStructValues, not for WriteRow or WriteValues.
+// When the row type comes from a RowIterator, use iter.Metadata.GetRowType after the first Next.
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareColumnNames initializes the delimited schema from column names before the
-// first row is written. If a schema is already initialized, names must match.
+// PrepareColumnNames registers column names before the first row. Same role as
+// [WithColumnNames]; use before WriteGCVs or when emitting a header with no data rows.
+// Not required for WriteRow or WriteValues.
 func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
@@ -469,7 +503,10 @@ func (w *DelimitedWriter) prepareColumnNames(names []string) error {
 	return nil
 }
 
-// WriteHeader writes the delimited header once using the initialized column names.
+// WriteHeader writes the CSV/TSV header line once. Column names must already be registered
+// ([WithColumnNames], [PrepareColumnNames], [WithRowType], or an earlier WriteRow).
+// Use when [WithHeader](true) and the export has no data rows, or to emit the header
+// before streaming without relying on the first data row.
 func (w *DelimitedWriter) WriteHeader() error {
 	if w.wroteHeader {
 		return nil
@@ -497,6 +534,8 @@ func (w *DelimitedWriter) WriteHeader() error {
 	return nil
 }
 
+// WriteValues writes one row from column names and GCVs. Does not require With* or
+// Prepare*; names are passed on each call and may initialize the writer on the first row.
 func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
@@ -504,16 +543,8 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 	return w.WriteGCVs(values)
 }
 
-// WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
-func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromStructValues(w.schema.types, values)
-	if err != nil {
-		return err
-	}
-	return w.WriteGCVs(gcvs)
-}
-
+// WriteGCVs writes one row from GCVs. Column names must already be registered
+// ([WithColumnNames], [PrepareColumnNames], or an earlier WriteRow/WriteValues).
 func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	csvWriter, err := w.csvWriter()
 	if err != nil {
@@ -539,6 +570,16 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	}
 	w.wroteData = true
 	return nil
+}
+
+// WriteStructValues writes one row from structpb values using the field-type schema
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromStructValues(w.schema.types, values)
+	if err != nil {
+		return err
+	}
+	return w.WriteGCVs(gcvs)
 }
 
 func (w *DelimitedWriter) setRowType(rowType *sppb.StructType) {
@@ -659,6 +700,7 @@ func newJSONLWriter(out io.Writer) *JSONLWriter {
 	}
 }
 
+// WriteRow writes one JSONL row. Does not require With* or Prepare*; see [DelimitedWriter.WriteRow].
 func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 	columnNames, values, err := rowData(row)
 	if err != nil {
@@ -677,14 +719,12 @@ func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType initializes the JSONL schema from a row type before the first row is written.
-// When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use
-// iter.Metadata.GetRowType after the first Next.
+// PrepareRowType registers names and field types; see [DelimitedWriter.PrepareRowType].
 func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareColumnNames initializes the JSONL schema from column names before the first row is written.
+// PrepareColumnNames registers column names; see [DelimitedWriter.PrepareColumnNames].
 func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
@@ -712,6 +752,7 @@ func (w *JSONLWriter) prepareColumnNames(names []string) error {
 	return nil
 }
 
+// WriteValues writes one row; see [DelimitedWriter.WriteValues].
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
@@ -719,8 +760,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 	return w.WriteGCVs(values)
 }
 
-// WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// WriteStructValues writes one row; see [DelimitedWriter.WriteStructValues].
 func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
@@ -729,6 +769,7 @@ func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
 	return w.WriteGCVs(gcvs)
 }
 
+// WriteGCVs writes one row; see [DelimitedWriter.WriteGCVs].
 func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if w.out == nil {
 		return ErrNilOutputWriter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -25,8 +25,7 @@
 // INSERT OR UPDATE are valid Spanner GoogleSQL DML forms; see the INSERT section
 // in https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
 // Constructors accept options such as [WithRowType], [WithColumnNames],
-// [WithMetadata], and [WithFormatter]. When schema is known only after
-// construction, call the matching Prepare method on the concrete writer.
+// [WithMetadata], and [WithFormatter].
 // [RowData], [FormatDelimitedRow], and [FormatJSONLRow] support one-row paths.
 //
 // # Schema registration and row input
@@ -35,17 +34,13 @@
 // column lists). Some paths also register per-column *sppb.Type values so rows
 // can be streamed as []*structpb.Value without fabricating metadata wrappers.
 //
-// Prefer registering schema with [WithRowType], [WithColumnNames], or
-// [WithMetadata] at construction. When schema is known only after construction,
-// call [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames].
-// For metadata only: PrepareRowType(metadata.GetRowType()).
+// Register schema with [WithRowType], [WithColumnNames], or [WithMetadata] at
+// construction. [WithRowType] and [WithMetadata] store names plus field types
+// (internal columnSchema) and are required for [WriteStructValues].
+// [WithColumnNames] stores names only; types come from each GCV in [WriteGCVs].
 //
-//   - [WithRowType] / PrepareRowType: names plus field types (internal columnSchema).
-//     Required for [WriteStructValues].
-//   - [WithColumnNames] / PrepareColumnNames: names only; types come from each GCV.
-//   - [WithMetadata]: metadata.GetRowType(); other metadata fields are ignored.
-//
-// [DelimitedWriter.Prepare] is deprecated; use PrepareRowType or PrepareColumnNames.
+// [DelimitedWriter.Prepare] is deprecated late-binding for result-set metadata
+// only; prefer constructing the writer with With options when possible.
 //
 // Row write layers (high to low):
 //
@@ -414,15 +409,12 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
-// construction, or [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+	return w.prepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType initializes the delimited schema from a row type before the first
-// row is written. If a schema is already initialized, column names must match.
-func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
+func (w *DelimitedWriter) prepareRowType(rowType *sppb.StructType) error {
 	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
@@ -431,19 +423,6 @@ func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 		return err
 	}
 	w.setRowType(rowType)
-	return nil
-}
-
-// PrepareColumnNames initializes the delimited schema from column names before the
-// first row is written. If a schema is already initialized, names must match.
-func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
-	if len(names) == 0 {
-		return ErrMissingColumnNames
-	}
-	if err := w.initOrValidateColumnNames(names); err != nil {
-		return err
-	}
-	w.setColumnNames(names)
 	return nil
 }
 
@@ -483,7 +462,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// registered by [WithRowType] or [WithMetadata].
 func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
@@ -649,14 +628,12 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
-// construction, or [JSONLWriter.PrepareRowType] / [JSONLWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+	return w.prepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType initializes the JSONL schema from a row type before the first row is written.
-func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
+func (w *JSONLWriter) prepareRowType(rowType *sppb.StructType) error {
 	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
@@ -668,18 +645,6 @@ func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return nil
 }
 
-// PrepareColumnNames initializes the JSONL schema from column names before the first row is written.
-func (w *JSONLWriter) PrepareColumnNames(names []string) error {
-	if len(names) == 0 {
-		return ErrMissingColumnNames
-	}
-	if err := w.initOrValidateColumnNames(names); err != nil {
-		return err
-	}
-	w.setColumnNames(names)
-	return nil
-}
-
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
@@ -688,7 +653,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// registered by [WithRowType] or [WithMetadata].
 func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
@@ -838,14 +803,12 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
-// construction, or [SQLInsertWriter.PrepareRowType] / [SQLInsertWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at construction.
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+	return w.prepareRowType(rowTypeFromMetadata(metadata))
 }
 
-// PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
-func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
+func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
 	columnNames, err := prepareRowType(rowType)
 	if err != nil {
 		return err
@@ -858,8 +821,7 @@ func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return nil
 }
 
-// PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
-func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
+func (w *SQLInsertWriter) prepareColumnNames(names []string) error {
 	if len(names) == 0 {
 		return ErrMissingColumnNames
 	}
@@ -879,7 +841,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// registered by [WithRowType] or [WithMetadata].
 func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -850,12 +850,12 @@ func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	if err != nil {
 		return err
 	}
-	if _, err := validatedColumnNames(w.schema.names, columnNames); err != nil {
+	if _, err := w.initOrValidateQuotedColumns(columnNames); err != nil {
 		return err
 	}
-	w.setRowType(rowType)
-	_, err = w.initOrValidateQuotedColumns(columnNames)
-	return err
+	w.schema.names = columnNamesFromRowType(rowType)
+	w.schema.types = fieldTypesFromRowType(rowType)
+	return nil
 }
 
 // PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
@@ -863,12 +863,11 @@ func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
 	if len(names) == 0 {
 		return ErrMissingColumnNames
 	}
-	if _, err := validatedColumnNames(w.schema.names, names); err != nil {
+	if _, err := w.initOrValidateQuotedColumns(names); err != nil {
 		return err
 	}
-	w.setColumnNames(names)
-	_, err := w.initOrValidateQuotedColumns(names)
-	return err
+	w.schema.types = nil
+	return nil
 }
 
 func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -38,8 +38,8 @@
 // (the same two shapes as the With options). There is no separate Prepare API
 // for metadata: use [WithMetadata] or PrepareRowType(metadata.GetRowType()).
 //
-//   - [WithRowType] / PrepareRowType: *sppb.StructType (names and field types).
-//     Required for WriteProtoValues.
+//   - [WithRowType] / PrepareRowType: column names plus per-column field types
+//     (stored as names and types slices). Required for WriteProtoValues.
 //   - [WithColumnNames] / PrepareColumnNames: names only; GCV rows supply types.
 //   - [WithMetadata]: metadata.GetRowType() (other metadata fields ignored).
 //
@@ -328,6 +328,23 @@ func WithHeader(header bool) DelimitedOption {
 	})
 }
 
+// columnSchema holds column names for output labeling and optional field types for
+// WriteProtoValues. When types is non-empty, len(types) equals len(names).
+type columnSchema struct {
+	names []string
+	types []*sppb.Type
+}
+
+func (s *columnSchema) applyRowType(rowType *sppb.StructType) {
+	s.names = columnNamesFromRowType(rowType)
+	s.types = fieldTypesFromRowType(rowType)
+}
+
+func (s *columnSchema) applyNamesOnly(names []string) {
+	s.names = slices.Clone(names)
+	s.types = nil
+}
+
 // DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
 type DelimitedWriter struct {
 	Formatter *spanvalue.FormatConfig
@@ -336,8 +353,7 @@ type DelimitedWriter struct {
 	// schema, later changes do not retroactively rewrite cached header names.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
 
-	columnNames         []string
-	rowType             *sppb.StructType
+	schema              columnSchema
 	resolvedColumnNames []string
 	out                 io.Writer
 	writer              *csv.Writer
@@ -441,7 +457,7 @@ func (w *DelimitedWriter) WriteHeader() error {
 	if err != nil {
 		return err
 	}
-	if len(w.columnNames) == 0 {
+	if len(w.schema.names) == 0 {
 		return ErrMissingColumnNames
 	}
 
@@ -466,7 +482,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 // WriteProtoValues writes one row from protobuf values using the row type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *DelimitedWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromRowType(w.rowType, values)
+	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -478,11 +494,11 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if err != nil {
 		return err
 	}
-	if len(w.columnNames) == 0 {
+	if len(w.schema.names) == 0 {
 		return ErrMissingColumnNames
 	}
 
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.columnNames, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -501,23 +517,21 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 }
 
 func (w *DelimitedWriter) setRowType(rowType *sppb.StructType) {
-	w.rowType = rowType
-	w.columnNames = columnNamesFromRowType(rowType)
+	w.schema.applyRowType(rowType)
 	w.resolvedColumnNames = nil
 }
 
 func (w *DelimitedWriter) setColumnNames(names []string) {
-	w.rowType = nil
-	w.columnNames = slices.Clone(names)
+	w.schema.applyNamesOnly(names)
 	w.resolvedColumnNames = nil
 }
 
 func (w *DelimitedWriter) initOrValidateColumnNames(columnNames []string) error {
-	initialized := len(w.columnNames) == 0
-	if err := initOrValidateColumnNames(&w.columnNames, columnNames); err != nil {
+	initialized := len(w.schema.names) == 0
+	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
 		return err
 	}
-	if initialized && len(w.columnNames) > 0 {
+	if initialized && len(w.schema.names) > 0 {
 		w.resolvedColumnNames = nil
 	}
 	return nil
@@ -567,13 +581,13 @@ func (w *DelimitedWriter) Flush() error {
 }
 
 func (w *DelimitedWriter) resolvedNames() ([]string, error) {
-	if len(w.resolvedColumnNames) != 0 || len(w.columnNames) == 0 {
+	if len(w.resolvedColumnNames) != 0 || len(w.schema.names) == 0 {
 		return w.resolvedColumnNames, nil
 	}
 	if w.UnnamedFieldNamer == nil {
-		return w.columnNames, nil
+		return w.schema.names, nil
 	}
-	resolvedNames, err := internal.ResolveColumnNames(w.columnNames, w.UnnamedFieldNamer)
+	resolvedNames, err := internal.ResolveColumnNames(w.schema.names, w.UnnamedFieldNamer)
 	if err != nil {
 		return nil, err
 	}
@@ -588,8 +602,7 @@ type JSONLWriter struct {
 	// schema, later changes do not retroactively rewrite cached object keys.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
 
-	columnNames         []string
-	rowType             *sppb.StructType
+	schema              columnSchema
 	resolvedColumnNames []string
 	marshaledKeys       [][]byte
 	out                 io.Writer
@@ -674,7 +687,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 // WriteProtoValues writes one row from protobuf values using the row type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *JSONLWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromRowType(w.rowType, values)
+	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -685,10 +698,10 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}
-	if len(w.columnNames) == 0 {
+	if len(w.schema.names) == 0 {
 		return ErrMissingColumnNames
 	}
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.columnNames, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -714,25 +727,23 @@ func (w *JSONLWriter) Flush() error {
 }
 
 func (w *JSONLWriter) setRowType(rowType *sppb.StructType) {
-	w.rowType = rowType
-	w.columnNames = columnNamesFromRowType(rowType)
+	w.schema.applyRowType(rowType)
 	w.resolvedColumnNames = nil
 	w.marshaledKeys = nil
 }
 
 func (w *JSONLWriter) setColumnNames(names []string) {
-	w.rowType = nil
-	w.columnNames = slices.Clone(names)
+	w.schema.applyNamesOnly(names)
 	w.resolvedColumnNames = nil
 	w.marshaledKeys = nil
 }
 
 func (w *JSONLWriter) initOrValidateColumnNames(columnNames []string) error {
-	initialized := len(w.columnNames) == 0
-	if err := initOrValidateColumnNames(&w.columnNames, columnNames); err != nil {
+	initialized := len(w.schema.names) == 0
+	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
 		return err
 	}
-	if initialized && len(w.columnNames) > 0 {
+	if initialized && len(w.schema.names) > 0 {
 		w.resolvedColumnNames = nil
 		w.marshaledKeys = nil
 	}
@@ -747,13 +758,13 @@ func (w *JSONLWriter) formatter() *spanvalue.FormatConfig {
 }
 
 func (w *JSONLWriter) resolvedNames() ([]string, error) {
-	if len(w.resolvedColumnNames) != 0 || len(w.columnNames) == 0 {
+	if len(w.resolvedColumnNames) != 0 || len(w.schema.names) == 0 {
 		return w.resolvedColumnNames, nil
 	}
 	if w.UnnamedFieldNamer == nil {
-		return w.columnNames, nil
+		return w.schema.names, nil
 	}
-	resolvedNames, err := internal.ResolveColumnNames(w.columnNames, w.UnnamedFieldNamer)
+	resolvedNames, err := internal.ResolveColumnNames(w.schema.names, w.UnnamedFieldNamer)
 	if err != nil {
 		return nil, err
 	}
@@ -779,8 +790,7 @@ type SQLInsertWriter struct {
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
-	rowType           *sppb.StructType
-	columnNames       []string
+	schema            columnSchema
 	quotedColumnNames string
 	quotedTable       string
 	quotedTableInput  string
@@ -864,7 +874,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 // WriteProtoValues writes one row from protobuf values using the row type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *SQLInsertWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromRowType(w.rowType, values)
+	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -896,7 +906,7 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if err != nil {
 		return err
 	}
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.columnNames, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -919,14 +929,12 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 }
 
 func (w *SQLInsertWriter) setRowType(rowType *sppb.StructType) {
-	w.rowType = rowType
-	w.columnNames = columnNamesFromRowType(rowType)
+	w.schema.applyRowType(rowType)
 	w.quotedColumnNames = ""
 }
 
 func (w *SQLInsertWriter) setColumnNames(names []string) {
-	w.rowType = nil
-	w.columnNames = slices.Clone(names)
+	w.schema.applyNamesOnly(names)
 	w.quotedColumnNames = ""
 }
 
@@ -941,7 +949,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if len(columnNames) == 0 && w.quotedColumnNames != "" {
 		return w.quotedColumnNames, nil
 	}
-	names, err := validatedColumnNames(w.columnNames, columnNames)
+	names, err := validatedColumnNames(w.schema.names, columnNames)
 	if err != nil {
 		return "", err
 	}
@@ -949,8 +957,8 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if err != nil {
 		return "", err
 	}
-	if len(w.columnNames) == 0 {
-		w.columnNames = names
+	if len(w.schema.names) == 0 {
+		w.schema.names = names
 	}
 	w.quotedColumnNames = strings.Join(quotedColumns, ", ")
 	return w.quotedColumnNames, nil
@@ -1086,21 +1094,34 @@ func columnNamesFromRowType(rowType *sppb.StructType) []string {
 	return names
 }
 
-func gcvsFromRowType(rowType *sppb.StructType, values []*structpb.Value) ([]spanner.GenericColumnValue, error) {
+func fieldTypesFromRowType(rowType *sppb.StructType) []*sppb.Type {
 	if rowType == nil {
-		return nil, ErrMissingRowType
+		return nil
 	}
 	fields := rowType.GetFields()
-	if len(values) != len(fields) {
-		return nil, fmt.Errorf("%w: got %d values for %d fields", ErrMismatchedProtoValueCount, len(values), len(fields))
+	types := make([]*sppb.Type, len(fields))
+	for i, field := range fields {
+		if field != nil {
+			types[i] = field.GetType()
+		}
+	}
+	return types
+}
+
+func gcvsFromFieldTypes(types []*sppb.Type, values []*structpb.Value) ([]spanner.GenericColumnValue, error) {
+	if len(types) == 0 {
+		return nil, ErrMissingRowType
+	}
+	if len(values) != len(types) {
+		return nil, fmt.Errorf("%w: got %d values for %d fields", ErrMismatchedProtoValueCount, len(values), len(types))
 	}
 	gcvs := make([]spanner.GenericColumnValue, len(values))
 	for i, value := range values {
-		field := fields[i]
-		if field == nil {
+		typ := types[i]
+		if typ == nil {
 			return nil, fmt.Errorf("column %d: %w", i, spanvalue.ErrNilStructField)
 		}
-		gcv, err := spanvalue.GenericColumnValueOf(field.GetType(), value)
+		gcv, err := spanvalue.GenericColumnValueOf(typ, value)
 		if err != nil {
 			return nil, fmt.Errorf("column %d: %w", i, err)
 		}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -847,20 +847,25 @@ func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	if err != nil {
 		return err
 	}
-	if _, err := w.initOrValidateQuotedColumns(columnNames); err != nil {
+	if _, err := validatedColumnNames(w.schema.names, columnNames); err != nil {
 		return err
 	}
 	w.setRowType(rowType)
-	return nil
+	_, err = w.initOrValidateQuotedColumns(columnNames)
+	return err
 }
 
 // PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
 func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
-	if _, err := w.initOrValidateQuotedColumns(names); err != nil {
+	if len(names) == 0 {
+		return ErrMissingColumnNames
+	}
+	if _, err := validatedColumnNames(w.schema.names, names); err != nil {
 		return err
 	}
 	w.setColumnNames(names)
-	return nil
+	_, err := w.initOrValidateQuotedColumns(names)
+	return err
 }
 
 func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -32,17 +32,19 @@
 // column lists). Some call paths also need a Spanner row type (field types) to
 // build rows from []*structpb.Value without pre-built GCVs.
 //
-// Register schema at construction or with Prepare:
+// Prefer registering schema with [WithRowType], [WithColumnNames], or
+// [WithMetadata] at construction. When schema is known only after construction,
+// call [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames]
+// (the same two shapes as the With options). There is no separate Prepare API
+// for metadata: use [WithMetadata] or PrepareRowType(metadata.GetRowType()).
 //
-//   - [WithRowType] / [DelimitedWriter.PrepareRowType]: stores *sppb.StructType
-//     (names plus field types). Required for [DelimitedWriter.WriteProtoValues]
-//     and the JSONL/SQL equivalents.
-//   - [WithColumnNames] / [DelimitedWriter.PrepareColumnNames]: stores names only.
-//     Row types come from each GCV when using WriteGCVs.
-//   - [WithMetadata] / [DelimitedWriter.PrepareMetadata]: stores
-//     metadata.GetRowType() (same as WithRowType). Other ResultSetMetadata
-//     fields are ignored. [DelimitedWriter.Prepare] is deprecated; prefer
-//     PrepareMetadata, PrepareRowType, or PrepareColumnNames.
+//   - [WithRowType] / PrepareRowType: *sppb.StructType (names and field types).
+//     Required for WriteProtoValues.
+//   - [WithColumnNames] / PrepareColumnNames: names only; GCV rows supply types.
+//   - [WithMetadata]: metadata.GetRowType() (other metadata fields ignored).
+//
+// [DelimitedWriter.Prepare] remains as a deprecated alias for
+// PrepareRowType(metadata.GetRowType()).
 //
 // Per-row writes:
 //
@@ -393,16 +395,9 @@ func (w *DelimitedWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [DelimitedWriter.PrepareMetadata], [DelimitedWriter.PrepareRowType],
-// or [DelimitedWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
+// construction, or [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames].
 func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareMetadata(metadata)
-}
-
-// PrepareMetadata initializes the delimited schema from result-set metadata before
-// the first row is written. Only metadata.GetRowType() is used; other metadata
-// fields are ignored. If a schema is already initialized, column names must match.
-func (w *DelimitedWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -469,7 +464,7 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *DelimitedWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {
@@ -638,15 +633,9 @@ func (w *JSONLWriter) WriteRow(row *spanner.Row) error {
 // row is written. If a schema is already initialized, Prepare verifies that the
 // metadata column names match the existing schema.
 //
-// Deprecated: Use [JSONLWriter.PrepareMetadata], [JSONLWriter.PrepareRowType],
-// or [JSONLWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
+// construction, or [JSONLWriter.PrepareRowType] / [JSONLWriter.PrepareColumnNames].
 func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareMetadata(metadata)
-}
-
-// PrepareMetadata initializes the JSONL schema from result-set metadata before the
-// first row is written. Only metadata.GetRowType() is used.
-func (w *JSONLWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -683,7 +672,7 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *JSONLWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {
@@ -836,15 +825,9 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // first row is written. If a schema is already initialized, Prepare verifies
 // that the metadata column names match the existing schema.
 //
-// Deprecated: Use [SQLInsertWriter.PrepareMetadata], [SQLInsertWriter.PrepareRowType],
-// or [SQLInsertWriter.PrepareColumnNames].
+// Deprecated: Prefer [WithRowType], [WithColumnNames], or [WithMetadata] at
+// construction, or [SQLInsertWriter.PrepareRowType] / [SQLInsertWriter.PrepareColumnNames].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareMetadata(metadata)
-}
-
-// PrepareMetadata initializes the SQL INSERT schema from result-set metadata before
-// the first row is written. Only metadata.GetRowType() is used.
-func (w *SQLInsertWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
@@ -879,7 +862,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteProtoValues writes one row from protobuf values using the row type schema
-// registered by [WithRowType], [WithMetadata], [PrepareRowType], or [PrepareMetadata].
+// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
 func (w *SQLInsertWriter) WriteProtoValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromRowType(w.rowType, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -32,7 +32,7 @@
 // Names only: [WithColumnNames], PrepareColumnNames. Names and types: [WithRowType],
 // [WithMetadata], PrepareRowType. [WithMetadata] uses metadata.GetRowType(); from a
 // [cloud.google.com/go/spanner.RowIterator], Metadata is set after the first Next.
-// [DelimitedWriter.Prepare] is deprecated.
+// [DelimitedWriter.Prepare], [JSONLWriter.Prepare], and [SQLInsertWriter.Prepare] are deprecated.
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
 // before the first data row, or on [DelimitedWriter.Flush] when no data row was written.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -9,10 +9,13 @@
 // names avoid collisions with existing names. DelimitedWriter buffers through
 // encoding/csv, so callers must call Flush after the final write.
 //
-// Use Writer when an adapter only needs row streaming, and FlushWriter when it
-// owns the full write lifecycle. DelimitedWriter, JSONLWriter, and SQLInsertWriter
-// implement FlushWriter. If an adapter exposes a Close method, that Close
-// method should call Flush; Flush does not close the underlying io.Writer.
+// Use [Writer] when an adapter only streams [cloud.google.com/go/spanner.Row]
+// values from the Spanner client. Use [DelimitedWriter.WriteStructValues] on a concrete writer
+// when the row is already represented as []*structpb.Value plus a registered
+// field-type schema (spannerpb + structpb only at the writer boundary). Use
+// [DelimitedWriter.WriteGCVs] when each cell is already a GenericColumnValue.
+// [FlushWriter] covers writers that need finalization; call Flush after the
+// last row. Flush does not close the underlying io.Writer.
 //
 // # Primary API
 //
@@ -29,33 +32,33 @@
 // # Schema registration and row input
 //
 // Writers need column names for labeling output (CSV headers, JSON keys, INSERT
-// column lists). Some call paths also need a Spanner row type (field types) to
-// build rows from []*structpb.Value without pre-built GCVs.
+// column lists). Some paths also register per-column *sppb.Type values so rows
+// can be streamed as []*structpb.Value without fabricating metadata wrappers.
 //
 // Prefer registering schema with [WithRowType], [WithColumnNames], or
 // [WithMetadata] at construction. When schema is known only after construction,
-// call [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames]
-// (the same two shapes as the With options). There is no separate Prepare API
-// for metadata: use [WithMetadata] or PrepareRowType(metadata.GetRowType()).
+// call [DelimitedWriter.PrepareRowType] or [DelimitedWriter.PrepareColumnNames].
+// For metadata only: PrepareRowType(metadata.GetRowType()).
 //
-//   - [WithRowType] / PrepareRowType: column names plus per-column field types
-//     (stored as names and types slices). Required for WriteProtoValues.
-//   - [WithColumnNames] / PrepareColumnNames: names only; GCV rows supply types.
-//   - [WithMetadata]: metadata.GetRowType() (other metadata fields ignored).
+//   - [WithRowType] / PrepareRowType: names plus field types (internal columnSchema).
+//     Required for [WriteStructValues].
+//   - [WithColumnNames] / PrepareColumnNames: names only; types come from each GCV.
+//   - [WithMetadata]: metadata.GetRowType(); other metadata fields are ignored.
 //
-// [DelimitedWriter.Prepare] remains as a deprecated alias for
-// PrepareRowType(metadata.GetRowType()).
+// [DelimitedWriter.Prepare] is deprecated; use PrepareRowType or PrepareColumnNames.
 //
-// Per-row writes:
+// Row write layers (high to low):
 //
-//   - WriteRow / WriteValues: full *spanner.Row or explicit names plus GCVs.
-//   - WriteGCVs: column names must be set; each GCV supplies Type and Value.
-//   - WriteProtoValues: row type must be set; values are []*structpb.Value
-//     paired with fields[i].Type (nil type is an error).
+//   - [Writer.WriteRow]: Spanner client row (*spanner.Row).
+//   - WriteValues: explicit column names plus GCVs (may initialize names per row).
+//   - [WriteGCVs]: registered column names; each GCV carries Type and Value.
+//   - [DelimitedWriter.WriteStructValues]: registered field types; []*structpb.Value per row.
 //
-// Formatting always uses GCV Type and Value at format time. ResultSetMetadata is
-// not consulted while formatting a row; it is only a convenient carrier for
-// RowType when callers already have query metadata.
+// Delimited, JSONL, and SQL writers use different output encodings after spanvalue
+// formats each column; there is no shared "formatted row" interface.
+//
+// spanvalue formats cells from Type+Value pairs internally. ResultSetMetadata is
+// only a carrier for RowType when registering schema, not used while formatting.
 //
 // DelimitedWriter defaults to emitting a header row. Use [WithHeader] with false
 // for headerless CSV/TSV when names are registered but must not appear as the
@@ -109,10 +112,10 @@ var (
 	ErrHeaderAfterData = errors.New("header after data")
 	// ErrInvalidDelimiter reports that DelimitedWriter received an invalid delimiter.
 	ErrInvalidDelimiter = errors.New("invalid delimiter")
-	// ErrMissingRowType reports that WriteProtoValues requires a row type schema.
-	ErrMissingRowType = errors.New("missing row type schema")
-	// ErrMismatchedProtoValueCount reports that WriteProtoValues value count does not match the row type.
-	ErrMismatchedProtoValueCount = errors.New("mismatched proto value count")
+	// ErrMissingFieldTypes reports that WriteStructValues requires registered field types.
+	ErrMissingFieldTypes = errors.New("missing field types schema")
+	// ErrMismatchedStructValueCount reports that WriteStructValues value count does not match the schema.
+	ErrMismatchedStructValueCount = errors.New("mismatched struct value count")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -222,7 +225,7 @@ type metadataOption struct {
 }
 
 // WithMetadata initializes a writer schema from metadata.GetRowType(), including
-// field types for WriteProtoValues. Other metadata fields are ignored.
+// field types for WriteStructValues. Other metadata fields are ignored.
 // Prefer [WithRowType] when metadata is not available.
 func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
@@ -329,7 +332,7 @@ func WithHeader(header bool) DelimitedOption {
 }
 
 // columnSchema holds column names for output labeling and optional field types for
-// WriteProtoValues. When types is non-empty, len(types) equals len(names).
+// WriteStructValues. When types is non-empty, len(types) equals len(names).
 type columnSchema struct {
 	names []string
 	types []*sppb.Type
@@ -479,10 +482,10 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 	return w.WriteGCVs(values)
 }
 
-// WriteProtoValues writes one row from protobuf values using the row type schema
+// WriteStructValues writes one row from structpb values using the field-type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
-func (w *DelimitedWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
+func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -684,10 +687,10 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 	return w.WriteGCVs(values)
 }
 
-// WriteProtoValues writes one row from protobuf values using the row type schema
+// WriteStructValues writes one row from structpb values using the field-type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
-func (w *JSONLWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
+func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -876,10 +879,10 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 	return w.writeGCVs(values, quotedColumns)
 }
 
-// WriteProtoValues writes one row from protobuf values using the row type schema
+// WriteStructValues writes one row from structpb values using the field-type schema
 // registered by [WithRowType], [WithMetadata], or [PrepareRowType].
-func (w *SQLInsertWriter) WriteProtoValues(values []*structpb.Value) error {
-	gcvs, err := gcvsFromFieldTypes(w.schema.types, values)
+func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
+	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
 	}
@@ -1113,20 +1116,23 @@ func fieldTypesFromRowType(rowType *sppb.StructType) []*sppb.Type {
 	return types
 }
 
-func gcvsFromFieldTypes(types []*sppb.Type, values []*structpb.Value) ([]spanner.GenericColumnValue, error) {
+func gcvFromTypeValue(typ *sppb.Type, value *structpb.Value) (spanner.GenericColumnValue, error) {
+	if typ == nil {
+		return spanner.GenericColumnValue{}, spanvalue.ErrNilStructField
+	}
+	return spanner.GenericColumnValue{Type: typ, Value: value}, nil
+}
+
+func gcvsFromStructValues(types []*sppb.Type, values []*structpb.Value) ([]spanner.GenericColumnValue, error) {
 	if len(types) == 0 {
-		return nil, ErrMissingRowType
+		return nil, ErrMissingFieldTypes
 	}
 	if len(values) != len(types) {
-		return nil, fmt.Errorf("%w: got %d values for %d fields", ErrMismatchedProtoValueCount, len(values), len(types))
+		return nil, fmt.Errorf("%w: got %d values for %d fields", ErrMismatchedStructValueCount, len(values), len(types))
 	}
 	gcvs := make([]spanner.GenericColumnValue, len(values))
 	for i, value := range values {
-		typ := types[i]
-		if typ == nil {
-			return nil, fmt.Errorf("column %d: %w", i, spanvalue.ErrNilStructField)
-		}
-		gcv, err := spanvalue.GenericColumnValueOf(typ, value)
+		gcv, err := gcvFromTypeValue(types[i], value)
 		if err != nil {
 			return nil, fmt.Errorf("column %d: %w", i, err)
 		}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1100,16 +1100,16 @@ func TestWithColumnNamesWriteGCVs(t *testing.T) {
 	}
 }
 
-func TestWithRowTypeWriteProtoValues(t *testing.T) {
+func TestWithRowTypeWriteStructValues(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
 	w := NewJSONLWriter(&out, WithRowType(rowTypeWithColumnNames("id", "name")))
-	if err := w.WriteProtoValues([]*structpb.Value{
+	if err := w.WriteStructValues([]*structpb.Value{
 		structpb.NewStringValue("42"),
 		structpb.NewStringValue("Alice"),
 	}); err != nil {
-		t.Fatalf("WriteProtoValues() error = %v", err)
+		t.Fatalf("WriteStructValues() error = %v", err)
 	}
 
 	want := "{\"id\":42,\"name\":\"Alice\"}\n"
@@ -1118,17 +1118,17 @@ func TestWithRowTypeWriteProtoValues(t *testing.T) {
 	}
 }
 
-func TestWriteProtoValuesMissingRowType(t *testing.T) {
+func TestWriteStructValuesMissingFieldTypes(t *testing.T) {
 	t.Parallel()
 
 	w := NewDelimitedWriter(&bytes.Buffer{}, ',')
-	err := w.WriteProtoValues([]*structpb.Value{structpb.NewStringValue("1")})
-	if !errors.Is(err, ErrMissingRowType) {
-		t.Fatalf("WriteProtoValues() error = %v, want ErrMissingRowType", err)
+	err := w.WriteStructValues([]*structpb.Value{structpb.NewStringValue("1")})
+	if !errors.Is(err, ErrMissingFieldTypes) {
+		t.Fatalf("WriteStructValues() error = %v, want ErrMissingFieldTypes", err)
 	}
 }
 
-func TestWriteProtoValuesNilFieldType(t *testing.T) {
+func TestWriteStructValuesNilFieldType(t *testing.T) {
 	t.Parallel()
 
 	rowType := &sppb.StructType{
@@ -1137,9 +1137,9 @@ func TestWriteProtoValuesNilFieldType(t *testing.T) {
 		},
 	}
 	w := NewSQLInsertWriter(&bytes.Buffer{}, "users", WithRowType(rowType))
-	err := w.WriteProtoValues([]*structpb.Value{structpb.NewStringValue("1")})
+	err := w.WriteStructValues([]*structpb.Value{structpb.NewStringValue("1")})
 	if !errors.Is(err, spanvalue.ErrNilStructField) {
-		t.Fatalf("WriteProtoValues() error = %v, want ErrNilStructField", err)
+		t.Fatalf("WriteStructValues() error = %v, want ErrNilStructField", err)
 	}
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1062,6 +1062,51 @@ func TestFormatDelimitedValuesInvalidDelimiter(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterFlushWritesHeaderWithNoRows(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	want := "id,name\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDelimitedWriterFlushDoesNotDuplicateHeader(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(1),
+		gcvctor.StringValue("a"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	want := "id,name\n1,a\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDelimitedWriterFlushWithoutColumnNames(t *testing.T) {
+	t.Parallel()
+
+	err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithHeader(true)).Flush()
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("Flush() error = %v, want ErrMissingColumnNames", err)
+	}
+}
+
 func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1143,46 +1143,19 @@ func TestWriteStructValuesNilFieldType(t *testing.T) {
 	}
 }
 
-func TestDelimitedWriterPrepareColumnNames(t *testing.T) {
-	t.Parallel()
-
-	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',')
-	if err := w.PrepareColumnNames([]string{"name", "age"}); err != nil {
-		t.Fatalf("PrepareColumnNames() error = %v", err)
-	}
-	if err := w.WriteGCVs([]spanner.GenericColumnValue{
-		gcvctor.StringValue("Ada"),
-		gcvctor.Int64Value(30),
-	}); err != nil {
-		t.Fatalf("WriteGCVs() error = %v", err)
-	}
-	flushDelimitedWriter(t, w)
-
-	want := "name,age\nAda,30\n"
-	if diff := cmp.Diff(want, out.String()); diff != "" {
-		t.Fatalf("output mismatch (-want +got):\n%s", diff)
-	}
-
-	err := w.PrepareColumnNames([]string{"name", "score"})
-	if !errors.Is(err, ErrColumnNamesMismatch) {
-		t.Fatalf("PrepareColumnNames() mismatch error = %v, want ErrColumnNamesMismatch", err)
-	}
-}
-
 func TestSQLInsertWriterPrepareColumnNamesRecoversAfterQuoteError(t *testing.T) {
 	t.Parallel()
 
 	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
-	err := w.PrepareColumnNames([]string{""})
+	err := w.prepareColumnNames([]string{""})
 	if !errors.Is(err, ErrEmptyColumnName) {
-		t.Fatalf("PrepareColumnNames() error = %v, want ErrEmptyColumnName", err)
+		t.Fatalf("prepareColumnNames() error = %v, want ErrEmptyColumnName", err)
 	}
-	if err := w.PrepareColumnNames([]string{"id"}); err != nil {
-		t.Fatalf("PrepareColumnNames() retry error = %v", err)
+	if err := w.prepareColumnNames([]string{"id"}); err != nil {
+		t.Fatalf("prepareColumnNames() retry error = %v", err)
 	}
 	if w.quotedColumnNames == "" {
-		t.Fatal("quotedColumnNames not cached after successful PrepareColumnNames")
+		t.Fatal("quotedColumnNames not cached after successful prepareColumnNames")
 	}
 }
 
@@ -1190,27 +1163,21 @@ func TestSQLInsertWriterPrepareRowTypeCachesQuotedColumns(t *testing.T) {
 	t.Parallel()
 
 	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
-	if err := w.PrepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
-		t.Fatalf("PrepareRowType() error = %v", err)
+	if err := w.prepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
+		t.Fatalf("prepareRowType() error = %v", err)
 	}
 	if w.quotedColumnNames == "" {
-		t.Fatal("quotedColumnNames not cached after PrepareRowType")
+		t.Fatal("quotedColumnNames not cached after prepareRowType")
 	}
 }
 
-func TestPrepareRowTypeConsistentAcrossWriters(t *testing.T) {
+func TestWithRowTypeConsistentAcrossWriters(t *testing.T) {
 	t.Parallel()
 
-	meta := metadataWithColumnNames("id", "name")
+	rowType := rowTypeWithColumnNames("id", "name")
 	var delimited, jsonl bytes.Buffer
-	dw := NewDelimitedWriter(&delimited, ',')
-	jw := NewJSONLWriter(&jsonl)
-	if err := dw.PrepareRowType(meta.GetRowType()); err != nil {
-		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
-	}
-	if err := jw.PrepareRowType(meta.GetRowType()); err != nil {
-		t.Fatalf("JSONLWriter.PrepareRowType() error = %v", err)
-	}
+	dw := NewDelimitedWriter(&delimited, ',', WithRowType(rowType))
+	jw := NewJSONLWriter(&jsonl, WithRowType(rowType))
 	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1143,6 +1143,33 @@ func TestWriteProtoValuesNilFieldType(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterPrepareColumnNames(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',')
+	if err := w.PrepareColumnNames([]string{"name", "age"}); err != nil {
+		t.Fatalf("PrepareColumnNames() error = %v", err)
+	}
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Ada"),
+		gcvctor.Int64Value(30),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "name,age\nAda,30\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+
+	err := w.PrepareColumnNames([]string{"name", "score"})
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("PrepareColumnNames() mismatch error = %v, want ErrColumnNamesMismatch", err)
+	}
+}
+
 func TestPrepareRowTypeMatchesPrepareMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1180,8 +1180,8 @@ func TestPrepareRowTypeMatchesPrepareMetadata(t *testing.T) {
 	if err := dw.PrepareRowType(meta.GetRowType()); err != nil {
 		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
 	}
-	if err := jw.Prepare(meta); err != nil {
-		t.Fatalf("JSONLWriter.Prepare() error = %v", err)
+	if err := jw.PrepareMetadata(meta); err != nil {
+		t.Fatalf("JSONLWriter.PrepareMetadata() error = %v", err)
 	}
 	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/apstndb/spanvalue/internal"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -27,16 +28,23 @@ var (
 )
 
 func metadataWithColumnNames(names ...string) *sppb.ResultSetMetadata {
+	return &sppb.ResultSetMetadata{RowType: rowTypeWithColumnNames(names...)}
+}
+
+func rowTypeWithColumnNames(names ...string) *sppb.StructType {
 	fields := make([]*sppb.StructType_Field, len(names))
 	for i, name := range names {
+		code := sppb.TypeCode_INT64
+		switch name {
+		case "name", "note", "payload", "full_name":
+			code = sppb.TypeCode_STRING
+		}
 		fields[i] = &sppb.StructType_Field{
 			Name: name,
-			Type: &sppb.Type{Code: sppb.TypeCode_STRING},
+			Type: &sppb.Type{Code: code},
 		}
 	}
-	return &sppb.ResultSetMetadata{
-		RowType: &sppb.StructType{Fields: fields},
-	}
+	return &sppb.StructType{Fields: fields}
 }
 
 func flushDelimitedWriter(t *testing.T, w *DelimitedWriter) {
@@ -1051,5 +1059,114 @@ func TestFormatDelimitedValuesInvalidDelimiter(t *testing.T) {
 				t.Fatalf("format error = %v, want ErrInvalidDelimiter", err)
 			}
 		})
+	}
+}
+
+func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(false))
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(1),
+		gcvctor.StringValue("a"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "1,a\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithColumnNamesWriteGCVs(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, '\t', WithColumnNames([]string{"id", "name"}))
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(1),
+		gcvctor.StringValue("a"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "id\tname\n1\ta\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithRowTypeWriteProtoValues(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriter(&out, WithRowType(rowTypeWithColumnNames("id", "name")))
+	if err := w.WriteProtoValues([]*structpb.Value{
+		structpb.NewStringValue("42"),
+		structpb.NewStringValue("Alice"),
+	}); err != nil {
+		t.Fatalf("WriteProtoValues() error = %v", err)
+	}
+
+	want := "{\"id\":42,\"name\":\"Alice\"}\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWriteProtoValuesMissingRowType(t *testing.T) {
+	t.Parallel()
+
+	w := NewDelimitedWriter(&bytes.Buffer{}, ',')
+	err := w.WriteProtoValues([]*structpb.Value{structpb.NewStringValue("1")})
+	if !errors.Is(err, ErrMissingRowType) {
+		t.Fatalf("WriteProtoValues() error = %v, want ErrMissingRowType", err)
+	}
+}
+
+func TestWriteProtoValuesNilFieldType(t *testing.T) {
+	t.Parallel()
+
+	rowType := &sppb.StructType{
+		Fields: []*sppb.StructType_Field{
+			{Name: "id", Type: nil},
+		},
+	}
+	w := NewSQLInsertWriter(&bytes.Buffer{}, "users", WithRowType(rowType))
+	err := w.WriteProtoValues([]*structpb.Value{structpb.NewStringValue("1")})
+	if !errors.Is(err, spanvalue.ErrNilStructField) {
+		t.Fatalf("WriteProtoValues() error = %v, want ErrNilStructField", err)
+	}
+}
+
+func TestPrepareRowTypeMatchesPrepareMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta := metadataWithColumnNames("id", "name")
+	var delimited, jsonl bytes.Buffer
+	dw := NewDelimitedWriter(&delimited, ',')
+	jw := NewJSONLWriter(&jsonl)
+	if err := dw.PrepareRowType(meta.GetRowType()); err != nil {
+		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
+	}
+	if err := jw.Prepare(meta); err != nil {
+		t.Fatalf("JSONLWriter.Prepare() error = %v", err)
+	}
+	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if err := jw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(2), gcvctor.StringValue("b")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, dw)
+	if want := "id,name\n1,a\n"; delimited.String() != want {
+		t.Fatalf("delimited = %q, want %q", delimited.String(), want)
+	}
+	if want := "{\"id\":2,\"name\":\"b\"}\n"; jsonl.String() != want {
+		t.Fatalf("jsonl = %q, want %q", jsonl.String(), want)
 	}
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1170,6 +1170,22 @@ func TestDelimitedWriterPrepareColumnNames(t *testing.T) {
 	}
 }
 
+func TestSQLInsertWriterPrepareColumnNamesRecoversAfterQuoteError(t *testing.T) {
+	t.Parallel()
+
+	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	err := w.PrepareColumnNames([]string{""})
+	if !errors.Is(err, ErrEmptyColumnName) {
+		t.Fatalf("PrepareColumnNames() error = %v, want ErrEmptyColumnName", err)
+	}
+	if err := w.PrepareColumnNames([]string{"id"}); err != nil {
+		t.Fatalf("PrepareColumnNames() retry error = %v", err)
+	}
+	if w.quotedColumnNames == "" {
+		t.Fatal("quotedColumnNames not cached after successful PrepareColumnNames")
+	}
+}
+
 func TestSQLInsertWriterPrepareRowTypeCachesQuotedColumns(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1170,7 +1170,7 @@ func TestDelimitedWriterPrepareColumnNames(t *testing.T) {
 	}
 }
 
-func TestPrepareRowTypeMatchesPrepareMetadata(t *testing.T) {
+func TestPrepareRowTypeConsistentAcrossWriters(t *testing.T) {
 	t.Parallel()
 
 	meta := metadataWithColumnNames("id", "name")
@@ -1180,8 +1180,8 @@ func TestPrepareRowTypeMatchesPrepareMetadata(t *testing.T) {
 	if err := dw.PrepareRowType(meta.GetRowType()); err != nil {
 		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
 	}
-	if err := jw.PrepareMetadata(meta); err != nil {
-		t.Fatalf("JSONLWriter.PrepareMetadata() error = %v", err)
+	if err := jw.PrepareRowType(meta.GetRowType()); err != nil {
+		t.Fatalf("JSONLWriter.PrepareRowType() error = %v", err)
 	}
 	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1170,6 +1170,18 @@ func TestDelimitedWriterPrepareColumnNames(t *testing.T) {
 	}
 }
 
+func TestSQLInsertWriterPrepareRowTypeCachesQuotedColumns(t *testing.T) {
+	t.Parallel()
+
+	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	if err := w.PrepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if w.quotedColumnNames == "" {
+		t.Fatal("quotedColumnNames not cached after PrepareRowType")
+	}
+}
+
 func TestPrepareRowTypeConsistentAcrossWriters(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1143,19 +1143,46 @@ func TestWriteStructValuesNilFieldType(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterPrepareColumnNamesAfterConstruction(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',')
+	if err := w.PrepareColumnNames([]string{"name", "age"}); err != nil {
+		t.Fatalf("PrepareColumnNames() error = %v", err)
+	}
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.StringValue("Ada"),
+		gcvctor.Int64Value(30),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "name,age\nAda,30\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+
+	err := w.PrepareColumnNames([]string{"name", "score"})
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("PrepareColumnNames() mismatch error = %v, want ErrColumnNamesMismatch", err)
+	}
+}
+
 func TestSQLInsertWriterPrepareColumnNamesRecoversAfterQuoteError(t *testing.T) {
 	t.Parallel()
 
 	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
-	err := w.prepareColumnNames([]string{""})
+	err := w.PrepareColumnNames([]string{""})
 	if !errors.Is(err, ErrEmptyColumnName) {
-		t.Fatalf("prepareColumnNames() error = %v, want ErrEmptyColumnName", err)
+		t.Fatalf("PrepareColumnNames() error = %v, want ErrEmptyColumnName", err)
 	}
-	if err := w.prepareColumnNames([]string{"id"}); err != nil {
-		t.Fatalf("prepareColumnNames() retry error = %v", err)
+	if err := w.PrepareColumnNames([]string{"id"}); err != nil {
+		t.Fatalf("PrepareColumnNames() retry error = %v", err)
 	}
 	if w.quotedColumnNames == "" {
-		t.Fatal("quotedColumnNames not cached after successful prepareColumnNames")
+		t.Fatal("quotedColumnNames not cached after successful PrepareColumnNames")
 	}
 }
 
@@ -1163,11 +1190,39 @@ func TestSQLInsertWriterPrepareRowTypeCachesQuotedColumns(t *testing.T) {
 	t.Parallel()
 
 	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
-	if err := w.prepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
-		t.Fatalf("prepareRowType() error = %v", err)
+	if err := w.PrepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
 	}
 	if w.quotedColumnNames == "" {
-		t.Fatal("quotedColumnNames not cached after prepareRowType")
+		t.Fatal("quotedColumnNames not cached after PrepareRowType")
+	}
+}
+
+func TestPrepareRowTypeAfterConstruction(t *testing.T) {
+	t.Parallel()
+
+	rowType := rowTypeWithColumnNames("id", "name")
+	var delimited, jsonl bytes.Buffer
+	dw := NewDelimitedWriter(&delimited, ',')
+	jw := NewJSONLWriter(&jsonl)
+	if err := dw.PrepareRowType(rowType); err != nil {
+		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
+	}
+	if err := jw.PrepareRowType(rowType); err != nil {
+		t.Fatalf("JSONLWriter.PrepareRowType() error = %v", err)
+	}
+	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if err := jw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(2), gcvctor.StringValue("b")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, dw)
+	if want := "id,name\n1,a\n"; delimited.String() != want {
+		t.Fatalf("delimited = %q, want %q", delimited.String(), want)
+	}
+	if want := "{\"id\":2,\"name\":\"b\"}\n"; jsonl.String() != want {
+		t.Fatalf("jsonl = %q, want %q", jsonl.String(), want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `WithRowType`, `WithColumnNames`, `PrepareRowType`, and `PrepareColumnNames` on delimited, JSONL, and SQL INSERT writers.
- Add `WriteStructValues` for `[]*structpb.Value` with a registered field-type schema (`columnSchema`: names + optional types). `WithMetadata` and deprecated `Prepare` on all three writers delegate through `metadata.GetRowType()`.
- Document row write layers and when column names vs field types must be pre-registered (package godoc section "Column names and field types"); add `WithHeader(false)` for headerless CSV/TSV.
- **Fix `DelimitedWriter.Flush`**: when `WithHeader(true)` and column names are registered but no data row was written, `Flush` now emits the pending CSV/TSV header (zero-row exports). README documents the `iter.Next` pattern: `PrepareRowType` after the first `Next`, then `Flush`.
- README + godoc: typical Spanner export with rows uses `iter.Do` + `WriteRow` (no schema options at construction). `RowIterator.Metadata` is available after the first `Next`, not when the iterator is created.
- Fix SQL `PrepareRowType` so quoted column names are cached after schema init.

Closes #91

## Test plan

- [x] `make check`
- [x] `TestDelimitedWriterFlushWritesHeaderWithNoRows` and related Flush/header tests