### PR TITLE
fix(writer): zero-column RowType and empty-schema Flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,15 @@ for {
 return w.Flush()
 ```
 
-Which schema to pre-register depends on the write API (names only vs names and types);
-see `go doc writer`, section "Column names and field types".
+Which schema to pre-register depends on the write API (names only vs names and types).
+Registration is not the same as having zero columns: without `Prepare*` / `With*` and
+with no row written, `Flush` or `WriteHeader` returns `writer.ErrMissingColumnNames`.
+`PrepareRowType(nil)` or a zero-field `GetRowType()` registers an empty schema (DML
+without `THEN RETURN`: `Flush` writes nothing). An empty `PrepareColumnNames` slice
+still errors—use `PrepareRowType` for that case. A zero-row `SELECT` has column names
+in metadata, so `PrepareRowType` plus `Flush` can emit a header-only file. See
+`go doc writer`, sections "Column names and field types" and
+"Registered schema vs missing schema".
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ Which schema to pre-register depends on the write API (names only vs names and t
 Registration is not the same as having zero columns: without `Prepare*` / `With*` and
 with no row written, `Flush` or `WriteHeader` returns `writer.ErrMissingColumnNames`.
 `PrepareRowType(nil)` or a zero-field `GetRowType()` registers an empty schema (DML
-without `THEN RETURN`: `Flush` writes nothing). An empty `PrepareColumnNames` slice
-still errors—use `PrepareRowType` for that case. A zero-row `SELECT` has column names
+without `THEN RETURN`: `Flush` writes nothing). `PrepareColumnNames` with an empty
+slice returns `writer.ErrMissingColumnNames`; `WithColumnNames([])` at construction is
+ignored (the writer stays unregistered, same as omitting the option). Use
+`PrepareRowType` for zero-column result sets. A zero-row `SELECT` has column names
 in metadata, so `PrepareRowType` plus `Flush` can emit a header-only file. See
 `go doc writer`, sections "Column names and field types" and
 "Registered schema vs missing schema".

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -32,11 +32,31 @@
 // Names only: [WithColumnNames], PrepareColumnNames. Names and types: [WithRowType],
 // [WithMetadata], PrepareRowType. [WithMetadata] uses metadata.GetRowType(); from a
 // [cloud.google.com/go/spanner.RowIterator], Metadata is set after the first Next.
+// The first [WriteRow] or [WriteValues] call can also register column names from a row.
 // [DelimitedWriter.Prepare], [JSONLWriter.Prepare], and [SQLInsertWriter.Prepare] are deprecated.
 //
+// # Registered schema vs missing schema
+//
+// Writers distinguish schema that was never registered from a registered schema with
+// zero column names (len(names) == 0):
+//
+//   - Not registered: no Prepare*, With*, or row has supplied names yet.
+//     [DelimitedWriter.WriteHeader], [DelimitedWriter.Flush] (with [WithHeader](true)),
+//     and [DelimitedWriter.WriteGCVs] without prior registration return [ErrMissingColumnNames].
+//   - Registered empty: [PrepareRowType] or [WithRowType] with a nil row type or a row type
+//     whose fields slice is empty (for example DML without THEN RETURN: zero rows and zero
+//     columns). [DelimitedWriter.Flush] succeeds and writes no output; [DelimitedWriter.WriteHeader]
+//     is a no-op because there are no column names. A later [WriteRow] still initializes
+//     names from the row if one arrives.
+//   - [PrepareColumnNames] and [WithColumnNames] with an empty name list return
+//     [ErrMissingColumnNames] and do not register a schema. For a zero-column result set,
+//     use [PrepareRowType] or [WithRowType] instead (for example after iter.Metadata.GetRowType()
+//     on DML without THEN RETURN).
+//
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
-// before the first data row, or on [DelimitedWriter.Flush] when no data row was written.
-// [WithHeader](false) omits the header. [DelimitedWriter.WriteHeader] forces the header earlier.
+// before the first data row, or on [DelimitedWriter.Flush] when no data row was written
+// (including zero-row SELECT when names were registered). [WithHeader](false) omits the header.
+// [DelimitedWriter.WriteHeader] forces the header earlier.
 //
 // Delimited, JSONL, and SQL encodings differ after spanvalue formats each column.
 //
@@ -80,7 +100,12 @@ var (
 	ErrNilOutputWriter = errors.New("nil output writer")
 	// ErrNilRow reports that WriteRow was called with a nil row.
 	ErrNilRow = spanvalue.ErrNilRow
-	// ErrMissingColumnNames reports that writing values requires initialized column names.
+	// ErrMissingColumnNames reports that an operation requires a registered column schema
+	// when none was registered yet, or column names/types are insufficient for the write
+	// (for example values without names). It is not returned for a registered zero-column
+	// schema (see package doc "Registered schema vs missing schema"). An empty name list
+	// passed to [WithColumnNames] or [PrepareColumnNames] also returns this error; use
+	// [PrepareRowType] for zero-column result sets.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
 	ErrColumnNamesMismatch = errors.New("column names mismatch")
@@ -224,6 +249,7 @@ type rowTypeOption struct {
 }
 
 // WithRowType registers column names and field types at construction.
+// Nil rowType registers an empty schema (see package doc).
 func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
@@ -245,6 +271,8 @@ type columnNamesOption struct {
 }
 
 // WithColumnNames registers column names only and clears any registered field types.
+// An empty names slice is ignored (the writer stays unregistered); use [WithRowType]
+// for a zero-column result set.
 func WithColumnNames(names []string) Option {
 	return columnNamesOption{names: slices.Clone(names)}
 }
@@ -310,19 +338,25 @@ func WithHeader(header bool) DelimitedOption {
 
 // columnSchema holds column names for output labeling and optional field types for
 // WriteStructValues. When types is non-empty, len(types) equals len(names).
+// registered is true after Prepare*, With*, or the first row supplies a schema
+// (including a zero-field row type).
 type columnSchema struct {
-	names []string
-	types []*sppb.Type
+	names      []string
+	types      []*sppb.Type
+	registered bool
 }
 
 func (s *columnSchema) applyRowType(rowType *sppb.StructType) {
+	rowType = normalizeRowType(rowType)
 	s.names = columnNamesFromRowType(rowType)
 	s.types = fieldTypesFromRowType(rowType)
+	s.registered = true
 }
 
 func (s *columnSchema) applyNamesOnly(names []string) {
 	s.names = slices.Clone(names)
 	s.types = nil
+	s.registered = true
 }
 
 // DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
@@ -399,22 +433,25 @@ func (w *DelimitedWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 }
 
 // PrepareRowType registers column names and field types; same as [WithRowType].
+// Nil rowType and a row type with no fields both register an empty schema (see package doc).
 func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
 // PrepareColumnNames registers column names only; same as [WithColumnNames].
+// An empty names slice returns [ErrMissingColumnNames]; for zero-column result sets use
+// [DelimitedWriter.PrepareRowType] instead.
 func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
 
 func (w *DelimitedWriter) prepareRowType(rowType *sppb.StructType) error {
-	columnNames, err := prepareRowType(rowType)
-	if err != nil {
-		return err
-	}
-	if err := w.initOrValidateColumnNames(columnNames); err != nil {
-		return err
+	rowType = normalizeRowType(rowType)
+	columnNames := columnNamesFromRowType(rowType)
+	if len(columnNames) > 0 {
+		if err := w.initOrValidateColumnNames(columnNames); err != nil {
+			return err
+		}
 	}
 	w.setRowType(rowType)
 	return nil
@@ -431,7 +468,9 @@ func (w *DelimitedWriter) prepareColumnNames(names []string) error {
 	return nil
 }
 
-// WriteHeader writes the CSV/TSV header once; column names must already be registered.
+// WriteHeader writes the CSV/TSV header once; a column schema must already be registered.
+// With zero registered column names (empty row type), WriteHeader succeeds without writing.
+// With no registered schema, it returns [ErrMissingColumnNames].
 // When [DelimitedWriter.Header] is true, [DelimitedWriter.Flush] also writes a pending header.
 func (w *DelimitedWriter) WriteHeader() error {
 	if w.wroteHeader {
@@ -446,7 +485,10 @@ func (w *DelimitedWriter) WriteHeader() error {
 		return err
 	}
 	if len(w.schema.names) == 0 {
-		return ErrMissingColumnNames
+		if !w.schema.registered {
+			return ErrMissingColumnNames
+		}
+		return nil
 	}
 
 	resolvedNames, err := w.resolvedNames()
@@ -474,7 +516,13 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if err != nil {
 		return err
 	}
+	if !w.schema.registered {
+		return ErrMissingColumnNames
+	}
 	if len(w.schema.names) == 0 {
+		if len(values) == 0 {
+			return nil
+		}
 		return ErrMissingColumnNames
 	}
 
@@ -512,6 +560,9 @@ func (w *DelimitedWriter) setRowType(rowType *sppb.StructType) {
 }
 
 func (w *DelimitedWriter) setColumnNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
 	w.schema.applyNamesOnly(names)
 	w.resolvedColumnNames = nil
 }
@@ -520,6 +571,9 @@ func (w *DelimitedWriter) initOrValidateColumnNames(columnNames []string) error 
 	initialized := len(w.schema.names) == 0
 	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
 		return err
+	}
+	if len(w.schema.names) > 0 {
+		w.schema.registered = true
 	}
 	if initialized && len(w.schema.names) > 0 {
 		w.resolvedColumnNames = nil
@@ -561,11 +615,14 @@ func validDelimiter(delimiter rune) bool {
 }
 
 // Flush flushes buffered delimited data to the underlying writer. When [DelimitedWriter.Header]
-// is true, column names are registered, and no header was written yet, Flush writes the
-// header first (including zero-row exports). Flush does not close the underlying writer.
+// is true, a schema is registered, len(column names) > 0, and no header was written yet,
+// Flush writes the header first (including zero-row SELECT exports). With a registered
+// zero-column schema, Flush succeeds without writing. With no registered schema and
+// [DelimitedWriter.Header] true, Flush returns [ErrMissingColumnNames]. Flush does not close
+// the underlying writer.
 func (w *DelimitedWriter) Flush() error {
 	if w.Header && !w.wroteHeader {
-		if len(w.schema.names) == 0 {
+		if !w.schema.registered {
 			return ErrMissingColumnNames
 		}
 		if err := w.WriteHeader(); err != nil {
@@ -653,22 +710,24 @@ func (w *JSONLWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 }
 
 // PrepareRowType registers names and field types; see [DelimitedWriter.PrepareRowType].
+// Nil rowType registers an empty schema.
 func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
 // PrepareColumnNames registers column names; see [DelimitedWriter.PrepareColumnNames].
+// An empty names slice returns [ErrMissingColumnNames].
 func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
 
 func (w *JSONLWriter) prepareRowType(rowType *sppb.StructType) error {
-	columnNames, err := prepareRowType(rowType)
-	if err != nil {
-		return err
-	}
-	if err := w.initOrValidateColumnNames(columnNames); err != nil {
-		return err
+	rowType = normalizeRowType(rowType)
+	columnNames := columnNamesFromRowType(rowType)
+	if len(columnNames) > 0 {
+		if err := w.initOrValidateColumnNames(columnNames); err != nil {
+			return err
+		}
 	}
 	w.setRowType(rowType)
 	return nil
@@ -707,7 +766,13 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}
+	if !w.schema.registered {
+		return ErrMissingColumnNames
+	}
 	if len(w.schema.names) == 0 {
+		if len(values) == 0 {
+			return nil
+		}
 		return ErrMissingColumnNames
 	}
 	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
@@ -742,6 +807,9 @@ func (w *JSONLWriter) setRowType(rowType *sppb.StructType) {
 }
 
 func (w *JSONLWriter) setColumnNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
 	w.schema.applyNamesOnly(names)
 	w.resolvedColumnNames = nil
 	w.marshaledKeys = nil
@@ -751,6 +819,9 @@ func (w *JSONLWriter) initOrValidateColumnNames(columnNames []string) error {
 	initialized := len(w.schema.names) == 0
 	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
 		return err
+	}
+	if len(w.schema.names) > 0 {
+		w.schema.registered = true
 	}
 	if initialized && len(w.schema.names) > 0 {
 		w.resolvedColumnNames = nil
@@ -852,25 +923,29 @@ func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
 // When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use
-// iter.Metadata.GetRowType after the first Next.
+// iter.Metadata.GetRowType after the first Next. Nil rowType registers an empty schema;
+// [SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
 // PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
+// An empty names slice returns [ErrMissingColumnNames]; for zero-column result sets use
+// [SQLInsertWriter.PrepareRowType] instead.
 func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
 
 func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
-	columnNames, err := prepareRowType(rowType)
-	if err != nil {
-		return err
+	rowType = normalizeRowType(rowType)
+	columnNames := columnNamesFromRowType(rowType)
+	if len(columnNames) == 0 {
+		w.setRowType(rowType)
+		return nil
 	}
 	if _, err := w.initOrValidateQuotedColumns(columnNames); err != nil {
 		return err
 	}
-	w.schema.names = columnNamesFromRowType(rowType)
 	w.schema.types = fieldTypesFromRowType(rowType)
 	return nil
 }
@@ -905,6 +980,12 @@ func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 }
 
 func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
+	if !w.schema.registered {
+		return ErrMissingColumnNames
+	}
+	if len(w.schema.names) == 0 {
+		return ErrMissingColumnNames
+	}
 	quotedColumns, err := w.initOrValidateQuotedColumns(nil)
 	if err != nil {
 		return err
@@ -957,6 +1038,9 @@ func (w *SQLInsertWriter) setRowType(rowType *sppb.StructType) {
 }
 
 func (w *SQLInsertWriter) setColumnNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
 	w.schema.applyNamesOnly(names)
 	w.quotedColumnNames = ""
 }
@@ -983,6 +1067,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if len(w.schema.names) == 0 {
 		w.schema.names = names
 	}
+	w.schema.registered = true
 	w.quotedColumnNames = strings.Join(quotedColumns, ", ")
 	return w.quotedColumnNames, nil
 }
@@ -1088,12 +1173,11 @@ func jsonFormatter(fc *spanvalue.FormatConfig) *spanvalue.FormatConfig {
 	return spanvalue.JSONFormatConfig()
 }
 
-func prepareRowType(rowType *sppb.StructType) ([]string, error) {
-	columnNames := columnNamesFromRowType(rowType)
-	if len(columnNames) == 0 {
-		return nil, ErrMissingColumnNames
+func normalizeRowType(rowType *sppb.StructType) *sppb.StructType {
+	if rowType == nil {
+		return &sppb.StructType{}
 	}
-	return columnNames, nil
+	return rowType
 }
 
 func rowTypeFromMetadata(metadata *sppb.ResultSetMetadata) *sppb.StructType {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -938,12 +938,17 @@ func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
 	if err := validatePrepareRowTypeTransition(&w.schema, columnNames); err != nil {
 		return err
 	}
-	w.setRowType(rowType)
 	if len(columnNames) == 0 {
+		w.setRowType(rowType)
 		return nil
 	}
-	_, err := w.initOrValidateQuotedColumns(columnNames)
-	return err
+	quotedColumns, err := quoteIdentifiers(columnNames)
+	if err != nil {
+		return err
+	}
+	w.setRowType(rowType)
+	w.quotedColumnNames = strings.Join(quotedColumns, ", ")
+	return nil
 }
 
 func (w *SQLInsertWriter) prepareColumnNames(names []string) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -448,10 +448,8 @@ func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
 func (w *DelimitedWriter) prepareRowType(rowType *sppb.StructType) error {
 	rowType = normalizeRowType(rowType)
 	columnNames := columnNamesFromRowType(rowType)
-	if len(columnNames) > 0 {
-		if err := w.initOrValidateColumnNames(columnNames); err != nil {
-			return err
-		}
+	if err := validatePrepareRowTypeTransition(&w.schema, columnNames); err != nil {
+		return err
 	}
 	w.setRowType(rowType)
 	return nil
@@ -724,10 +722,8 @@ func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 func (w *JSONLWriter) prepareRowType(rowType *sppb.StructType) error {
 	rowType = normalizeRowType(rowType)
 	columnNames := columnNamesFromRowType(rowType)
-	if len(columnNames) > 0 {
-		if err := w.initOrValidateColumnNames(columnNames); err != nil {
-			return err
-		}
+	if err := validatePrepareRowTypeTransition(&w.schema, columnNames); err != nil {
+		return err
 	}
 	w.setRowType(rowType)
 	return nil
@@ -939,15 +935,15 @@ func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
 func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
 	rowType = normalizeRowType(rowType)
 	columnNames := columnNamesFromRowType(rowType)
-	if len(columnNames) == 0 {
-		w.setRowType(rowType)
-		return nil
-	}
-	if _, err := w.initOrValidateQuotedColumns(columnNames); err != nil {
+	if err := validatePrepareRowTypeTransition(&w.schema, columnNames); err != nil {
 		return err
 	}
-	w.schema.types = fieldTypesFromRowType(rowType)
-	return nil
+	w.setRowType(rowType)
+	if len(columnNames) == 0 {
+		return nil
+	}
+	_, err := w.initOrValidateQuotedColumns(columnNames)
+	return err
 }
 
 func (w *SQLInsertWriter) prepareColumnNames(names []string) error {
@@ -1268,6 +1264,19 @@ func validatedColumnNames(existing []string, columnNames []string) ([]string, er
 		return nil, fmt.Errorf("%w: got %v want %v", ErrColumnNamesMismatch, columnNames, existing)
 	}
 	return existing, nil
+}
+
+// validatePrepareRowTypeTransition checks a PrepareRowType call against the current schema
+// before setRowType mutates names, types, or cached derived fields.
+func validatePrepareRowTypeTransition(schema *columnSchema, columnNames []string) error {
+	if len(columnNames) == 0 {
+		if schema.registered && len(schema.names) > 0 {
+			return fmt.Errorf("%w: got empty row type, want %v", ErrColumnNamesMismatch, schema.names)
+		}
+		return nil
+	}
+	_, err := validatedColumnNames(schema.names, columnNames)
+	return err
 }
 
 // quoteIdentifiers quotes GoogleSQL identifiers and rejects empty names.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -48,10 +48,11 @@
 //     columns). [DelimitedWriter.Flush] succeeds and writes no output; [DelimitedWriter.WriteHeader]
 //     is a no-op because there are no column names. A later [WriteRow] still initializes
 //     names from the row if one arrives.
-//   - [PrepareColumnNames] and [WithColumnNames] with an empty name list return
-//     [ErrMissingColumnNames] and do not register a schema. For a zero-column result set,
-//     use [PrepareRowType] or [WithRowType] instead (for example after iter.Metadata.GetRowType()
-//     on DML without THEN RETURN).
+//   - [PrepareColumnNames] with an empty name list returns [ErrMissingColumnNames].
+//   - [WithColumnNames] with an empty name list is ignored at construction (the writer stays
+//     unregistered); it does not return an error because options cannot report one. For a
+//     zero-column result set, use [PrepareRowType] or [WithRowType] instead (for example after
+//     iter.Metadata.GetRowType() on DML without THEN RETURN).
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
 // before the first data row, or on [DelimitedWriter.Flush] when no data row was written
@@ -103,9 +104,9 @@ var (
 	// ErrMissingColumnNames reports that an operation requires a registered column schema
 	// when none was registered yet, or column names/types are insufficient for the write
 	// (for example values without names). It is not returned for a registered zero-column
-	// schema (see package doc "Registered schema vs missing schema"). An empty name list
-	// passed to [WithColumnNames] or [PrepareColumnNames] also returns this error; use
-	// [PrepareRowType] for zero-column result sets.
+	// schema (see package doc "Registered schema vs missing schema"). [PrepareColumnNames]
+	// with an empty name list returns this error; [WithColumnNames] with an empty list is
+	// ignored (writer stays unregistered). Use [PrepareRowType] for zero-column result sets.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
 	ErrColumnNamesMismatch = errors.New("column names mismatch")
@@ -438,9 +439,9 @@ func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareColumnNames registers column names only; same as [WithColumnNames].
-// An empty names slice returns [ErrMissingColumnNames]; for zero-column result sets use
-// [DelimitedWriter.PrepareRowType] instead.
+// PrepareColumnNames registers column names only; same as [WithColumnNames] for non-empty
+// names. Unlike [WithColumnNames], an empty names slice returns [ErrMissingColumnNames];
+// for zero-column result sets use [DelimitedWriter.PrepareRowType] instead.
 func (w *DelimitedWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
@@ -714,7 +715,6 @@ func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 }
 
 // PrepareColumnNames registers column names; see [DelimitedWriter.PrepareColumnNames].
-// An empty names slice returns [ErrMissingColumnNames].
 func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }
@@ -926,8 +926,7 @@ func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 }
 
 // PrepareColumnNames initializes the SQL INSERT schema from column names before the first row is written.
-// An empty names slice returns [ErrMissingColumnNames]; for zero-column result sets use
-// [SQLInsertWriter.PrepareRowType] instead.
+// See [DelimitedWriter.PrepareColumnNames] for empty-name behavior.
 func (w *SQLInsertWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1169,6 +1169,15 @@ func TestDelimitedWriterPrepareColumnNamesEmptyErrors(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterWithColumnNamesEmptyIgnored(t *testing.T) {
+	t.Parallel()
+
+	err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithColumnNames(nil), WithHeader(true)).Flush()
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("Flush() error = %v, want ErrMissingColumnNames (writer still unregistered)", err)
+	}
+}
+
 func TestDelimitedWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -31,6 +31,10 @@ func metadataWithColumnNames(names ...string) *sppb.ResultSetMetadata {
 	return &sppb.ResultSetMetadata{RowType: rowTypeWithColumnNames(names...)}
 }
 
+func emptyRowType() *sppb.StructType {
+	return &sppb.StructType{Fields: []*sppb.StructType_Field{}}
+}
+
 func rowTypeWithColumnNames(names ...string) *sppb.StructType {
 	fields := make([]*sppb.StructType_Field, len(names))
 	for i, name := range names {
@@ -274,24 +278,42 @@ func TestSQLInsertWriterPrepare(t *testing.T) {
 	}
 }
 
-func TestWritersPrepareWithoutMetadata(t *testing.T) {
+func TestWritersPrepareNilMetadataRegistersEmptySchema(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		prepare func(*sppb.ResultSetMetadata) error
+		name string
+		run  func() error
 	}{
 		{
-			name:    "csv",
-			prepare: NewDelimitedWriter(&bytes.Buffer{}, Comma).Prepare,
+			name: "csv",
+			run: func() error {
+				w := NewDelimitedWriter(&bytes.Buffer{}, Comma, WithHeader(true))
+				if err := w.Prepare(nil); err != nil {
+					return err
+				}
+				return w.Flush()
+			},
 		},
 		{
-			name:    "jsonl",
-			prepare: NewJSONLWriter(&bytes.Buffer{}).Prepare,
+			name: "jsonl",
+			run: func() error {
+				w := NewJSONLWriter(&bytes.Buffer{})
+				if err := w.Prepare(nil); err != nil {
+					return err
+				}
+				return w.Flush()
+			},
 		},
 		{
-			name:    "sql",
-			prepare: NewSQLInsertWriter(&bytes.Buffer{}, "users").Prepare,
+			name: "sql",
+			run: func() error {
+				w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+				if err := w.Prepare(nil); err != nil {
+					return err
+				}
+				return w.Flush()
+			},
 		},
 	}
 
@@ -299,9 +321,8 @@ func TestWritersPrepareWithoutMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.prepare(nil)
-			if !errors.Is(err, ErrMissingColumnNames) {
-				t.Fatalf("Prepare(nil) error = %v, want ErrMissingColumnNames", err)
+			if err := tt.run(); err != nil {
+				t.Fatalf("run() error = %v", err)
 			}
 		})
 	}
@@ -1104,6 +1125,98 @@ func TestDelimitedWriterFlushWithoutColumnNames(t *testing.T) {
 	err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithHeader(true)).Flush()
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("Flush() error = %v, want ErrMissingColumnNames", err)
+	}
+}
+
+func TestDelimitedWriterPrepareRowTypeNilRegistersEmptySchema(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	if err := w.PrepareRowType(nil); err != nil {
+		t.Fatalf("PrepareRowType(nil) error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
+func TestDelimitedWriterPrepareColumnNamesEmptyErrors(t *testing.T) {
+	t.Parallel()
+
+	err := NewDelimitedWriter(&bytes.Buffer{}, ',').PrepareColumnNames(nil)
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("PrepareColumnNames(nil) error = %v, want ErrMissingColumnNames", err)
+	}
+}
+
+func TestDelimitedWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
+func TestDelimitedWriterPrepareEmptyRowTypeWriteGCVsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.WriteGCVs(nil); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
+func TestJSONLWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriter(&out)
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
+func TestSQLInsertWriterPrepareEmptyRowTypeFlushNoOp(t *testing.T) {
+	t.Parallel()
+
+	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	err := w.WriteGCVs(nil)
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)
 	}
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1144,6 +1144,22 @@ func TestDelimitedWriterPrepareRowTypeNilRegistersEmptySchema(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterPrepareRowTypeEmptyAfterNonEmptyErrors(t *testing.T) {
+	t.Parallel()
+
+	w := NewDelimitedWriter(&bytes.Buffer{}, ',')
+	if err := w.PrepareRowType(rowTypeWithColumnNames("id")); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	err := w.PrepareRowType(emptyRowType())
+	if !errors.Is(err, ErrColumnNamesMismatch) {
+		t.Fatalf("PrepareRowType(empty) error = %v, want ErrColumnNamesMismatch", err)
+	}
+	if len(w.schema.names) != 1 || w.schema.names[0] != "id" {
+		t.Fatalf("schema.names = %v, want [id]", w.schema.names)
+	}
+}
+
 func TestDelimitedWriterPrepareColumnNamesEmptyErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Register an empty column schema when `PrepareRowType` / `WithRowType` receives `nil` or a row type with no fields (for example DML without `THEN RETURN`). `DelimitedWriter.Flush` then succeeds without writing output.
- Distinguish **unregistered** writers (`ErrMissingColumnNames` on `Flush` / `WriteHeader`) from **registered zero-column** writers (no-op header, empty output).
- Keep `PrepareColumnNames` / `WithColumnNames` with an empty name list as errors; godoc and README steer zero-column cases to `PrepareRowType`.
- `WithColumnNames([])` at construction is ignored (writer stays unregistered).

## Test plan

- [x] `make check`
- [x] New tests for `PrepareRowType(nil)`, empty row type, `PrepareColumnNames(nil)`, and `Prepare(nil)` empty schema


Made with [Cursor](https://cursor.com)