### PR TITLE
docs: adopter feedback on writer streaming and CSV edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ a registered field-type schema (spannerpb + structpb at the boundary), and
 `WriteGCVs` when values are already `GenericColumnValue`. Use `writer.Writer`
 when an adapter only needs `WriteRow`. Use `writer.FlushWriter` when an adapter
 owns both row streaming and finalization.
+
+**Production streaming (Spanner client):** register schema once with
+`writer.WithMetadata(iter.Metadata)` (equivalent to `WithRowType(metadata.GetRowType())`—do
+not pass both), then `WriteRow` on each `Next()`, and `Flush` in a defer. You do not
+need to build `[]GenericColumnValue` per row or call `WriteStructValues` on that path.
+
+**In-memory fixtures:** after `WithMetadata` or `WithRowType`, prefer `WriteStructValues`
+with `[]*structpb.Value` cells (or `WriteGCVs` with `gcvctor` helpers). Do not zip
+`RowType` field types with `ListValue` cells manually when types are already registered.
 `DelimitedWriter` and `JSONLWriter` preserve explicit duplicate column names.
 Empty column names are the only names passed to `UnnamedFieldNamer`, and
 generated names avoid collisions with existing explicit names. Set
@@ -138,17 +147,41 @@ for {
 return w.Flush()
 ```
 
-Which schema to pre-register depends on the write API (names only vs names and types).
+### Schema registration
+
+| Goal | API |
+|------|-----|
+| Streaming `RowIterator` | `WithMetadata(iter.Metadata)` once, then `WriteRow` |
+| Known column names only | `WithColumnNames` / `PrepareColumnNames` (at least one name) |
+| Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` |
+| Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(GetRowType())` when fields are empty—**not** `PrepareColumnNames` |
+| Zero-row `SELECT` (columns in metadata, no rows) | `PrepareRowType` after first `Next`, then `Flush` for header-only CSV |
+
 Registration is not the same as having zero columns: without `Prepare*` / `With*` and
 with no row written, `Flush` or `WriteHeader` returns `writer.ErrMissingColumnNames`.
-`PrepareRowType(nil)` or a zero-field `GetRowType()` registers an empty schema (DML
-without `THEN RETURN`: `Flush` writes nothing). `PrepareColumnNames` with an empty
-slice returns `writer.ErrMissingColumnNames`; `WithColumnNames([])` at construction is
-ignored (the writer stays unregistered, same as omitting the option). Use
-`PrepareRowType` for zero-column result sets. A zero-row `SELECT` has column names
-in metadata, so `PrepareRowType` plus `Flush` can emit a header-only file. See
+`PrepareColumnNames` with an empty slice returns `writer.ErrMissingColumnNames`;
+`WithColumnNames([])` at construction is ignored (writer stays unregistered). See
 `go doc writer`, sections "Column names and field types" and
 "Registered schema vs missing schema".
+
+### Result-set shape vs CSV output
+
+| Metadata | Rows | `Flush` with `Header=true` |
+|----------|------|----------------------------|
+| Zero fields (partitioned DML, etc.) | 0 | Empty file (no header line) |
+| Normal `SELECT` row type | 0 | Header row only |
+| Normal `SELECT` row type | ≥1 | Header then data rows |
+
+DML or other statements with no result columns: call `PrepareRowType` on
+`iter.Metadata.GetRowType()` (possibly nil or zero fields), then `Flush`—do not rely on
+`PrepareColumnNames` with an empty name list.
+
+### ENUM and PROTO in CSV
+
+Delimited output uses [`SimpleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SimpleFormatConfig)
+by default. Build cells with [`gcvctor.EnumValue`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#EnumValue)
+and [`gcvctor.ProtoValue`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ProtoValue),
+then `WriteGCVs` (see `TestDelimitedWriterWriteGCVsEnumProto` in the `writer` package).
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see the `writer` package documentation. For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ owns both row streaming and finalization.
 `nil` there and registers an empty schema. When every query returns at least one row,
 `iter.Do` and `WriteRow` are enough (the first row supplies column names). When the result
 may be empty but metadata still lists columns, use the `iter.Next` loop below and call
-`PrepareRowType(iter.Metadata.GetRowType())` on the first pass, then `WriteRow` and `Flush`
+`PrepareRowType(iter.Metadata.GetRowType())` on the first loop iteration (even when `Next` returns
+`iterator.Done`), then `WriteRow` and `Flush`
 in a defer. You do not need to build `[]GenericColumnValue` per row or call
 `WriteStructValues` on that path. If you already hold `*sppb.ResultSetMetadata` outside a
 `RowIterator` (for example an in-memory `spannerpb.ResultSet`), `WithMetadata(md)` at

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ owns both row streaming and finalization.
 `iter.Do` and `WriteRow` are enough (the first row supplies column names). When the result
 may be empty but metadata still lists columns, use the `iter.Next` loop below and call
 `PrepareRowType(iter.Metadata.GetRowType())` on the first loop iteration (even when `Next` returns
-`iterator.Done`), then `WriteRow` and `Flush`
-in a defer. You do not need to build `[]GenericColumnValue` per row or call
+`iterator.Done`), then `WriteRow` in the loop and `return w.Flush()` after the loop (do not
+`defer w.Flush()`—that discards Flush errors). You do not need to build `[]GenericColumnValue` per row or call
 `WriteStructValues` on that path. If you already hold `*sppb.ResultSetMetadata` outside a
 `RowIterator` (for example an in-memory `spannerpb.ResultSet`), `WithMetadata(md)` at
 construction is fine.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,16 @@ a registered field-type schema (spannerpb + structpb at the boundary), and
 when an adapter only needs `WriteRow`. Use `writer.FlushWriter` when an adapter
 owns both row streaming and finalization.
 
-**Production streaming (Spanner client):** register schema once with
-`writer.WithMetadata(iter.Metadata)` (equivalent to `WithRowType(metadata.GetRowType())`—do
-not pass both), then `WriteRow` on each `Next()`, and `Flush` in a defer. You do not
-need to build `[]GenericColumnValue` per row or call `WriteStructValues` on that path.
+**Production streaming (Spanner client):** `iter.Metadata` is set only after the first
+`Next()`. Do not pass `iter.Metadata` to `WithMetadata` at writer construction—it is still
+`nil` there and registers an empty schema. When every query returns at least one row,
+`iter.Do` and `WriteRow` are enough (the first row supplies column names). When the result
+may be empty but metadata still lists columns, use the `iter.Next` loop below and call
+`PrepareRowType(iter.Metadata.GetRowType())` on the first pass, then `WriteRow` and `Flush`
+in a defer. You do not need to build `[]GenericColumnValue` per row or call
+`WriteStructValues` on that path. If you already hold `*sppb.ResultSetMetadata` outside a
+`RowIterator` (for example an in-memory `spannerpb.ResultSet`), `WithMetadata(md)` at
+construction is fine.
 
 **In-memory fixtures:** after `WithMetadata` or `WithRowType`, prefer `WriteStructValues`
 with `[]*structpb.Value` cells (or `WriteGCVs` with `gcvctor` helpers). Do not zip
@@ -151,10 +157,10 @@ return w.Flush()
 
 | Goal | API |
 |------|-----|
-| Streaming `RowIterator` | `WithMetadata(iter.Metadata)` once, then `WriteRow` |
+| Streaming `RowIterator` | `PrepareRowType(iter.Metadata.GetRowType())` after first `Next`, then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
 | Known column names only | `WithColumnNames` / `PrepareColumnNames` (at least one name) |
-| Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` |
-| Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(GetRowType())` when fields are empty—**not** `PrepareColumnNames` |
+| Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` (when `md` is already available) |
+| Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(metadata.GetRowType())` when fields are empty—**not** `PrepareColumnNames` |
 | Zero-row `SELECT` (columns in metadata, no rows) | `PrepareRowType` after first `Next`, then `Flush` for header-only CSV |
 
 Registration is not the same as having zero columns: without `Prepare*` / `With*` and

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -291,8 +291,8 @@ func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
 }
 
 // ProtoValue returns a non-null PROTO GenericColumnValue for the fully qualified message name fqn.
-// The message bytes are stored in the GCV as a base64-encoded string; delimited export formats
-// that payload via SimpleFormatConfig (see writer.TestDelimitedWriterWriteGCVsEnumProto).
+// The message bytes are stored in the GCV as a base64-encoded string. Delimited export decodes that
+// wire payload for SimpleFormatConfig when possible (see writer.TestDelimitedWriterWriteGCVsEnumProto).
 func ProtoValue(fqn string, b []byte) spanner.GenericColumnValue {
 	return BytesBasedValueOf(typector.FQNToProtoType(fqn), b)
 }

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -291,11 +291,15 @@ func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
 }
 
 // ProtoValue returns a non-null PROTO GenericColumnValue for the fully qualified message name fqn.
+// The value is the raw message bytes; delimited export uses SimpleFormatConfig string form (see
+// writer.TestDelimitedWriterWriteGCVsEnumProto).
 func ProtoValue(fqn string, b []byte) spanner.GenericColumnValue {
 	return BytesBasedValueOf(typector.FQNToProtoType(fqn), b)
 }
 
 // EnumValue returns a non-null ENUM GenericColumnValue for the fully qualified enum name fqn.
+// The structpb value is the enum number as a decimal string; delimited export prints that
+// string (see writer.TestDelimitedWriterWriteGCVsEnumProto).
 func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.FQNToEnumType(fqn),

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -291,8 +291,8 @@ func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
 }
 
 // ProtoValue returns a non-null PROTO GenericColumnValue for the fully qualified message name fqn.
-// The value is the raw message bytes; delimited export uses SimpleFormatConfig string form (see
-// writer.TestDelimitedWriterWriteGCVsEnumProto).
+// The message bytes are stored in the GCV as a base64-encoded string; delimited export formats
+// that payload via SimpleFormatConfig (see writer.TestDelimitedWriterWriteGCVsEnumProto).
 func ProtoValue(fqn string, b []byte) spanner.GenericColumnValue {
 	return BytesBasedValueOf(typector.FQNToProtoType(fqn), b)
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -48,11 +48,17 @@
 //     columns). [DelimitedWriter.Flush] succeeds and writes no output; [DelimitedWriter.WriteHeader]
 //     is a no-op because there are no column names. A later [WriteRow] still initializes
 //     names from the row if one arrives.
-//   - [PrepareColumnNames] with an empty name list returns [ErrMissingColumnNames].
+//   - [PrepareColumnNames] requires at least one column name and returns [ErrMissingColumnNames]
+//     for an empty list. Do not use it when metadata has zero columns; use [PrepareRowType] or
+//     [WithRowType] with nil or an empty fields slice instead (for example DML without THEN RETURN).
 //   - [WithColumnNames] with an empty name list is ignored at construction (the writer stays
-//     unregistered); it does not return an error because options cannot report one. For a
-//     zero-column result set, use [PrepareRowType] or [WithRowType] instead (for example after
-//     iter.Metadata.GetRowType() on DML without THEN RETURN).
+//     unregistered); it does not return an error because options cannot report one (#95 tracks
+//     error-returning options). Prefer [PrepareRowType] for zero-column metadata.
+//
+// [WithMetadata] registers the same names and types as [WithRowType](metadata.GetRowType()); call
+// one or the other, not both. For [cloud.google.com/go/spanner.RowIterator] streaming, prefer
+// [WithMetadata](iter.Metadata) once at construction and [WriteRow] per [RowIterator.Next]; defer
+// [DelimitedWriter.Flush] so a zero-row SELECT still emits a header when [WithHeader] is true.
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
 // before the first data row, or on [DelimitedWriter.Flush] when no data row was written

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -59,8 +59,9 @@
 // Use it when metadata is already available (not iter.Metadata from a
 // [cloud.google.com/go/spanner.RowIterator] before the first Next). For streaming, call
 // [PrepareRowType] with iter.Metadata.GetRowType() after the first Next when the result may be empty
-// but still has columns (including when Next returns iterator.Done); defer [DelimitedWriter.Flush]
-// for a header-only CSV. When every query returns at least one row, [WriteRow] registers names from
+// but still has columns (including when Next returns iterator.Done); call [DelimitedWriter.Flush]
+// after the loop and propagate its error (do not defer Flush—it returns an error). When every query
+// returns at least one row, [WriteRow] registers names from
 // the first row.
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -56,9 +56,11 @@
 //     error-returning options). Prefer [PrepareRowType] for zero-column metadata.
 //
 // [WithMetadata] registers the same names and types as [WithRowType](metadata.GetRowType()); call
-// one or the other, not both. For [cloud.google.com/go/spanner.RowIterator] streaming, prefer
-// [WithMetadata](iter.Metadata) once at construction and [WriteRow] per [RowIterator.Next]; defer
-// [DelimitedWriter.Flush] so a zero-row SELECT still emits a header when [WithHeader] is true.
+// one or the other, not both. Use it when metadata is already available (not [RowIterator.Metadata]
+// before the first [RowIterator.Next]). For streaming, call [PrepareRowType](iter.Metadata.GetRowType())
+// after the first Next when the result may be empty but still has columns; defer [DelimitedWriter.Flush]
+// for a header-only CSV. When every query returns at least one row, [WriteRow] registers names from
+// the first row.
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
 // before the first data row, or on [DelimitedWriter.Flush] when no data row was written

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -55,10 +55,11 @@
 //     unregistered); it does not return an error because options cannot report one (#95 tracks
 //     error-returning options). Prefer [PrepareRowType] for zero-column metadata.
 //
-// [WithMetadata] registers the same names and types as [WithRowType](metadata.GetRowType()); call
-// one or the other, not both. Use it when metadata is already available (not [RowIterator.Metadata]
-// before the first [RowIterator.Next]). For streaming, call [PrepareRowType](iter.Metadata.GetRowType())
-// after the first Next when the result may be empty but still has columns; defer [DelimitedWriter.Flush]
+// [WithMetadata] registers the same names and types as [WithRowType]; call one or the other, not both.
+// Use it when metadata is already available (not iter.Metadata from a
+// [cloud.google.com/go/spanner.RowIterator] before the first Next). For streaming, call
+// [PrepareRowType] with iter.Metadata.GetRowType() after the first Next when the result may be empty
+// but still has columns (including when Next returns iterator.Done); defer [DelimitedWriter.Flush]
 // for a header-only CSV. When every query returns at least one row, [WriteRow] registers names from
 // the first row.
 //

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1281,7 +1281,7 @@ func TestDelimitedWriterWriteGCVsEnumProto(t *testing.T) {
 	}
 	flushDelimitedWriter(t, w)
 
-	// ENUM is formatted as the stored INT64 string; PROTO as the raw bytes string (SimpleFormatConfig).
+	// ENUM is the stored INT64 string; PROTO is base64 on the wire but decoded for SimpleFormatConfig CSV.
 	want := "status,payload\n1,abcd\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("output mismatch (-want +got):\n%s", diff)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1264,6 +1264,30 @@ func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterWriteGCVsEnumProto(t *testing.T) {
+	t.Parallel()
+
+	const (
+		enumFQN  = "my.proto.Status"
+		protoFQN = "examples.spanner.music.SingerInfo"
+	)
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"status", "payload"}))
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.EnumValue(enumFQN, 1),
+		gcvctor.ProtoValue(protoFQN, []byte("abcd")),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	// ENUM is formatted as the stored INT64 string; PROTO as the raw bytes string (SimpleFormatConfig).
+	want := "status,payload\n1,abcd\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestWithColumnNamesWriteGCVs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Addresses downstream feedback from [execspansql](https://github.com/apstndb/execspansql) adoption notes and review after `v0.4.1-alpha.2`:

- README + `writer` godoc: production `RowIterator` streaming—do not use `WithMetadata(iter.Metadata)` at construction (`Metadata` is nil until the first `Next`). Use `iter.Do` when every query returns at least one row; otherwise call `PrepareRowType` on the first loop iteration (including when `Next` returns `iterator.Done`), then `WriteRow`, then `return w.Flush()` (not `defer w.Flush()`, which discards `Flush` errors).
- README: schema-registration table (`PrepareRowType` for zero columns, not `PrepareColumnNames`); zero-column vs zero-row CSV table; `WithMetadata` vs `WithRowType` when metadata is already available outside a `RowIterator`.
- Fixtures: prefer `WriteStructValues` / `WriteGCVs` (no manual GCV zip).
- `TestDelimitedWriterWriteGCVsEnumProto` + `gcvctor` notes for ENUM/PROTO CSV formatting (wire base64 vs delimited output).

No API changes. [#95](https://github.com/apstndb/spanvalue/issues/95) remains the place for error-returning `WithColumnNames`.

## Test plan

- [x] `make check`