### PR TITLE
Format scalars via GCV plugins and optimize BYTES output

### DIFF
--- a/common.go
+++ b/common.go
@@ -189,7 +189,8 @@ type Formatter interface {
 //   - FormatComplexPlugins: nil or empty means no plugins run. Preset constructors
 //     append a trailing scalar plugin ([FormatSimpleValue], [FormatLiteralValue],
 //     [FormatSpannerCLIValue], or [FormatJSONSimpleValue]) that formats scalars directly
-//     from GenericColumnValue without Decode; remove it on a clone to use the legacy path.
+//     from GenericColumnValue without Decode; use [FormatConfigWithoutScalarPlugins] or remove
+//     them on a clone to use the legacy path. Plugins fall through when [FormatNullable] is replaced.
 //   - FormatNullable: formats non-NULL scalars after Decode when no scalar plugin handles
 //     the value. NULL scalars use [FormatConfig.GetNullString] before FormatNullable runs.
 //

--- a/common.go
+++ b/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -44,14 +43,7 @@ func (n NullBytes) String() string {
 	if n == nil {
 		return nullStringClientLib
 	}
-	var sb strings.Builder
-	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,
-	// so larger multipliers are speculative unless profiling shows a benefit.
-	sb.Grow(len(n))
-	for _, b := range n {
-		sb.WriteString(internal.ByteToEscapeSequenceReadable(b))
-	}
-	return sb.String()
+	return internal.ReadableBytesString(n)
 }
 
 var _, _ NullableValue = (NullBytes)(nil), (*NullBytes)(nil)
@@ -119,12 +111,10 @@ func (fc *FormatConfig) formatSimpleColumn(value spanner.GenericColumnValue) (st
 	if IsNull(value) {
 		return fc.GetNullString(), nil
 	}
-
 	nv, err := simpleGCVToNullable(value)
 	if err != nil {
 		return "", err
 	}
-
 	return fc.FormatNullable(nv)
 }
 
@@ -196,10 +186,12 @@ type Formatter interface {
 //   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
 //     for non-NULL STRUCT values. NULL STRUCT values use [FormatConfig.GetNullString]
 //     before struct callbacks run.
-//   - FormatComplexPlugins: nil or empty means no plugins run.
-//   - FormatNullable: required for non-NULL scalars reached through
-//     [FormatConfig.FormatColumn]. NULL scalars use [FormatConfig.GetNullString]
-//     before FormatNullable is called.
+//   - FormatComplexPlugins: nil or empty means no plugins run. Preset constructors
+//     append a trailing scalar plugin ([FormatSimpleValue], [FormatLiteralValue],
+//     [FormatSpannerCLIValue], or [FormatJSONSimpleValue]) that formats scalars directly
+//     from GenericColumnValue without Decode; remove it on a clone to use the legacy path.
+//   - FormatNullable: formats non-NULL scalars after Decode when no scalar plugin handles
+//     the value. NULL scalars use [FormatConfig.GetNullString] before FormatNullable runs.
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
 type FormatConfig struct {

--- a/doc.go
+++ b/doc.go
@@ -7,8 +7,12 @@
 //
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
 // [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig], and [JSONFormatConfig] to pick
-// a preset. Customize a preset with [FormatConfig.Clone]. [FormatConfig.FormatColumn] runs
-// [FormatComplexFunc] plugins first, then built-in ARRAY, STRUCT, and scalar formatting.
+// a preset. Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
+// [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
+// without Decode; remove them from [FormatConfig.FormatComplexPlugins] on a clone to use
+// Decode + [FormatNullable]. Customize a preset with [FormatConfig.Clone].
+// [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in
+// ARRAY, STRUCT, and scalar formatting.
 // Convenience entry points include [FormatRowLiteral], [FormatColumnLiteral],
 // [FormatRowJSONObject], and [FormatRowSpannerCLICompatible]. Identifier quoting helpers are
 // [QuoteIdentifier] and [QuoteQualifiedIdentifier].

--- a/doc.go
+++ b/doc.go
@@ -9,8 +9,10 @@
 // [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig], and [JSONFormatConfig] to pick
 // a preset. Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
-// without Decode; remove them from [FormatConfig.FormatComplexPlugins] on a clone to use
-// Decode + [FormatNullable]. Customize a preset with [FormatConfig.Clone].
+// without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from
+// [FormatConfig.FormatComplexPlugins] on a clone to use Decode + [FormatNullable].
+// Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is replaced.
+// Customize a preset with [FormatConfig.Clone].
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in
 // ARRAY, STRUCT, and scalar formatting.
 // Convenience entry points include [FormatRowLiteral], [FormatColumnLiteral],

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -171,7 +171,7 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
-	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+	case sppb.TypeCode_INT64:
 		s := gcv.Value.GetStringValue()
 		if _, err := strconv.ParseInt(s, 10, 64); err != nil {
 			return "", err
@@ -219,7 +219,7 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:
-		return "", fmt.Errorf("%w: %T", ErrUnknownType, gcv.Type.GetCode())
+		return "", fmt.Errorf("%w: %v", ErrUnknownType, gcv.Type.String())
 	}
 }
 
@@ -257,7 +257,7 @@ func formatGCVScalarSpannerCLI(gcv spanner.GenericColumnValue) (string, error) {
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:
-		return "", fmt.Errorf("%w: %T", ErrUnknownType, gcv.Type.GetCode())
+		return "", fmt.Errorf("%w: %v", ErrUnknownType, gcv.Type.String())
 	}
 }
 
@@ -335,23 +335,11 @@ func gcvFloat32(v *structpb.Value) (float32, error) {
 }
 
 func readableStringFromBytesWire(gcv spanner.GenericColumnValue) (string, error) {
-	s := gcv.Value.GetStringValue()
-	if s == "" && gcv.Value != nil {
-		if _, ok := gcv.Value.Kind.(*structpb.Value_StringValue); !ok {
-			return "", fmt.Errorf("%w: BYTES/PROTO value kind %T", ErrUnknownType, gcv.Value.GetKind())
-		}
-	}
-	return internal.ReadableStringFromBase64Wire(s)
+	return internal.ReadableStringFromBase64Wire(gcv.Value.GetStringValue())
 }
 
 func bytesFromGCVString(gcv spanner.GenericColumnValue) ([]byte, error) {
-	s := gcv.Value.GetStringValue()
-	if s == "" && gcv.Value != nil {
-		if _, ok := gcv.Value.Kind.(*structpb.Value_StringValue); !ok {
-			return nil, fmt.Errorf("%w: BYTES/PROTO value kind %T", ErrUnknownType, gcv.Value.GetKind())
-		}
-	}
-	return base64.StdEncoding.DecodeString(s)
+	return base64.StdEncoding.DecodeString(gcv.Value.GetStringValue())
 }
 
 // numericWireString returns the NUMERIC string wire payload as-is. Spanner, Spanner Omni, and the

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -1,7 +1,6 @@
 package spanvalue
 
 import (
-	"encoding/base64"
 	"fmt"
 	"math"
 	"reflect"
@@ -136,29 +135,18 @@ func formatGCVScalarSimple(gcv spanner.GenericColumnValue) (string, error) {
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
-	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM, sppb.TypeCode_STRING,
+		sppb.TypeCode_TIMESTAMP, sppb.TypeCode_DATE, sppb.TypeCode_JSON,
+		sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
 		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_FLOAT32:
 		return formatFloatSimple(gcv, 32)
 	case sppb.TypeCode_FLOAT64:
 		return formatFloatSimple(gcv, 64)
-	case sppb.TypeCode_STRING:
-		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
-		return readableStringFromBytesWire(gcv)
-	case sppb.TypeCode_TIMESTAMP:
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_DATE:
-		return gcv.Value.GetStringValue(), nil
+		return internal.ReadableStringFromBase64Wire(gcv.Value.GetStringValue())
 	case sppb.TypeCode_NUMERIC:
 		return numericWireString(gcv), nil
-	case sppb.TypeCode_JSON:
-		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
-			return pgJSONBString(gcv)
-		}
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
-		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:
@@ -194,7 +182,7 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 	case sppb.TypeCode_STRING:
 		return internal.ToStringLiteral(gcv.Value.GetStringValue()), nil
 	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
-		b, err := bytesFromGCVString(gcv)
+		b, err := internal.DecodeBase64Wire(gcv.Value.GetStringValue())
 		if err != nil {
 			return "", err
 		}
@@ -206,14 +194,8 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 	case sppb.TypeCode_NUMERIC:
 		return stringBasedLiteral("NUMERIC", numericWireString(gcv)), nil
 	case sppb.TypeCode_JSON:
-		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
-			s, err := pgJSONBString(gcv)
-			if err != nil {
-				return "", err
-			}
-			return stringBasedLiteral("JSON", s), nil
-		}
-		return stringBasedLiteral("JSON", gcv.Value.GetStringValue()), nil
+		s := gcv.Value.GetStringValue()
+		return stringBasedLiteral("JSON", s), nil
 	case sppb.TypeCode_INTERVAL:
 		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue()), nil
 	case sppb.TypeCode_UUID:
@@ -232,29 +214,18 @@ func formatGCVScalarSpannerCLI(gcv spanner.GenericColumnValue) (string, error) {
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
-	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM, sppb.TypeCode_STRING,
+		sppb.TypeCode_BYTES, sppb.TypeCode_PROTO,
+		sppb.TypeCode_TIMESTAMP, sppb.TypeCode_DATE,
+		sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
 		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_FLOAT32:
 		return formatFloatSpannerCLI(gcv, 32)
 	case sppb.TypeCode_FLOAT64:
 		return formatFloatSpannerCLI(gcv, 64)
-	case sppb.TypeCode_STRING:
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
-		// Wire is base64; Spanner CLI output is the same encoding.
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_TIMESTAMP:
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_DATE:
-		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_NUMERIC:
 		return trimSpannerCLINumericFraction(numericWireString(gcv)), nil
 	case sppb.TypeCode_JSON:
-		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
-			return pgJSONBString(gcv)
-		}
-		return gcv.Value.GetStringValue(), nil
-	case sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
 		return gcv.Value.GetStringValue(), nil
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
@@ -336,21 +307,9 @@ func gcvFloat32(v *structpb.Value) (float32, error) {
 	}
 }
 
-func readableStringFromBytesWire(gcv spanner.GenericColumnValue) (string, error) {
-	return internal.ReadableStringFromBase64Wire(gcv.Value.GetStringValue())
-}
-
-func bytesFromGCVString(gcv spanner.GenericColumnValue) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(gcv.Value.GetStringValue())
-}
-
 // numericWireString returns the NUMERIC string wire payload as-is. Spanner, Spanner Omni, and the
 // emulator already emit canonical decimal strings; [gcvctor.NumericValue] and friends store the
 // same shape. Normalizing via big.Rat is the constructor's job, not spanvalue formatting.
 func numericWireString(gcv spanner.GenericColumnValue) string {
 	return gcv.Value.GetStringValue()
-}
-
-func pgJSONBString(gcv spanner.GenericColumnValue) (string, error) {
-	return gcv.Value.GetStringValue(), nil
 }

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -2,7 +2,6 @@ package spanvalue
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -69,12 +68,16 @@ func scalarFastPathActive(formatter Formatter, presetNullable FormatNullableFunc
 
 // FormatSimpleValue is a [FormatComplexFunc] that formats non-ARRAY, non-STRUCT scalars for
 // [SimpleFormatConfig] without constructing a [NullableValue]. It returns [ErrFallthrough] for
-// ARRAY and STRUCT, when [FormatConfig.FormatNullable] is not the preset default, or for types
-// handled by earlier plugins. NUMERIC uses the string wire payload as-is; canonical wire is the
-// GCV constructor's responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
+// ARRAY, STRUCT, and type codes outside [isScalarFastPathTypeCode], when
+// [FormatConfig.FormatNullable] is not the preset default, or for types handled by earlier
+// plugins. NUMERIC uses the string wire payload as-is; canonical wire is the GCV constructor's
+// responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
 func FormatSimpleValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
+		return "", ErrFallthrough
+	}
+	if !isScalarFastPathTypeCode(value.Type.GetCode()) {
 		return "", ErrFallthrough
 	}
 	if !scalarFastPathActive(formatter, formatNullableValueSimple) {
@@ -94,6 +97,9 @@ func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT, sppb.TypeCode_PROTO, sppb.TypeCode_ENUM:
 		return "", ErrFallthrough
 	}
+	if !isScalarFastPathTypeCode(value.Type.GetCode()) {
+		return "", ErrFallthrough
+	}
 	if !scalarFastPathActive(formatter, formatNullableValueLiteral) {
 		return "", ErrFallthrough
 	}
@@ -107,6 +113,9 @@ func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _
 func FormatSpannerCLIValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
+		return "", ErrFallthrough
+	}
+	if !isScalarFastPathTypeCode(value.Type.GetCode()) {
 		return "", ErrFallthrough
 	}
 	if !scalarFastPathActive(formatter, FormatNullableSpannerCLICompatible) {
@@ -353,22 +362,5 @@ func numericWireString(gcv spanner.GenericColumnValue) string {
 }
 
 func pgJSONBString(gcv spanner.GenericColumnValue) (string, error) {
-	switch k := gcv.Value.GetKind().(type) {
-	case *structpb.Value_StringValue:
-		return k.StringValue, nil
-	default:
-		b, err := gcv.Value.MarshalJSON()
-		if err != nil {
-			return "", err
-		}
-		var v any
-		if err := json.Unmarshal(b, &v); err != nil {
-			return "", err
-		}
-		out, err := json.Marshal(v)
-		if err != nil {
-			return "", err
-		}
-		return string(out), nil
-	}
+	return gcv.Value.GetStringValue(), nil
 }

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -1,0 +1,308 @@
+package spanvalue
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/apstndb/spanvalue/internal"
+)
+
+var (
+	_ FormatComplexFunc = FormatSimpleValue
+	_ FormatComplexFunc = FormatLiteralValue
+	_ FormatComplexFunc = FormatSpannerCLIValue
+)
+
+// FormatSimpleValue is a [FormatComplexFunc] that formats non-ARRAY, non-STRUCT scalars for
+// [SimpleFormatConfig] without constructing a [NullableValue]. It returns [ErrFallthrough] for
+// ARRAY and STRUCT. NUMERIC uses the string wire payload as-is; canonical wire is the GCV
+// constructor's responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
+func FormatSimpleValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+	switch value.Type.GetCode() {
+	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
+		return "", ErrFallthrough
+	}
+	if IsNull(value) {
+		return formatter.GetNullString(), nil
+	}
+	return formatGCVScalarSimple(value)
+}
+
+// FormatLiteralValue is a [FormatComplexFunc] for [LiteralFormatConfig]. It returns
+// [ErrFallthrough] for ARRAY, STRUCT, PROTO, and ENUM so [FormatProtoAsCast] and
+// [FormatEnumAsCast] run first.
+func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+	switch value.Type.GetCode() {
+	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT, sppb.TypeCode_PROTO, sppb.TypeCode_ENUM:
+		return "", ErrFallthrough
+	}
+	if IsNull(value) {
+		return formatter.GetNullString(), nil
+	}
+	return formatGCVScalarLiteral(value)
+}
+
+// FormatSpannerCLIValue is a [FormatComplexFunc] for [SpannerCLICompatibleFormatConfig].
+func FormatSpannerCLIValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+	switch value.Type.GetCode() {
+	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
+		return "", ErrFallthrough
+	}
+	if IsNull(value) {
+		return formatter.GetNullString(), nil
+	}
+	return formatGCVScalarSpannerCLI(value)
+}
+
+func formatGCVScalarSimple(gcv spanner.GenericColumnValue) (string, error) {
+	switch gcv.Type.GetCode() {
+	case sppb.TypeCode_BOOL:
+		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_FLOAT32:
+		return formatFloatSimple(gcv, 32)
+	case sppb.TypeCode_FLOAT64:
+		return formatFloatSimple(gcv, 64)
+	case sppb.TypeCode_STRING:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
+		return readableStringFromBytesWire(gcv)
+	case sppb.TypeCode_TIMESTAMP:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_DATE:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_NUMERIC:
+		return numericWireString(gcv), nil
+	case sppb.TypeCode_JSON:
+		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
+			return pgJSONBString(gcv)
+		}
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
+		fallthrough
+	default:
+		return "", fmt.Errorf("%w: %v", ErrUnknownType, gcv.Type.String())
+	}
+}
+
+func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
+	switch gcv.Type.GetCode() {
+	case sppb.TypeCode_BOOL:
+		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+		s := gcv.Value.GetStringValue()
+		if _, err := strconv.ParseInt(s, 10, 64); err != nil {
+			return "", err
+		}
+		return s, nil
+	case sppb.TypeCode_FLOAT32:
+		f, err := gcvFloat32(gcv.Value)
+		if err != nil {
+			return "", err
+		}
+		return internal.Float32ToLiteral(f), nil
+	case sppb.TypeCode_FLOAT64:
+		f, err := gcvFloat64(gcv.Value)
+		if err != nil {
+			return "", err
+		}
+		return internal.Float64ToLiteral(f), nil
+	case sppb.TypeCode_STRING:
+		return internal.ToStringLiteral(gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
+		b, err := bytesFromGCVString(gcv)
+		if err != nil {
+			return "", err
+		}
+		return internal.ToReadableBytesLiteral(b), nil
+	case sppb.TypeCode_TIMESTAMP:
+		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_DATE:
+		return stringBasedLiteral("DATE", gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_NUMERIC:
+		return stringBasedLiteral("NUMERIC", numericWireString(gcv)), nil
+	case sppb.TypeCode_JSON:
+		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
+			s, err := pgJSONBString(gcv)
+			if err != nil {
+				return "", err
+			}
+			return stringBasedLiteral("JSON", s), nil
+		}
+		return stringBasedLiteral("JSON", gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_INTERVAL:
+		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_UUID:
+		return stringLiteralCast("UUID", gcv.Value.GetStringValue()), nil
+	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
+		fallthrough
+	default:
+		return "", fmt.Errorf("%w: %T", ErrUnknownType, gcv.Type.GetCode())
+	}
+}
+
+func formatGCVScalarSpannerCLI(gcv spanner.GenericColumnValue) (string, error) {
+	switch gcv.Type.GetCode() {
+	case sppb.TypeCode_BOOL:
+		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_FLOAT32:
+		return formatFloatSpannerCLI(gcv, 32)
+	case sppb.TypeCode_FLOAT64:
+		return formatFloatSpannerCLI(gcv, 64)
+	case sppb.TypeCode_STRING:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
+		// Wire is base64; Spanner CLI output is the same encoding.
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_TIMESTAMP:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_DATE:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_NUMERIC:
+		return trimSpannerCLINumericFraction(numericWireString(gcv)), nil
+	case sppb.TypeCode_JSON:
+		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
+			return pgJSONBString(gcv)
+		}
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
+		return gcv.Value.GetStringValue(), nil
+	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
+		fallthrough
+	default:
+		return "", fmt.Errorf("%w: %T", ErrUnknownType, gcv.Type.GetCode())
+	}
+}
+
+func formatFloatSimple(gcv spanner.GenericColumnValue, bits int) (string, error) {
+	if bits == 32 {
+		f, err := gcvFloat32(gcv.Value)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%v", f), nil
+	}
+	f, err := gcvFloat64(gcv.Value)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", f), nil
+}
+
+func formatFloatSpannerCLI(gcv spanner.GenericColumnValue, bits int) (string, error) {
+	if bits == 32 {
+		f, err := gcvFloat32(gcv.Value)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%f", f), nil
+	}
+	f, err := gcvFloat64(gcv.Value)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%f", f), nil
+}
+
+// gcvFloat64 reads a FLOAT64 wire value (NumberValue or NaN/±Inf strings).
+// Logic matches cloud.google.com/go/spanner getFloat64Value.
+func gcvFloat64(v *structpb.Value) (float64, error) {
+	switch x := v.GetKind().(type) {
+	case *structpb.Value_NumberValue:
+		return x.NumberValue, nil
+	case *structpb.Value_StringValue:
+		switch x.StringValue {
+		case "NaN":
+			return math.NaN(), nil
+		case "Infinity":
+			return math.Inf(1), nil
+		case "-Infinity":
+			return math.Inf(-1), nil
+		default:
+			return 0, fmt.Errorf("%w: unexpected FLOAT64 string %q", ErrUnknownType, x.StringValue)
+		}
+	default:
+		return 0, fmt.Errorf("%w: FLOAT64 value kind %T", ErrUnknownType, v.GetKind())
+	}
+}
+
+// gcvFloat32 reads a FLOAT32 wire value. Logic matches cloud.google.com/go/spanner getFloat32Value.
+func gcvFloat32(v *structpb.Value) (float32, error) {
+	switch x := v.GetKind().(type) {
+	case *structpb.Value_NumberValue:
+		return float32(x.NumberValue), nil
+	case *structpb.Value_StringValue:
+		switch x.StringValue {
+		case "NaN":
+			return float32(math.NaN()), nil
+		case "Infinity":
+			return float32(math.Inf(1)), nil
+		case "-Infinity":
+			return float32(math.Inf(-1)), nil
+		default:
+			return 0, fmt.Errorf("%w: unexpected FLOAT32 string %q", ErrUnknownType, x.StringValue)
+		}
+	default:
+		return 0, fmt.Errorf("%w: FLOAT32 value kind %T", ErrUnknownType, v.GetKind())
+	}
+}
+
+func readableStringFromBytesWire(gcv spanner.GenericColumnValue) (string, error) {
+	s := gcv.Value.GetStringValue()
+	if s == "" && gcv.Value != nil {
+		if _, ok := gcv.Value.Kind.(*structpb.Value_StringValue); !ok {
+			return "", fmt.Errorf("%w: BYTES/PROTO value kind %T", ErrUnknownType, gcv.Value.GetKind())
+		}
+	}
+	return internal.ReadableStringFromBase64Wire(s)
+}
+
+func bytesFromGCVString(gcv spanner.GenericColumnValue) ([]byte, error) {
+	s := gcv.Value.GetStringValue()
+	if s == "" && gcv.Value != nil {
+		if _, ok := gcv.Value.Kind.(*structpb.Value_StringValue); !ok {
+			return nil, fmt.Errorf("%w: BYTES/PROTO value kind %T", ErrUnknownType, gcv.Value.GetKind())
+		}
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
+
+// numericWireString returns the NUMERIC string wire payload as-is. Spanner, Spanner Omni, and the
+// emulator already emit canonical decimal strings; [gcvctor.NumericValue] and friends store the
+// same shape. Normalizing via big.Rat is the constructor's job, not spanvalue formatting.
+func numericWireString(gcv spanner.GenericColumnValue) string {
+	return gcv.Value.GetStringValue()
+}
+
+func pgJSONBString(gcv spanner.GenericColumnValue) (string, error) {
+	switch k := gcv.Value.GetKind().(type) {
+	case *structpb.Value_StringValue:
+		return k.StringValue, nil
+	default:
+		b, err := gcv.Value.MarshalJSON()
+		if err != nil {
+			return "", err
+		}
+		var v any
+		if err := json.Unmarshal(b, &v); err != nil {
+			return "", err
+		}
+		out, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	}
+}

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
+	"slices"
 	"strconv"
 
 	"cloud.google.com/go/spanner"
@@ -20,13 +22,62 @@ var (
 	_ FormatComplexFunc = FormatSpannerCLIValue
 )
 
+var presetScalarPlugins = []FormatComplexFunc{
+	FormatSimpleValue,
+	FormatLiteralValue,
+	FormatSpannerCLIValue,
+}
+
+func isPresetScalarPlugin(f FormatComplexFunc) bool {
+	if f == nil {
+		return false
+	}
+	fp := reflect.ValueOf(f).Pointer()
+	for _, p := range presetScalarPlugins {
+		if reflect.ValueOf(p).Pointer() == fp {
+			return true
+		}
+	}
+	return false
+}
+
+func nullableFuncsEqual(a, b FormatNullableFunc) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
+// FormatConfigWithoutScalarPlugins returns a clone of fc with preset scalar fast-path plugins
+// removed so scalars use Decode and [FormatNullable].
+func FormatConfigWithoutScalarPlugins(fc *FormatConfig) *FormatConfig {
+	if fc == nil {
+		return nil
+	}
+	clone := fc.Clone()
+	clone.FormatComplexPlugins = slices.DeleteFunc(clone.FormatComplexPlugins, isPresetScalarPlugin)
+	return clone
+}
+
+func scalarFastPathActive(formatter Formatter, presetNullable FormatNullableFunc) bool {
+	fc, ok := formatter.(*FormatConfig)
+	if !ok {
+		return true
+	}
+	return nullableFuncsEqual(fc.FormatNullable, presetNullable)
+}
+
 // FormatSimpleValue is a [FormatComplexFunc] that formats non-ARRAY, non-STRUCT scalars for
 // [SimpleFormatConfig] without constructing a [NullableValue]. It returns [ErrFallthrough] for
-// ARRAY and STRUCT. NUMERIC uses the string wire payload as-is; canonical wire is the GCV
-// constructor's responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
+// ARRAY and STRUCT, when [FormatConfig.FormatNullable] is not the preset default, or for types
+// handled by earlier plugins. NUMERIC uses the string wire payload as-is; canonical wire is the
+// GCV constructor's responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
 func FormatSimpleValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 	switch value.Type.GetCode() {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
+		return "", ErrFallthrough
+	}
+	if !scalarFastPathActive(formatter, formatNullableValueSimple) {
 		return "", ErrFallthrough
 	}
 	if IsNull(value) {
@@ -43,6 +94,9 @@ func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT, sppb.TypeCode_PROTO, sppb.TypeCode_ENUM:
 		return "", ErrFallthrough
 	}
+	if !scalarFastPathActive(formatter, formatNullableValueLiteral) {
+		return "", ErrFallthrough
+	}
 	if IsNull(value) {
 		return formatter.GetNullString(), nil
 	}
@@ -55,6 +109,9 @@ func FormatSpannerCLIValue(formatter Formatter, value spanner.GenericColumnValue
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
 		return "", ErrFallthrough
 	}
+	if !scalarFastPathActive(formatter, FormatNullableSpannerCLICompatible) {
+		return "", ErrFallthrough
+	}
 	if IsNull(value) {
 		return formatter.GetNullString(), nil
 	}
@@ -62,6 +119,9 @@ func FormatSpannerCLIValue(formatter Formatter, value spanner.GenericColumnValue
 }
 
 func formatGCVScalarSimple(gcv spanner.GenericColumnValue) (string, error) {
+	if err := validateScalarWire(gcv); err != nil {
+		return "", err
+	}
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
@@ -96,6 +156,9 @@ func formatGCVScalarSimple(gcv spanner.GenericColumnValue) (string, error) {
 }
 
 func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
+	if err := validateScalarWire(gcv); err != nil {
+		return "", err
+	}
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
@@ -152,6 +215,9 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 }
 
 func formatGCVScalarSpannerCLI(gcv spanner.GenericColumnValue) (string, error) {
+	if err := validateScalarWire(gcv); err != nil {
+		return "", err
+	}
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -19,12 +19,14 @@ var (
 	_ FormatComplexFunc = FormatSimpleValue
 	_ FormatComplexFunc = FormatLiteralValue
 	_ FormatComplexFunc = FormatSpannerCLIValue
+	_ FormatComplexFunc = FormatJSONSimpleValue
 )
 
 var presetScalarPlugins = []FormatComplexFunc{
 	FormatSimpleValue,
 	FormatLiteralValue,
 	FormatSpannerCLIValue,
+	FormatJSONSimpleValue,
 }
 
 func isPresetScalarPlugin(f FormatComplexFunc) bool {

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -59,6 +59,14 @@ func FormatConfigWithoutScalarPlugins(fc *FormatConfig) *FormatConfig {
 	return clone
 }
 
+// scalarTypeCode returns the column type code, or ok false to fall through when Type is nil.
+func scalarTypeCode(value spanner.GenericColumnValue) (sppb.TypeCode, bool) {
+	if value.Type == nil {
+		return 0, false
+	}
+	return value.Type.GetCode(), true
+}
+
 func scalarFastPathActive(formatter Formatter, presetNullable FormatNullableFunc) bool {
 	fc, ok := formatter.(*FormatConfig)
 	if !ok {
@@ -74,11 +82,15 @@ func scalarFastPathActive(formatter Formatter, presetNullable FormatNullableFunc
 // plugins. NUMERIC uses the string wire payload as-is; canonical wire is the GCV constructor's
 // responsibility (see [github.com/apstndb/spanvalue/gcvctor.StringBasedValueFromCode]).
 func FormatSimpleValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
-	switch value.Type.GetCode() {
+	code, ok := scalarTypeCode(value)
+	if !ok {
+		return "", ErrFallthrough
+	}
+	switch code {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
 		return "", ErrFallthrough
 	}
-	if !isScalarFastPathTypeCode(value.Type.GetCode()) {
+	if !isScalarFastPathTypeCode(code) {
 		return "", ErrFallthrough
 	}
 	if !scalarFastPathActive(formatter, formatNullableValueSimple) {
@@ -112,11 +124,15 @@ func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _
 
 // FormatSpannerCLIValue is a [FormatComplexFunc] for [SpannerCLICompatibleFormatConfig].
 func FormatSpannerCLIValue(formatter Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
-	switch value.Type.GetCode() {
+	code, ok := scalarTypeCode(value)
+	if !ok {
+		return "", ErrFallthrough
+	}
+	switch code {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT:
 		return "", ErrFallthrough
 	}
-	if !isScalarFastPathTypeCode(value.Type.GetCode()) {
+	if !isScalarFastPathTypeCode(code) {
 		return "", ErrFallthrough
 	}
 	if !scalarFastPathActive(formatter, FormatNullableSpannerCLICompatible) {

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -240,13 +240,13 @@ func formatFloatSimple(gcv spanner.GenericColumnValue, bits int) (string, error)
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%v", f), nil
+		return strconv.FormatFloat(float64(f), 'g', -1, 32), nil
 	}
 	f, err := gcvFloat64(gcv.Value)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%v", f), nil
+	return strconv.FormatFloat(f, 'g', -1, 64), nil
 }
 
 func formatFloatSpannerCLI(gcv spanner.GenericColumnValue, bits int) (string, error) {
@@ -255,13 +255,13 @@ func formatFloatSpannerCLI(gcv spanner.GenericColumnValue, bits int) (string, er
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%f", f), nil
+		return strconv.FormatFloat(float64(f), 'f', 6, 32), nil
 	}
 	f, err := gcvFloat64(gcv.Value)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%f", f), nil
+	return strconv.FormatFloat(f, 'f', 6, 64), nil
 }
 
 // gcvFloat64 reads a FLOAT64 wire value (NumberValue or NaN/±Inf strings).

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -3,44 +3,22 @@ package spanvalue
 import (
 	"math"
 	"math/big"
-	"reflect"
-	"slices"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var scalarFastPathPluginPCs = func() []uintptr {
-	plugins := []FormatComplexFunc{
-		FormatSimpleValue,
-		FormatLiteralValue,
-		FormatSpannerCLIValue,
-		FormatJSONSimpleValue,
-	}
-	pcs := make([]uintptr, len(plugins))
-	for i, p := range plugins {
-		pcs[i] = reflect.ValueOf(p).Pointer()
-	}
-	return pcs
-}()
-
-func isScalarFastPathPlugin(f FormatComplexFunc) bool {
-	if f == nil {
-		return false
-	}
-	return slices.Contains(scalarFastPathPluginPCs, reflect.ValueOf(f).Pointer())
-}
-
 func formatConfigNullableOnly(fc *FormatConfig) *FormatConfig {
-	clone := fc.Clone()
-	clone.FormatComplexPlugins = slices.DeleteFunc(clone.FormatComplexPlugins, isScalarFastPathPlugin)
-	return clone
+	return FormatConfigWithoutScalarPlugins(fc)
 }
 
 func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {
@@ -99,5 +77,33 @@ func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFormatConfig_customFormatNullableUsesHook(t *testing.T) {
+	t.Parallel()
+
+	fc := SimpleFormatConfig()
+	fc.FormatNullable = func(NullableValue) (string, error) { return "CUSTOM", nil }
+
+	got, err := fc.FormatToplevelColumn(gcvctor.BoolValue(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "CUSTOM" {
+		t.Fatalf("got %q want CUSTOM", got)
+	}
+}
+
+func TestFormatSimpleValue_rejectsMalformedWireKind(t *testing.T) {
+	t.Parallel()
+
+	gcv := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_BOOL),
+		Value: structpb.NewStringValue("true"),
+	}
+	_, err := SimpleFormatConfig().FormatToplevelColumn(gcv)
+	if err == nil {
+		t.Fatal("expected error for BOOL typed value with string wire")
 	}
 }

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -1,0 +1,103 @@
+package spanvalue
+
+import (
+	"math"
+	"math/big"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+)
+
+var scalarFastPathPluginPCs = func() []uintptr {
+	plugins := []FormatComplexFunc{
+		FormatSimpleValue,
+		FormatLiteralValue,
+		FormatSpannerCLIValue,
+		FormatJSONSimpleValue,
+	}
+	pcs := make([]uintptr, len(plugins))
+	for i, p := range plugins {
+		pcs[i] = reflect.ValueOf(p).Pointer()
+	}
+	return pcs
+}()
+
+func isScalarFastPathPlugin(f FormatComplexFunc) bool {
+	if f == nil {
+		return false
+	}
+	return slices.Contains(scalarFastPathPluginPCs, reflect.ValueOf(f).Pointer())
+}
+
+func formatConfigNullableOnly(fc *FormatConfig) *FormatConfig {
+	clone := fc.Clone()
+	clone.FormatComplexPlugins = slices.DeleteFunc(clone.FormatComplexPlugins, isScalarFastPathPlugin)
+	return clone
+}
+
+func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {
+	t.Parallel()
+
+	rat := big.NewRat(314, 100)
+	pgRat := big.NewRat(22, 7)
+	ts := lo.Must(time.Parse(time.RFC3339Nano, "2020-01-02T03:04:05.123456789Z"))
+	uid := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+	scalars := []spanner.GenericColumnValue{
+		gcvctor.BoolValue(true),
+		gcvctor.Int64Value(42),
+		gcvctor.Float32Value(float32(1.25)),
+		gcvctor.Float64Value(math.Pi),
+		gcvctor.StringValue("hello"),
+		gcvctor.BytesValue([]byte{0, 1, 2, 255}),
+		gcvctor.BytesValue([]byte(`a\b`)),
+		gcvctor.DateValue(civil.Date{Year: 2020, Month: 1, Day: 2}),
+		gcvctor.TimestampValue(ts),
+		gcvctor.NumericValue(rat),
+		gcvctor.PGNumericValue(pgRat),
+		lo.Must(gcvctor.JSONValue(map[string]any{"k": 1})),
+		lo.Must(gcvctor.PGJSONBValue(map[string]int{"k": 1})),
+		lo.Must(gcvctor.IntervalStringValue("P1Y2M3DT4H5M6.789S")),
+		gcvctor.UUIDValue(uid),
+		gcvctor.Float64Value(math.NaN()),
+		gcvctor.Float64Value(math.Inf(1)),
+	}
+
+	presets := []struct {
+		name string
+		fc   *FormatConfig
+	}{
+		{name: "simple", fc: SimpleFormatConfig()},
+		{name: "literal", fc: LiteralFormatConfig()},
+		{name: "spanner_cli", fc: SpannerCLICompatibleFormatConfig()},
+	}
+
+	for _, preset := range presets {
+		preset := preset
+		t.Run(preset.name, func(t *testing.T) {
+			t.Parallel()
+			legacy := formatConfigNullableOnly(preset.fc)
+			for i, gcv := range scalars {
+				got, err := preset.fc.FormatToplevelColumn(gcv)
+				if err != nil {
+					t.Fatalf("scalar[%d] direct: %v", i, err)
+				}
+				want, err := legacy.FormatToplevelColumn(gcv)
+				if err != nil {
+					t.Fatalf("scalar[%d] nullable path: %v", i, err)
+				}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Fatalf("scalar[%d] (%s) mismatch (-nullable +direct):\n%s", i, gcv.Type.GetCode(), diff)
+				}
+			}
+		})
+	}
+}

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -95,6 +95,49 @@ func TestFormatConfig_customFormatNullableUsesHook(t *testing.T) {
 	}
 }
 
+func TestValidateFloatWire_nonFiniteStringsOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{"NaN", "Infinity", "-Infinity"} {
+		if err := validateFloatWire(structpb.NewStringValue(s), sppb.TypeCode_FLOAT64); err != nil {
+			t.Errorf("validateFloatWire(%q): %v", s, err)
+		}
+	}
+	if err := validateFloatWire(structpb.NewStringValue("1.5"), sppb.TypeCode_FLOAT64); err == nil {
+		t.Fatal("expected error for finite float as string wire")
+	}
+	if err := validateFloatWire(structpb.NewNumberValue(1.5), sppb.TypeCode_FLOAT64); err != nil {
+		t.Fatalf("number wire: %v", err)
+	}
+}
+
+func TestFormatSimpleValue_fallthroughUnknownTypeCode(t *testing.T) {
+	t.Parallel()
+
+	const want = "CUSTOM_UNKNOWN"
+	handler := FormatComplexFunc(func(_ Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+		if value.Type.GetCode() == sppb.TypeCode_TYPE_CODE_UNSPECIFIED {
+			return want, nil
+		}
+		return "", ErrFallthrough
+	})
+
+	fc := SimpleFormatConfig()
+	fc.FormatComplexPlugins = append(fc.FormatComplexPlugins, handler)
+
+	gcv := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED),
+		Value: structpb.NewStringValue("payload"),
+	}
+	got, err := fc.FormatToplevelColumn(gcv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
 func TestFormatSimpleValue_rejectsMalformedWireKind(t *testing.T) {
 	t.Parallel()
 

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -3,6 +3,7 @@ package spanvalue
 import (
 	"math"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
@@ -19,6 +20,18 @@ import (
 
 func formatConfigNullableOnly(fc *FormatConfig) *FormatConfig {
 	return FormatConfigWithoutScalarPlugins(fc)
+}
+
+func TestFormatConfigWithoutScalarPlugins_removesJSONScalarPlugin(t *testing.T) {
+	t.Parallel()
+
+	stripped := FormatConfigWithoutScalarPlugins(JSONFormatConfig())
+	jsonPlugin := reflect.ValueOf(FormatJSONSimpleValue).Pointer()
+	for _, p := range stripped.FormatComplexPlugins {
+		if reflect.ValueOf(p).Pointer() == jsonPlugin {
+			t.Fatal("FormatJSONSimpleValue still present after FormatConfigWithoutScalarPlugins")
+		}
+	}
 }
 
 func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -28,6 +28,9 @@ func validateScalarWire(gcv spanner.GenericColumnValue) error {
 	if IsNull(gcv) {
 		return fmt.Errorf("%w: null value", ErrUnknownType)
 	}
+	if gcv.Type == nil {
+		return fmt.Errorf("%w: nil type", ErrUnknownType)
+	}
 	code := gcv.Type.GetCode()
 	switch code {
 	case sppb.TypeCode_BOOL:

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -8,6 +8,22 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// isScalarFastPathTypeCode reports whether the preset scalar plugins format this
+// [sppb.TypeCode] directly. Other codes fall through to later plugins or
+// [FormatConfig.formatSimpleColumn].
+func isScalarFastPathTypeCode(code sppb.TypeCode) bool {
+	switch code {
+	case sppb.TypeCode_BOOL, sppb.TypeCode_INT64, sppb.TypeCode_ENUM,
+		sppb.TypeCode_FLOAT32, sppb.TypeCode_FLOAT64,
+		sppb.TypeCode_STRING, sppb.TypeCode_BYTES, sppb.TypeCode_PROTO,
+		sppb.TypeCode_TIMESTAMP, sppb.TypeCode_DATE, sppb.TypeCode_NUMERIC,
+		sppb.TypeCode_JSON, sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
+		return true
+	default:
+		return false
+	}
+}
+
 func validateScalarWire(gcv spanner.GenericColumnValue) error {
 	if gcv.Value == nil {
 		return nil
@@ -23,12 +39,9 @@ func validateScalarWire(gcv spanner.GenericColumnValue) error {
 	case sppb.TypeCode_FLOAT32, sppb.TypeCode_FLOAT64:
 		return validateFloatWire(gcv.Value, code)
 	case sppb.TypeCode_JSON:
-		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
-			return validatePGJSONBWire(gcv.Value)
-		}
+		// [sppb.TypeCode_JSON] and PG_JSONB-annotated JSON are encoded as a JSON string
+		// (see TypeCode godoc in cloud.google.com/go/spanner/apiv1/spannerpb).
 		return requireStringWire(gcv.Value, code)
-	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
-		fallthrough
 	default:
 		return fmt.Errorf("%w: %v", ErrUnknownType, gcv.Type.String())
 	}
@@ -49,19 +62,20 @@ func requireStringWire(v *structpb.Value, code sppb.TypeCode) error {
 }
 
 func validateFloatWire(v *structpb.Value, code sppb.TypeCode) error {
-	switch v.GetKind().(type) {
-	case *structpb.Value_NumberValue, *structpb.Value_StringValue:
+	// TypeCode_FLOAT32/FLOAT64: JSON number, or "NaN"/"Infinity"/"-Infinity" strings.
+	// Spanner client wire uses structpb NumberValue for finite values and StringValue
+	// for non-finite values (see [gcvctor.float64ToStructpbValue]).
+	switch k := v.GetKind().(type) {
+	case *structpb.Value_NumberValue:
 		return nil
+	case *structpb.Value_StringValue:
+		switch k.StringValue {
+		case "NaN", "Infinity", "-Infinity":
+			return nil
+		default:
+			return fmt.Errorf("%w: %v unexpected float string %q", ErrUnknownType, code, k.StringValue)
+		}
 	default:
 		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
-	}
-}
-
-func validatePGJSONBWire(v *structpb.Value) error {
-	switch v.GetKind().(type) {
-	case *structpb.Value_StringValue, *structpb.Value_StructValue, *structpb.Value_ListValue:
-		return nil
-	default:
-		return fmt.Errorf("%w: JSON value kind %T", ErrUnknownType, v.GetKind())
 	}
 }

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -25,8 +25,8 @@ func isScalarFastPathTypeCode(code sppb.TypeCode) bool {
 }
 
 func validateScalarWire(gcv spanner.GenericColumnValue) error {
-	if gcv.Value == nil {
-		return nil
+	if IsNull(gcv) {
+		return fmt.Errorf("%w: null value", ErrUnknownType)
 	}
 	code := gcv.Type.GetCode()
 	switch code {

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -1,0 +1,67 @@
+package spanvalue
+
+import (
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func validateScalarWire(gcv spanner.GenericColumnValue) error {
+	if gcv.Value == nil {
+		return nil
+	}
+	code := gcv.Type.GetCode()
+	switch code {
+	case sppb.TypeCode_BOOL:
+		return requireBoolWire(gcv.Value, code)
+	case sppb.TypeCode_INT64, sppb.TypeCode_ENUM, sppb.TypeCode_STRING,
+		sppb.TypeCode_BYTES, sppb.TypeCode_PROTO, sppb.TypeCode_TIMESTAMP, sppb.TypeCode_DATE,
+		sppb.TypeCode_NUMERIC, sppb.TypeCode_INTERVAL, sppb.TypeCode_UUID:
+		return requireStringWire(gcv.Value, code)
+	case sppb.TypeCode_FLOAT32, sppb.TypeCode_FLOAT64:
+		return validateFloatWire(gcv.Value, code)
+	case sppb.TypeCode_JSON:
+		if gcv.Type.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
+			return validatePGJSONBWire(gcv.Value)
+		}
+		return requireStringWire(gcv.Value, code)
+	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
+		fallthrough
+	default:
+		return fmt.Errorf("%w: %v", ErrUnknownType, gcv.Type.String())
+	}
+}
+
+func requireBoolWire(v *structpb.Value, code sppb.TypeCode) error {
+	if _, ok := v.GetKind().(*structpb.Value_BoolValue); !ok {
+		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+	}
+	return nil
+}
+
+func requireStringWire(v *structpb.Value, code sppb.TypeCode) error {
+	if _, ok := v.GetKind().(*structpb.Value_StringValue); !ok {
+		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+	}
+	return nil
+}
+
+func validateFloatWire(v *structpb.Value, code sppb.TypeCode) error {
+	switch v.GetKind().(type) {
+	case *structpb.Value_NumberValue, *structpb.Value_StringValue:
+		return nil
+	default:
+		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+	}
+}
+
+func validatePGJSONBWire(v *structpb.Value) error {
+	switch v.GetKind().(type) {
+	case *structpb.Value_StringValue, *structpb.Value_StructValue, *structpb.Value_ListValue:
+		return nil
+	default:
+		return fmt.Errorf("%w: JSON value kind %T", ErrUnknownType, v.GetKind())
+	}
+}

--- a/format_per_type_bench_test.go
+++ b/format_per_type_bench_test.go
@@ -1,0 +1,143 @@
+package spanvalue
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+)
+
+const benchCellsPerType = 10_000
+
+type benchScalarCase struct {
+	name string
+	// newCell returns a value for index i; generation runs once before timing.
+	newCell func(i int) spanner.GenericColumnValue
+}
+
+func benchScalarCases() []benchScalarCase {
+	rat := big.NewRat(314, 100)
+	pgRat := big.NewRat(22, 7)
+	ts := lo.Must(time.Parse(time.RFC3339Nano, "2020-01-02T03:04:05.123456789Z"))
+	date := civil.Date{Year: 2020, Month: 1, Day: 2}
+	uid := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	jsonGCV := lo.Must(gcvctor.JSONValue(map[string]any{"k": 1}))
+	pgJSONGCV := lo.Must(gcvctor.PGJSONBValue(map[string]int{"k": 1}))
+	intervalGCV := lo.Must(gcvctor.IntervalStringValue("P1Y2M3DT4H5M6.789S"))
+
+	return []benchScalarCase{
+		{name: "BOOL", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.BoolValue(i%2 == 0)
+		}},
+		{name: "INT64", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.Int64Value(int64(i))
+		}},
+		{name: "FLOAT32", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.Float32Value(float32(1.25) + float32(i)*1e-6)
+		}},
+		{name: "FLOAT64", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.Float64Value(3.141592653589793 + float64(i)*1e-9)
+		}},
+		{name: "FLOAT64_NaN", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.Float64Value(math.NaN())
+		}},
+		{name: "FLOAT64_Inf", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.Float64Value(math.Inf(1))
+		}},
+		{name: "STRING", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.StringValue(fmt.Sprintf("value-%d-with-padding", i))
+		}},
+		{name: "BYTES", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.BytesValue([]byte("payload-bytes"))
+		}},
+		{name: "DATE", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.DateValue(date)
+		}},
+		{name: "TIMESTAMP", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.TimestampValue(ts)
+		}},
+		{name: "NUMERIC", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.NumericValue(big.NewRat(int64(1000+i), 100))
+		}},
+		{name: "PG_NUMERIC", newCell: func(i int) spanner.GenericColumnValue {
+			return gcvctor.PGNumericValue(big.NewRat(int64(1000+i), 100))
+		}},
+		{name: "JSON", newCell: func(int) spanner.GenericColumnValue {
+			return jsonGCV
+		}},
+		{name: "PG_JSONB", newCell: func(int) spanner.GenericColumnValue {
+			return pgJSONGCV
+		}},
+		{name: "INTERVAL", newCell: func(int) spanner.GenericColumnValue {
+			return intervalGCV
+		}},
+		{name: "UUID", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.UUIDValue(uid)
+		}},
+		// NUMERIC allocates a new big.Rat per cell in newCell above; compare with shared rat:
+		{name: "NUMERIC_sharedRat", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.NumericValue(rat)
+		}},
+		{name: "PG_NUMERIC_sharedRat", newCell: func(int) spanner.GenericColumnValue {
+			return gcvctor.PGNumericValue(pgRat)
+		}},
+	}
+}
+
+func benchCellsForCase(tc benchScalarCase, n int) []spanner.GenericColumnValue {
+	out := make([]spanner.GenericColumnValue, n)
+	for i := range n {
+		out[i] = tc.newCell(i)
+	}
+	return out
+}
+
+var benchPerTypePresets = []struct {
+	name string
+	fc   func() *FormatConfig
+}{
+	{name: "Simple/Direct", fc: SimpleFormatConfig},
+	{name: "Simple/Nullable", fc: func() *FormatConfig {
+		return formatConfigNullableOnly(SimpleFormatConfig())
+	}},
+	{name: "Literal/Direct", fc: LiteralFormatConfig},
+	{name: "Literal/Nullable", fc: func() *FormatConfig {
+		return formatConfigNullableOnly(LiteralFormatConfig())
+	}},
+	{name: "SpannerCLI/Direct", fc: SpannerCLICompatibleFormatConfig},
+	{name: "SpannerCLI/Nullable", fc: func() *FormatConfig {
+		return formatConfigNullableOnly(SpannerCLICompatibleFormatConfig())
+	}},
+	{name: "JSON/Direct", fc: JSONFormatConfig},
+	{name: "JSON/Nullable", fc: func() *FormatConfig {
+		return formatConfigNullableOnly(JSONFormatConfig())
+	}},
+}
+
+// BenchmarkFormatPerType formats many cells of a single Spanner type per sub-benchmark.
+// Compare Direct (scalar FormatComplexFunc plugin) vs legacy Decode + FormatNullable.
+//
+// Examples:
+//
+//	go test -bench='BenchmarkFormatPerType/INT64/Simple' -benchmem .
+//	go test -bench='BenchmarkFormatPerType/BYTES' -benchmem -count=3 . | benchstat
+func BenchmarkFormatPerType(b *testing.B) {
+	for _, tc := range benchScalarCases() {
+		values := benchCellsForCase(tc, benchCellsPerType)
+		b.Run(tc.name, func(b *testing.B) {
+			for _, preset := range benchPerTypePresets {
+				preset := preset
+				b.Run(preset.name, func(b *testing.B) {
+					benchmarkFormatCells(b, preset.fc(), values)
+				})
+			}
+		})
+	}
+}

--- a/format_scalar_bench_test.go
+++ b/format_scalar_bench_test.go
@@ -1,0 +1,61 @@
+package spanvalue
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/samber/lo"
+)
+
+func benchmarkScalars() []spanner.GenericColumnValue {
+	rat := big.NewRat(314, 100)
+	ts := lo.Must(time.Parse(time.RFC3339Nano, "2020-01-02T03:04:05.123456789Z"))
+	return []spanner.GenericColumnValue{
+		gcvctor.StringValue("production-export-value-with-some-length"),
+		gcvctor.Int64Value(42424242),
+		gcvctor.BoolValue(true),
+		gcvctor.Float64Value(3.141592653589793),
+		gcvctor.BytesValue([]byte("ten bytes!")),
+		gcvctor.TimestampValue(ts),
+		gcvctor.NumericValue(rat),
+	}
+}
+
+func benchmarkFormatColumn(b *testing.B, fc *FormatConfig, values []spanner.GenericColumnValue) {
+	b.Helper()
+	b.ReportAllocs()
+	for range b.N {
+		for _, gcv := range values {
+			if _, err := fc.FormatToplevelColumn(gcv); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkFormatColumnSimple_Direct(b *testing.B) {
+	benchmarkFormatColumn(b, SimpleFormatConfig(), benchmarkScalars())
+}
+
+func BenchmarkFormatColumnSimple_NullablePath(b *testing.B) {
+	benchmarkFormatColumn(b, formatConfigNullableOnly(SimpleFormatConfig()), benchmarkScalars())
+}
+
+func BenchmarkFormatColumnLiteral_Direct(b *testing.B) {
+	benchmarkFormatColumn(b, LiteralFormatConfig(), benchmarkScalars())
+}
+
+func BenchmarkFormatColumnLiteral_NullablePath(b *testing.B) {
+	benchmarkFormatColumn(b, formatConfigNullableOnly(LiteralFormatConfig()), benchmarkScalars())
+}
+
+func BenchmarkFormatColumnSpannerCLI_Direct(b *testing.B) {
+	benchmarkFormatColumn(b, SpannerCLICompatibleFormatConfig(), benchmarkScalars())
+}
+
+func BenchmarkFormatColumnSpannerCLI_NullablePath(b *testing.B) {
+	benchmarkFormatColumn(b, formatConfigNullableOnly(SpannerCLICompatibleFormatConfig()), benchmarkScalars())
+}

--- a/format_throughput_bench_test.go
+++ b/format_throughput_bench_test.go
@@ -1,0 +1,104 @@
+// Throughput benchmarks: build many GenericColumnValues up front, then repeatedly
+// format and discard every cell. Use to compare scalar FormatComplexFunc plugins vs the
+// legacy Decode + FormatNullable path on a realistic mixed-type row shape.
+package spanvalue
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/samber/lo"
+)
+
+// benchSink prevents the compiler from eliding format results.
+var benchSink string
+
+// benchRowSchema is a fixed mix of scalar types resembling a delimited export row.
+func benchRowSchema(row int) []spanner.GenericColumnValue {
+	rat := big.NewRat(int64(1000+row), 100)
+	ts := lo.Must(time.Parse(time.RFC3339Nano, "2020-01-02T03:04:05.123456789Z"))
+	return []spanner.GenericColumnValue{
+		gcvctor.Int64Value(int64(row)),
+		gcvctor.StringValue(fmt.Sprintf("name-%d-with-padding-for-realistic-width", row)),
+		gcvctor.BoolValue(row%2 == 0),
+		gcvctor.Float64Value(3.141592653589793 + float64(row)*1e-6),
+		gcvctor.BytesValue([]byte("payload-bytes")),
+		gcvctor.TimestampValue(ts),
+		gcvctor.NumericValue(rat),
+		gcvctor.StringValue("tag"),
+	}
+}
+
+// benchDataset builds cellsToFormat values (rows × columns) once per sub-benchmark.
+func benchDataset(rows int) []spanner.GenericColumnValue {
+	const cols = 8
+	out := make([]spanner.GenericColumnValue, 0, rows*cols)
+	for r := range rows {
+		out = append(out, benchRowSchema(r)...)
+	}
+	return out
+}
+
+// benchmarkFormatCells formats every value in the slice each iteration and records
+// output into benchSink. bytes/op is estimated from the first cell's output length.
+func benchmarkFormatCells(b *testing.B, fc *FormatConfig, values []spanner.GenericColumnValue) {
+	b.Helper()
+	if len(values) == 0 {
+		b.Fatal("empty values")
+	}
+
+	b.StopTimer()
+	sample, err := fc.FormatToplevelColumn(values[0])
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(sample)) * int64(len(values)))
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for range b.N {
+		for _, gcv := range values {
+			s, err := fc.FormatToplevelColumn(gcv)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchSink = s
+		}
+	}
+}
+
+func benchmarkFormatThroughput(b *testing.B, fc *FormatConfig, values []spanner.GenericColumnValue) {
+	b.Helper()
+	benchmarkFormatCells(b, fc, values)
+}
+
+func BenchmarkFormatThroughput(b *testing.B) {
+	sizes := []int{1_000, 10_000}
+	for _, rows := range sizes {
+		values := benchDataset(rows)
+		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
+			b.Run("Simple/Direct", func(b *testing.B) {
+				benchmarkFormatThroughput(b, SimpleFormatConfig(), values)
+			})
+			b.Run("Simple/Nullable", func(b *testing.B) {
+				benchmarkFormatThroughput(b, formatConfigNullableOnly(SimpleFormatConfig()), values)
+			})
+			b.Run("Literal/Direct", func(b *testing.B) {
+				benchmarkFormatThroughput(b, LiteralFormatConfig(), values)
+			})
+			b.Run("Literal/Nullable", func(b *testing.B) {
+				benchmarkFormatThroughput(b, formatConfigNullableOnly(LiteralFormatConfig()), values)
+			})
+			b.Run("SpannerCLI/Direct", func(b *testing.B) {
+				benchmarkFormatThroughput(b, SpannerCLICompatibleFormatConfig(), values)
+			})
+			b.Run("SpannerCLI/Nullable", func(b *testing.B) {
+				benchmarkFormatThroughput(b, formatConfigNullableOnly(SpannerCLICompatibleFormatConfig()), values)
+			})
+		})
+	}
+}

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -47,6 +47,11 @@
 // ([cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_NUMERIC],
 // [cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_JSONB]).
 //
+// NUMERIC wire strings: [NumericValue] and [PGNumericValue] store Spanner-canonical decimals.
+// [StringBasedValueFromCode] does not normalize; callers that build NUMERIC cells by hand must
+// supply the same wire form Spanner returns (see that helper's doc). The [github.com/apstndb/spanvalue]
+// formatters treat NUMERIC string payloads as authoritative and do not parse them again.
+//
 // Formatting these values as strings is provided by the sibling package
 // [github.com/apstndb/spanvalue].
 package gcvctor

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -168,6 +168,13 @@ func BytesBasedValueOf(typ *sppb.Type, v []byte) spanner.GenericColumnValue {
 
 // StringBasedValueFromCode constructs a GenericColumnValue for a simple scalar type code
 // with a string wire payload.
+//
+// For [sppb.TypeCode_NUMERIC] and NUMERIC with [sppb.TypeAnnotationCode_PG_NUMERIC], v must
+// already be the canonical wire string Spanner uses (for GoogleSQL NUMERIC, the same form as
+// [cloud.google.com/go/spanner.NumericString] on a [*big.Rat]). spanvalue formatters read the
+// wire string as-is and do not re-normalize. Prefer [NumericValue], [PGNumericValue], or values
+// from the Spanner client (including the emulator and Spanner Omni) over passing arbitrary
+// decimals here.
 func StringBasedValueFromCode(code sppb.TypeCode, v string) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(code),
@@ -205,7 +212,8 @@ func TimestampStringValue(v string) (spanner.GenericColumnValue, error) {
 	return TimestampValue(ts.UTC()), nil
 }
 
-// NumericValue returns a NUMERIC GenericColumnValue.
+// NumericValue returns a NUMERIC GenericColumnValue with a canonical wire string from
+// [cloud.google.com/go/spanner.NumericString].
 // A nil v returns a typed SQL NULL NUMERIC for backward compatibility; use
 // [NumericValueChecked] to reject nil input with [ErrNilNumeric].
 func NumericValue(v *big.Rat) spanner.GenericColumnValue {
@@ -254,7 +262,8 @@ func JSONValue(v any) (spanner.GenericColumnValue, error) {
 }
 
 // PGNumericValue returns a PostgreSQL-dialect NUMERIC GenericColumnValue
-// ([sppb.TypeAnnotationCode_PG_NUMERIC]).
+// ([sppb.TypeAnnotationCode_PG_NUMERIC]) with a canonical wire string from
+// [cloud.google.com/go/spanner.NumericString].
 // A nil v returns a typed SQL NULL PG NUMERIC for backward compatibility; use
 // [PGNumericValueChecked] to reject nil input with [ErrNilNumeric].
 func PGNumericValue(v *big.Rat) spanner.GenericColumnValue {

--- a/internal/readable_bytes.go
+++ b/internal/readable_bytes.go
@@ -44,7 +44,7 @@ func ReadableBytesString(b []byte) string {
 	if isReadableASCII(b) {
 		return string(b)
 	}
-	out := make([]byte, 0, len(b)+len(b))
+	out := make([]byte, 0, len(b))
 	out = appendReadableEscaped(out, b)
 	return string(out)
 }
@@ -104,7 +104,7 @@ func ReadableStringFromBase64Wire(wire string) (string, error) {
 		return out, nil
 	}
 
-	out := make([]byte, 0, nw+nw)
+	out := make([]byte, 0, nw)
 	out = appendReadableEscaped(out, decoded)
 	putDecodeBuf(bp, buf)
 	return string(out), nil

--- a/internal/readable_bytes.go
+++ b/internal/readable_bytes.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/base64"
 	"sync"
+	"unsafe"
 )
 
 // readableEscapedByte maps each byte to the same text as EscapeRune(b, false, -1).
@@ -64,6 +65,16 @@ func putDecodeBuf(bp *[]byte, buf []byte) {
 	base64DecodeBufPool.Put(bp)
 }
 
+// base64WireInput is a zero-copy view of wire for [base64.StdEncoding.Decode].
+// The slice aliases wire and must not outlive it or be retained after Decode returns.
+// wire must not be mutated concurrently for the duration of Decode; Spanner
+// GenericColumnValue string wire from GetStringValue satisfies this when the
+// value is not modified per cloud.google.com/go/spanner.GenericColumnValue docs.
+// Call only when len(wire) > 0.
+func base64WireInput(wire string) []byte {
+	return unsafe.Slice(unsafe.StringData(wire), len(wire))
+}
+
 // ReadableStringFromBase64Wire decodes a Spanner BYTES/PROTO base64 wire string and
 // formats the payload with [ReadableBytesString].
 func ReadableStringFromBase64Wire(wire string) (string, error) {
@@ -80,7 +91,7 @@ func ReadableStringFromBase64Wire(wire string) (string, error) {
 		buf = buf[:n]
 	}
 
-	nw, err := base64.StdEncoding.Decode(buf, []byte(wire))
+	nw, err := base64.StdEncoding.Decode(buf, base64WireInput(wire))
 	if err != nil {
 		putDecodeBuf(bp, buf)
 		return "", err

--- a/internal/readable_bytes.go
+++ b/internal/readable_bytes.go
@@ -1,0 +1,100 @@
+package internal
+
+import (
+	"encoding/base64"
+	"sync"
+)
+
+// readableEscapedByte maps each byte to the same text as EscapeRune(b, false, -1).
+var readableEscapedByte [256]string
+
+func init() {
+	for b := range readableEscapedByte {
+		readableEscapedByte[b] = EscapeRune(rune(b), false, -1)
+	}
+}
+
+func isReadableASCII(b []byte) bool {
+	for _, c := range b {
+		if c == '\\' || c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func appendReadableEscaped(dst []byte, b []byte) []byte {
+	for _, c := range b {
+		esc := readableEscapedByte[c]
+		if len(esc) == 1 {
+			dst = append(dst, esc[0])
+		} else {
+			dst = append(dst, esc...)
+		}
+	}
+	return dst
+}
+
+// ReadableBytesString formats raw bytes for Simple-style output (no b" quotes).
+func ReadableBytesString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if isReadableASCII(b) {
+		return string(b)
+	}
+	out := make([]byte, 0, len(b)+len(b))
+	out = appendReadableEscaped(out, b)
+	return string(out)
+}
+
+var base64DecodeBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 64)
+		return &b
+	},
+}
+
+func putDecodeBuf(bp *[]byte, buf []byte) {
+	if cap(buf) > 4096 {
+		*bp = nil
+	} else {
+		*bp = buf[:0]
+	}
+	base64DecodeBufPool.Put(bp)
+}
+
+// ReadableStringFromBase64Wire decodes a Spanner BYTES/PROTO base64 wire string and
+// formats the payload with [ReadableBytesString].
+func ReadableStringFromBase64Wire(wire string) (string, error) {
+	if wire == "" {
+		return "", nil
+	}
+
+	n := base64.StdEncoding.DecodedLen(len(wire))
+	bp := base64DecodeBufPool.Get().(*[]byte)
+	buf := *bp
+	if cap(buf) < n {
+		buf = make([]byte, n)
+	} else {
+		buf = buf[:n]
+	}
+
+	nw, err := base64.StdEncoding.Decode(buf, []byte(wire))
+	if err != nil {
+		putDecodeBuf(bp, buf)
+		return "", err
+	}
+	decoded := buf[:nw]
+
+	if isReadableASCII(decoded) {
+		out := string(decoded)
+		putDecodeBuf(bp, buf)
+		return out, nil
+	}
+
+	out := make([]byte, 0, nw+nw)
+	out = appendReadableEscaped(out, decoded)
+	putDecodeBuf(bp, buf)
+	return string(out), nil
+}

--- a/internal/readable_bytes.go
+++ b/internal/readable_bytes.go
@@ -75,11 +75,11 @@ func base64WireInput(wire string) []byte {
 	return unsafe.Slice(unsafe.StringData(wire), len(wire))
 }
 
-// ReadableStringFromBase64Wire decodes a Spanner BYTES/PROTO base64 wire string and
-// formats the payload with [ReadableBytesString].
-func ReadableStringFromBase64Wire(wire string) (string, error) {
+// DecodeBase64Wire decodes a Spanner BYTES/PROTO base64 wire string.
+// The returned slice is owned by the caller (not pooled).
+func DecodeBase64Wire(wire string) ([]byte, error) {
 	if wire == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	n := base64.StdEncoding.DecodedLen(len(wire))
@@ -90,22 +90,21 @@ func ReadableStringFromBase64Wire(wire string) (string, error) {
 	} else {
 		buf = buf[:n]
 	}
+	defer putDecodeBuf(bp, buf)
 
 	nw, err := base64.StdEncoding.Decode(buf, base64WireInput(wire))
 	if err != nil {
-		putDecodeBuf(bp, buf)
+		return nil, err
+	}
+	return append([]byte(nil), buf[:nw]...), nil
+}
+
+// ReadableStringFromBase64Wire decodes a Spanner BYTES/PROTO base64 wire string and
+// formats the payload with [ReadableBytesString].
+func ReadableStringFromBase64Wire(wire string) (string, error) {
+	b, err := DecodeBase64Wire(wire)
+	if err != nil {
 		return "", err
 	}
-	decoded := buf[:nw]
-
-	if isReadableASCII(decoded) {
-		out := string(decoded)
-		putDecodeBuf(bp, buf)
-		return out, nil
-	}
-
-	out := make([]byte, 0, nw)
-	out = appendReadableEscaped(out, decoded)
-	putDecodeBuf(bp, buf)
-	return string(out), nil
+	return ReadableBytesString(b), nil
 }

--- a/internal/readable_bytes_test.go
+++ b/internal/readable_bytes_test.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadableBytesString_matchesEscapeRune(t *testing.T) {
+	t.Parallel()
+
+	var all [256]byte
+	for i := range all {
+		all[i] = byte(i)
+	}
+	for _, b := range [][]byte{
+		nil,
+		{},
+		[]byte("abc"),
+		[]byte("\x00\x01\x7f\xff"),
+		all[:],
+	} {
+		got := ReadableBytesString(b)
+		var want strings.Builder
+		for _, c := range b {
+			want.WriteString(EscapeRune(rune(c), false, -1))
+		}
+		if got != want.String() {
+			t.Fatalf("ReadableBytesString(%q) = %q, want %q", b, got, want.String())
+		}
+	}
+}
+
+func TestReadableStringFromBase64Wire(t *testing.T) {
+	t.Parallel()
+
+	wire := "SGVsbG8="
+	got, err := ReadableStringFromBase64Wire(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ReadableBytesString([]byte("Hello"))
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+
+	_, err = ReadableStringFromBase64Wire("!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestReadableBytesString_readableASCIIFastPath(t *testing.T) {
+	t.Parallel()
+
+	const s = "payload-bytes"
+	if got := ReadableBytesString([]byte(s)); got != s {
+		t.Fatalf("got %q want %q", got, s)
+	}
+	got, err := ReadableStringFromBase64Wire("cGF5bG9hZC1ieXRlcw==") // "payload-bytes"
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != s {
+		t.Fatalf("wire fast path: got %q want %q", got, s)
+	}
+}
+
+func BenchmarkReadableStringFromBase64Wire(b *testing.B) {
+	const wire = "SGVsbG8gV29ybGQh" // "Hello World!"
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := ReadableStringFromBase64Wire(wire); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/literal.go
+++ b/literal.go
@@ -35,6 +35,7 @@ func LiteralFormatConfig() *FormatConfig {
 		FormatComplexPlugins: []FormatComplexFunc{
 			FormatProtoAsCast,
 			FormatEnumAsCast,
+			FormatLiteralValue,
 		},
 	}
 }

--- a/simple.go
+++ b/simple.go
@@ -15,6 +15,9 @@ func SimpleFormatConfig() *FormatConfig {
 			FormatStructParen: FormatTupleStruct,
 		},
 		FormatNullable: formatNullableValueSimple,
+		FormatComplexPlugins: []FormatComplexFunc{
+			FormatSimpleValue,
+		},
 	}
 }
 

--- a/spanner_cli_compatible.go
+++ b/spanner_cli_compatible.go
@@ -3,7 +3,6 @@ package spanvalue
 import (
 	"encoding/base64"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -27,14 +26,15 @@ func SpannerCLICompatibleFormatConfig() *FormatConfig {
 			FormatStructParen: FormatBracketStruct,
 		},
 		FormatNullable: FormatNullableSpannerCLICompatible,
+		FormatComplexPlugins: []FormatComplexFunc{
+			FormatSpannerCLIValue,
+		},
 	}
 }
 
 func FormatRowSpannerCLICompatible(row *spanner.Row) ([]string, error) {
 	return spannerCLICompatibleFormatConfig.FormatRow(row)
 }
-
-var trailingPointZeroRe = regexp.MustCompile(`\.?0*$`)
 
 func FormatNullableSpannerCLICompatible(value NullableValue) (string, error) {
 	// Actually, it is redundant to check IsNull() here, but it is for consistency.
@@ -50,9 +50,9 @@ func FormatNullableSpannerCLICompatible(value NullableValue) (string, error) {
 	case spanner.NullFloat64:
 		return fmt.Sprintf("%f", v.Float64), nil
 	case spanner.NullNumeric:
-		return trailingPointZeroRe.ReplaceAllString(v.String(), ""), nil
+		return trimSpannerCLINumericFraction(v.String()), nil
 	case spanner.PGNumeric:
-		return trailingPointZeroRe.ReplaceAllString(v.Numeric, ""), nil
+		return trimSpannerCLINumericFraction(v.Numeric), nil
 	case spanner.NullTime:
 		return v.Time.Format(time.RFC3339Nano), nil
 	// They are actually processed by the default case, but explicitly written here for clarity.

--- a/spanner_cli_compatible_test.go
+++ b/spanner_cli_compatible_test.go
@@ -122,6 +122,11 @@ func TestDecodeColumn(t *testing.T) {
 			want:  "1.23",
 		},
 		{
+			desc:  "numeric integer",
+			value: big.NewRat(10, 1),
+			want:  "10",
+		},
+		{
 			desc:  "string",
 			value: "foo",
 			want:  "foo",

--- a/spanner_cli_numeric_trim.go
+++ b/spanner_cli_numeric_trim.go
@@ -1,0 +1,14 @@
+package spanvalue
+
+import "strings"
+
+// trimSpannerCLINumericFraction trims trailing zeros in the fractional part of a
+// NUMERIC wire string for Spanner CLI output (e.g. "3.140" → "3.14", "10.0" → "10").
+// Integer values without a decimal point are unchanged ("10" stays "10").
+func trimSpannerCLINumericFraction(s string) string {
+	if !strings.Contains(s, ".") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	return strings.TrimRight(s, ".")
+}

--- a/spanner_cli_numeric_trim_test.go
+++ b/spanner_cli_numeric_trim_test.go
@@ -1,0 +1,28 @@
+package spanvalue
+
+import "testing"
+
+func TestTrimSpannerCLINumericFraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in, want string
+	}{
+		{"3.140", "3.14"},
+		{"10.0", "10"},
+		{"10.00", "10"},
+		{"0.50", "0.5"},
+		{"0.0", "0"},
+		{"10", "10"},
+		{"100", "100"},
+		{"1000", "1000"},
+		{"42", "42"},
+		{"1.23", "1.23"},
+		{"-10.50", "-10.5"},
+	}
+	for _, tc := range tests {
+		if got := trimSpannerCLINumericFraction(tc.in); got != tc.want {
+			t.Errorf("trimSpannerCLINumericFraction(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add preset scalar `FormatComplexFunc` plugins (`FormatSimpleValue`, `FormatLiteralValue`, `FormatSpannerCLIValue`) so Simple, Literal, and Spanner CLI format `GenericColumnValue` without `Decode` + `FormatNullable`, matching the existing JSON plugin pattern.
- Optimize Simple-style BYTES/PROTO output with table-driven escaping and a readable-ASCII fast path; route `NullBytes.String()` through the same helper. Base64 decode uses a zero-copy `wire` view (`base64WireInput`).
- Fix Spanner CLI NUMERIC trimming for integer wire strings (`"10"` stays `10`) via `trimSpannerCLINumericFraction`, used on both the plugin and nullable paths.
- Validate scalar `structpb` wire kinds on the fast path; fall through unrecognized `TypeCode` values and when `FormatNullable` is replaced so custom plugins still work (`FormatConfigWithoutScalarPlugins` helper, including `FormatJSONSimpleValue`).
- Document NUMERIC wire ownership in `gcvctor` and add format benchmarks (`format_scalar_bench_test.go`, `format_throughput_bench_test.go`, `format_per_type_bench_test.go`).

## Benchmarks

Measured on **Apple M2**, `go1.26.3 (module go 1.23)`, `go test -benchmem` at HEAD. **Direct** = preset config with scalar plugins; **Nullable** = same preset with plugins stripped via `FormatConfigWithoutScalarPlugins` (legacy `Decode` + `FormatNullable`).

Reproduce:

```bash
go test -bench='BenchmarkFormatColumn' -benchmem -count=3 .
go test -bench='BenchmarkFormatThroughput' -benchmem -count=1 .
go test -bench='BenchmarkFormatPerType/BYTES/Simple' -benchmem -count=1 .
```

### Mixed scalars (7 cells/iter: STRING, INT64, BOOL, FLOAT64, BYTES, TIMESTAMP, NUMERIC)

| Preset | Direct | Nullable | ~speedup |
|--------|--------|----------|----------|
| Simple | ~6 µs/op, 3 allocs/op | ~30 µs/op, 49 allocs/op | **~5×** |
| Literal | ~19 µs/op, 103 allocs/op | ~30 µs/op, 144 allocs/op | **~1.5×** |
| Spanner CLI | ~1.6 µs/op, 2 allocs/op | ~17 µs/op, 49 allocs/op | **~10×** |

### Throughput (10k rows × 8 scalar columns = 80k cells)

| Preset | Direct | Nullable | ~speedup |
|--------|--------|----------|----------|
| Simple | ~45 ms (~1.7 MB/s) | ~390 ms | **~8–14×** |
| Literal | ~345 ms | ~528 ms | **~1.5×** |
| Spanner CLI | ~28 ms (~2.8 MB/s) | ~142 ms | **~5×** |

### BYTES only (10k cells, Simple)

| Path | Time | Allocs |
|------|------|--------|
| Direct | ~22 ms (~5.8 MB/s) | 10k allocs/op (mostly output `string`) |
| Nullable | ~44 ms | 50k allocs/op |

End-to-end wins are largest for **Simple** and **Spanner CLI** exports; **Literal** still allocates heavily per cell (casts/quotes) so the gap is smaller. Alloc counts on Direct paths are dominated by formatted output strings, not by avoiding `NullableValue` construction.

## Test plan

- [x] `make check`
- [x] `TestFormatGCVScalarPluginsMatchNullablePath` (parity vs nullable path)
- [x] `TestFormatConfig_customFormatNullableUsesHook`
- [x] `TestFormatSimpleValue_fallthroughUnknownTypeCode`
- [x] `TestFormatConfigWithoutScalarPlugins_removesJSONScalarPlugin`
- [x] `spanner_cli_compatible` numeric integer case (`10`)