### PR TITLE
feat(writer): RunRowIterator and WriteRowIterator for streaming exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ registers `iter.Metadata` on the first `Next`, streams rows, and finishes with
 and query stats even when the iterator is empty:
 
 ```go
-iter := txn.QueryWithStats(ctx, stmt)
+iter := txn.QueryWithStats(ctx, stmt) // WriteRowIterator stops iter for us
 
 w := writer.NewDelimitedWriter(
 	out,
@@ -137,14 +137,16 @@ _ = result.Metadata
 _ = result.Stats.QueryStats
 ```
 
-The manual `iter.Next` loop in older examples is equivalent; prefer
-`WriteRowIterator` when you need metadata or stats after an empty result.
+An equivalent manual loop — call `PrepareRowType(iter.Metadata.GetRowType())`
+after the first `Next`, write each row, then `Flush` — is still supported;
+prefer `WriteRowIterator` when you also need metadata or query stats from an
+empty result.
 
 ### Schema registration
 
 | Goal | API |
 |------|-----|
-| Streaming `RowIterator` | [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) / [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator), or `PrepareMetadata` / `PrepareRowType` after first `Next` then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
+| Streaming `RowIterator` | [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) / [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator), or `PrepareRowType` after first `Next` then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
 | Known column names only | `WithColumnNames` / `PrepareColumnNames` (at least one name) |
 | Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` (when `md` is already available) |
 | Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(metadata.GetRowType())` when fields are empty—**not** `PrepareColumnNames` |

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ return w.Flush()
 ```
 
 When a `SELECT` may return zero rows but metadata still lists result columns, use
-`iter.Next`. Spanner sets `iter.Metadata` after the first `Next` (row or
-`iterator.Done`); register names with `PrepareRowType` on that pass, then stream rows.
-`Flush` writes a pending header when no data row was emitted:
+`writer.WriteRowIterator` (or the generic `writer.RunRowIterator` with hooks). It
+registers `iter.Metadata` on the first `Next`, streams rows, and finishes with
+`Flush` (header-only when no data rows were written). It returns `iter.Metadata`
+and query stats even when the iterator is empty:
 
 ```go
-iter := txn.Query(ctx, stmt)
-defer iter.Stop()
+iter := txn.QueryWithStats(ctx, stmt)
 
 w := writer.NewDelimitedWriter(
 	out,
@@ -129,36 +129,22 @@ w := writer.NewDelimitedWriter(
 	writer.WithFormatter(cfg),
 	writer.WithHeader(true),
 )
-
-first := true
-for {
-	row, err := iter.Next()
-	if first {
-		first = false
-		if iter.Metadata != nil {
-			if err := w.PrepareRowType(iter.Metadata.GetRowType()); err != nil {
-				return err
-			}
-		}
-	}
-	if err == iterator.Done {
-		break
-	}
-	if err != nil {
-		return err
-	}
-	if err := w.WriteRow(row); err != nil {
-		return err
-	}
+result, err := writer.WriteRowIterator(iter, w)
+if err != nil {
+	return err
 }
-return w.Flush()
+_ = result.Metadata
+_ = result.Stats.QueryStats
 ```
+
+The manual `iter.Next` loop in older examples is equivalent; prefer
+`WriteRowIterator` when you need metadata or stats after an empty result.
 
 ### Schema registration
 
 | Goal | API |
 |------|-----|
-| Streaming `RowIterator` | `PrepareRowType(iter.Metadata.GetRowType())` after first `Next`, then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
+| Streaming `RowIterator` | [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) / [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator), or `PrepareMetadata` / `PrepareRowType` after first `Next` then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
 | Known column names only | `WithColumnNames` / `PrepareColumnNames` (at least one name) |
 | Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` (when `md` is already available) |
 | Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(metadata.GetRowType())` when fields are empty—**not** `PrepareColumnNames` |

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -9,7 +9,10 @@ import (
 )
 
 // ErrNilRowIterator reports that [RunRowIterator] or [WriteRowIterator] was called with a nil iterator.
-var ErrNilRowIterator = errors.New("nil RowIterator")
+var ErrNilRowIterator = errors.New("nil row iterator")
+
+// ErrNilWriter reports that [WriteRowIterator] was called with a nil writer.
+var ErrNilWriter = errors.New("nil row iterator writer")
 
 // RowIteratorStats holds execution information populated on a
 // [cloud.google.com/go/spanner.RowIterator] after iteration completes.
@@ -36,7 +39,8 @@ type RowIteratorResult struct {
 // PrepareMetadata runs once after the first [spanner.RowIterator.Next], with
 // whatever [cloud.google.com/go/spanner.RowIterator.Metadata] holds at that point
 // (including nil for DML or stats-only iterators, and including when the only
-// result is iterator.Done).
+// result is iterator.Done). It is not called when the first Next returns a query
+// error other than iterator.Done.
 //
 // Finish runs only after all rows are consumed without error. If PrepareMetadata
 // or WriteRow returns an error, the loop aborts and Finish is not called. The
@@ -61,7 +65,11 @@ type RowIteratorWriter interface {
 // RowIteratorHooksFromWriter returns hooks that register metadata via
 // [RowIteratorWriter.PrepareRowType], write each row, and call [Flusher.Flush]
 // in Finish. Flush is not called when PrepareRowType or WriteRow returns an error.
+// A nil writer returns empty hooks.
 func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
+	if w == nil {
+		return RowIteratorHooks{}
+	}
 	return RowIteratorHooks{
 		PrepareMetadata: func(md *sppb.ResultSetMetadata) error {
 			return w.PrepareRowType(rowTypeFromMetadata(md))
@@ -77,8 +85,8 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 // [spanner.RowIterator.Stop] on return.
 //
 // The returned [RowIteratorResult] reflects iter.Metadata and iter stats fields
-// after the loop (including when no data rows were written). When hooks.Finish is
-// set, it receives the same pointer that is returned.
+// after Stop and the loop (including when no data rows were written). When
+// hooks.Finish is set, it receives the same pointer that is returned.
 func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIteratorResult, error) {
 	if iter == nil {
 		return nil, ErrNilRowIterator
@@ -89,6 +97,12 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 // WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
 // See [RunRowIterator] for iterator metadata, stats, and zero-row behavior.
 func WriteRowIterator(iter *spanner.RowIterator, w RowIteratorWriter) (*RowIteratorResult, error) {
+	if iter == nil {
+		return nil, ErrNilRowIterator
+	}
+	if w == nil {
+		return nil, ErrNilWriter
+	}
 	return RunRowIterator(iter, RowIteratorHooksFromWriter(w))
 }
 
@@ -124,37 +138,50 @@ func (f spannerRowIteratorFacade) stats() RowIteratorStats {
 }
 
 func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIteratorResult, error) {
-	defer fac.stop()
+	stopped := false
+	stopOnce := func() {
+		if !stopped {
+			stopped = true
+			fac.stop()
+		}
+	}
+	defer stopOnce()
+
 	outcome := func() *RowIteratorResult {
 		return &RowIteratorResult{
 			Metadata: fac.metadata(),
 			Stats:    fac.stats(),
 		}
 	}
+	abort := func(err error) (*RowIteratorResult, error) {
+		stopOnce()
+		return outcome(), err
+	}
 
 	first := true
 	for {
 		row, err := fac.next()
+		if err != nil && !errors.Is(err, iterator.Done) {
+			return abort(err)
+		}
 		if first {
 			first = false
 			if hooks.PrepareMetadata != nil {
 				if err := hooks.PrepareMetadata(fac.metadata()); err != nil {
-					return outcome(), err
+					return abort(err)
 				}
 			}
 		}
 		if errors.Is(err, iterator.Done) {
 			break
 		}
-		if err != nil {
-			return outcome(), err
-		}
 		if hooks.WriteRow != nil {
 			if err := hooks.WriteRow(row); err != nil {
-				return outcome(), err
+				return abort(err)
 			}
 		}
 	}
+	stopOnce()
 	result := outcome()
 	if hooks.Finish != nil {
 		if err := hooks.Finish(result); err != nil {

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -17,12 +17,15 @@ var ErrNilRowIterator = errors.New("nil RowIterator")
 // RowCount is set for DML after iterator.Done.
 type RowIteratorStats struct {
 	QueryPlan  *sppb.QueryPlan
-	QueryStats map[string]interface{}
+	QueryStats map[string]any
 	RowCount   int64
 }
 
 // RowIteratorResult is the metadata and stats available from a
-// [cloud.google.com/go/spanner.RowIterator] after [RunRowIterator] finishes.
+// [cloud.google.com/go/spanner.RowIterator] after [RunRowIterator] returns.
+// On the error path, stats fields reflect whatever the iterator had populated at
+// the abort point and may be zero until [iterator.Done] (QueryStats and RowCount
+// are only fully populated after a successful run).
 type RowIteratorResult struct {
 	Metadata *sppb.ResultSetMetadata
 	Stats    RowIteratorStats
@@ -30,10 +33,16 @@ type RowIteratorResult struct {
 
 // RowIteratorHooks drives [RunRowIterator]. Nil function fields are skipped.
 //
-// PrepareMetadata runs after the first [spanner.RowIterator.Next] when
-// [cloud.google.com/go/spanner.RowIterator.Metadata] is non-nil (including when the
-// only result is iterator.Done). Finish runs after all rows are consumed; Stats is
-// fully populated at that point. QueryPlan and QueryStats require QueryWithStats.
+// PrepareMetadata runs once after the first [spanner.RowIterator.Next], with
+// whatever [cloud.google.com/go/spanner.RowIterator.Metadata] holds at that point
+// (including nil for DML or stats-only iterators, and including when the only
+// result is iterator.Done).
+//
+// Finish runs only after all rows are consumed without error. If PrepareMetadata
+// or WriteRow returns an error, the loop aborts and Finish is not called. The
+// returned [RowIteratorResult] is still populated with whatever iter.Metadata and
+// stats are available at the abort point. Stats is fully populated when Finish
+// runs successfully. QueryPlan and QueryStats require QueryWithStats.
 // Finish may read Metadata again for end-of-stream processing.
 type RowIteratorHooks struct {
 	PrepareMetadata func(*sppb.ResultSetMetadata) error
@@ -46,15 +55,18 @@ type RowIteratorHooks struct {
 // [SQLInsertWriter] implement it.
 type RowIteratorWriter interface {
 	FlushWriter
-	PrepareMetadata(*sppb.ResultSetMetadata) error
+	PrepareRowType(*sppb.StructType) error
 }
 
-// RowIteratorHooksFromWriter returns hooks that register metadata, write each row,
-// and call [Flusher.Flush] in Finish (ignoring the result).
+// RowIteratorHooksFromWriter returns hooks that register metadata via
+// [RowIteratorWriter.PrepareRowType], write each row, and call [Flusher.Flush]
+// in Finish. Flush is not called when PrepareRowType or WriteRow returns an error.
 func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 	return RowIteratorHooks{
-		PrepareMetadata: w.PrepareMetadata,
-		WriteRow:        w.WriteRow,
+		PrepareMetadata: func(md *sppb.ResultSetMetadata) error {
+			return w.PrepareRowType(rowTypeFromMetadata(md))
+		},
+		WriteRow: w.WriteRow,
 		Finish: func(*RowIteratorResult) error {
 			return w.Flush()
 		},
@@ -71,9 +83,7 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 	if iter == nil {
 		return nil, ErrNilRowIterator
 	}
-	fac := spannerRowIteratorFacade{iter}
-	defer fac.stop()
-	return runRowIterator(fac, hooks)
+	return runRowIterator(spannerRowIteratorFacade{iter}, hooks)
 }
 
 // WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
@@ -114,6 +124,7 @@ func (f spannerRowIteratorFacade) stats() RowIteratorStats {
 }
 
 func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIteratorResult, error) {
+	defer fac.stop()
 	outcome := func() *RowIteratorResult {
 		return &RowIteratorResult{
 			Metadata: fac.metadata(),
@@ -127,14 +138,12 @@ func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIterator
 		if first {
 			first = false
 			if hooks.PrepareMetadata != nil {
-				if md := fac.metadata(); md != nil {
-					if err := hooks.PrepareMetadata(md); err != nil {
-						return outcome(), err
-					}
+				if err := hooks.PrepareMetadata(fac.metadata()); err != nil {
+					return outcome(), err
 				}
 			}
 		}
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -1,0 +1,156 @@
+package writer
+
+import (
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/api/iterator"
+)
+
+// ErrNilRowIterator reports that [RunRowIterator] or [WriteRowIterator] was called with a nil iterator.
+var ErrNilRowIterator = errors.New("nil RowIterator")
+
+// RowIteratorStats holds execution information populated on a
+// [cloud.google.com/go/spanner.RowIterator] after iteration completes.
+// QueryPlan and QueryStats are set when the query used QueryWithStats.
+// RowCount is set for DML after iterator.Done.
+type RowIteratorStats struct {
+	QueryPlan  *sppb.QueryPlan
+	QueryStats map[string]interface{}
+	RowCount   int64
+}
+
+// RowIteratorResult is the metadata and stats available from a
+// [cloud.google.com/go/spanner.RowIterator] after [RunRowIterator] finishes.
+type RowIteratorResult struct {
+	Metadata *sppb.ResultSetMetadata
+	Stats    RowIteratorStats
+}
+
+// RowIteratorHooks drives [RunRowIterator]. Nil function fields are skipped.
+//
+// PrepareMetadata runs after the first [spanner.RowIterator.Next] when
+// [cloud.google.com/go/spanner.RowIterator.Metadata] is non-nil (including when the
+// only result is iterator.Done). Finish runs after all rows are consumed; Stats is
+// fully populated at that point. QueryPlan and QueryStats require QueryWithStats.
+// Finish may read Metadata again for end-of-stream processing.
+type RowIteratorHooks struct {
+	PrepareMetadata func(*sppb.ResultSetMetadata) error
+	WriteRow        func(*spanner.Row) error
+	Finish          func(*RowIteratorResult) error
+}
+
+// RowIteratorWriter streams rows from a [cloud.google.com/go/spanner.RowIterator]
+// through [WriteRowIterator]. [DelimitedWriter], [JSONLWriter], and
+// [SQLInsertWriter] implement it.
+type RowIteratorWriter interface {
+	FlushWriter
+	PrepareMetadata(*sppb.ResultSetMetadata) error
+}
+
+// RowIteratorHooksFromWriter returns hooks that register metadata, write each row,
+// and call [Flusher.Flush] in Finish (ignoring the result).
+func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
+	return RowIteratorHooks{
+		PrepareMetadata: w.PrepareMetadata,
+		WriteRow:        w.WriteRow,
+		Finish: func(*RowIteratorResult) error {
+			return w.Flush()
+		},
+	}
+}
+
+// RunRowIterator streams all rows from iter using hooks. It always calls
+// [spanner.RowIterator.Stop] on return.
+//
+// The returned [RowIteratorResult] reflects iter.Metadata and iter stats fields
+// after the loop (including when no data rows were written). When hooks.Finish is
+// set, it receives the same pointer that is returned.
+func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIteratorResult, error) {
+	if iter == nil {
+		return nil, ErrNilRowIterator
+	}
+	fac := spannerRowIteratorFacade{iter}
+	defer fac.stop()
+	return runRowIterator(fac, hooks)
+}
+
+// WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
+// See [RunRowIterator] for iterator metadata, stats, and zero-row behavior.
+func WriteRowIterator(iter *spanner.RowIterator, w RowIteratorWriter) (*RowIteratorResult, error) {
+	return RunRowIterator(iter, RowIteratorHooksFromWriter(w))
+}
+
+type rowIteratorFacade interface {
+	next() (*spanner.Row, error)
+	stop()
+	metadata() *sppb.ResultSetMetadata
+	stats() RowIteratorStats
+}
+
+type spannerRowIteratorFacade struct {
+	*spanner.RowIterator
+}
+
+func (f spannerRowIteratorFacade) next() (*spanner.Row, error) {
+	return f.Next()
+}
+
+func (f spannerRowIteratorFacade) stop() {
+	f.Stop()
+}
+
+func (f spannerRowIteratorFacade) metadata() *sppb.ResultSetMetadata {
+	return f.Metadata
+}
+
+func (f spannerRowIteratorFacade) stats() RowIteratorStats {
+	return RowIteratorStats{
+		QueryPlan:  f.QueryPlan,
+		QueryStats: f.QueryStats,
+		RowCount:   f.RowCount,
+	}
+}
+
+func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIteratorResult, error) {
+	outcome := func() *RowIteratorResult {
+		return &RowIteratorResult{
+			Metadata: fac.metadata(),
+			Stats:    fac.stats(),
+		}
+	}
+
+	first := true
+	for {
+		row, err := fac.next()
+		if first {
+			first = false
+			if hooks.PrepareMetadata != nil {
+				if md := fac.metadata(); md != nil {
+					if err := hooks.PrepareMetadata(md); err != nil {
+						return outcome(), err
+					}
+				}
+			}
+		}
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return outcome(), err
+		}
+		if hooks.WriteRow != nil {
+			if err := hooks.WriteRow(row); err != nil {
+				return outcome(), err
+			}
+		}
+	}
+	result := outcome()
+	if hooks.Finish != nil {
+		if err := hooks.Finish(result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -69,7 +69,7 @@ func TestWriteRowIterator_emptyWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id", "name")
-	wantStats := RowIteratorStats{RowCount: 0, QueryStats: map[string]interface{}{"elapsed_ms": 1.0}}
+	wantStats := RowIteratorStats{RowCount: 0, QueryStats: map[string]any{"elapsed_ms": 1.0}}
 	stub := &stubRowIterator{md: md, wantStat: wantStats}
 
 	var out bytes.Buffer
@@ -217,5 +217,8 @@ func TestWriteRowIterator_writeErrorStillReturnsOutcome(t *testing.T) {
 	}
 	if got.Metadata != md {
 		t.Fatal("metadata not returned on error")
+	}
+	if !stub.stopped {
+		t.Fatal("stop not called")
 	}
 }

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -1,0 +1,221 @@
+package writer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/iterator"
+)
+
+var (
+	_ rowIteratorFacade = (*stubRowIterator)(nil)
+	_ RowIteratorWriter = (*DelimitedWriter)(nil)
+	_ RowIteratorWriter = (*JSONLWriter)(nil)
+	_ RowIteratorWriter = (*SQLInsertWriter)(nil)
+)
+
+type stubRowIterator struct {
+	md       *sppb.ResultSetMetadata
+	wantStat RowIteratorStats
+	rows     []*spanner.Row
+	i        int
+	stopped  bool
+}
+
+func (s *stubRowIterator) next() (*spanner.Row, error) {
+	if s.i < len(s.rows) {
+		row := s.rows[s.i]
+		s.i++
+		return row, nil
+	}
+	return nil, iterator.Done
+}
+
+func (s *stubRowIterator) stop() {
+	s.stopped = true
+}
+
+func (s *stubRowIterator) metadata() *sppb.ResultSetMetadata {
+	return s.md
+}
+
+func (s *stubRowIterator) stats() RowIteratorStats {
+	return s.wantStat
+}
+
+func TestRunRowIterator_nilIterator(t *testing.T) {
+	t.Parallel()
+
+	_, err := RunRowIterator(nil, RowIteratorHooks{})
+	if !errors.Is(err, ErrNilRowIterator) {
+		t.Fatalf("error = %v, want ErrNilRowIterator", err)
+	}
+}
+
+func TestWriteRowIterator_nilIterator(t *testing.T) {
+	t.Parallel()
+
+	_, err := WriteRowIterator(nil, NewDelimitedWriter(&bytes.Buffer{}, ','))
+	if !errors.Is(err, ErrNilRowIterator) {
+		t.Fatalf("error = %v, want ErrNilRowIterator", err)
+	}
+}
+
+func TestWriteRowIterator_emptyWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id", "name")
+	wantStats := RowIteratorStats{RowCount: 0, QueryStats: map[string]interface{}{"elapsed_ms": 1.0}}
+	stub := &stubRowIterator{md: md, wantStat: wantStats}
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata not returned")
+	}
+	if diff := cmp.Diff(wantStats, got.Stats); diff != "" {
+		t.Fatalf("Stats mismatch (-want +got):\n%s", diff)
+	}
+	want := "id,name\n"
+	if out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestWriteRowIterator_emptyZeroColumnMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames()
+	stub := &stubRowIterator{md: md}
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata not returned")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
+func TestWriteRowIterator_withRows(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id", "name")
+	row, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(1), "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{
+		md:       md,
+		wantStat: RowIteratorStats{RowCount: 1},
+		rows:     []*spanner.Row{row},
+	}
+
+	var out bytes.Buffer
+	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata not returned")
+	}
+	if got.Stats.RowCount != 1 {
+		t.Fatalf("RowCount = %d, want 1", got.Stats.RowCount)
+	}
+	want := "id,name\n1,a\n"
+	if out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunRowIterator_finishReceivesResult(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	wantStats := RowIteratorStats{RowCount: 42}
+	stub := &stubRowIterator{md: md, wantStat: wantStats}
+
+	var finishResult *RowIteratorResult
+	hooks := RowIteratorHooks{
+		PrepareMetadata: func(*sppb.ResultSetMetadata) error { return nil },
+		Finish: func(res *RowIteratorResult) error {
+			finishResult = res
+			return nil
+		},
+	}
+	got, err := runRowIterator(stub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finishResult == nil {
+		t.Fatal("Finish was not called")
+	}
+	if finishResult != got {
+		t.Fatal("Finish should receive pointer to returned result")
+	}
+	if finishResult.Metadata != md {
+		t.Fatal("Finish metadata mismatch")
+	}
+	if finishResult.Stats.RowCount != 42 {
+		t.Fatalf("Finish stats RowCount = %d, want 42", finishResult.Stats.RowCount)
+	}
+}
+
+func TestRunRowIterator_prepareMetadataSeesFullMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	stub := &stubRowIterator{md: md}
+
+	var prepared *sppb.ResultSetMetadata
+	hooks := RowIteratorHooks{
+		PrepareMetadata: func(m *sppb.ResultSetMetadata) error {
+			prepared = m
+			return nil
+		},
+	}
+	_, err := runRowIterator(stub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared != md {
+		t.Fatal("PrepareMetadata did not receive iter metadata")
+	}
+}
+
+func TestWriteRowIterator_writeErrorStillReturnsOutcome(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+
+	hooks := RowIteratorHooksFromWriter(NewDelimitedWriter(&bytes.Buffer{}, ','))
+	hooks.WriteRow = func(*spanner.Row) error {
+		return errors.New("write failed")
+	}
+	got, err := runRowIterator(stub, hooks)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata not returned on error")
+	}
+}

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -22,11 +22,15 @@ type stubRowIterator struct {
 	md       *sppb.ResultSetMetadata
 	wantStat RowIteratorStats
 	rows     []*spanner.Row
+	err      error
 	i        int
 	stopped  bool
 }
 
 func (s *stubRowIterator) next() (*spanner.Row, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	if s.i < len(s.rows) {
 		row := s.rows[s.i]
 		s.i++
@@ -44,6 +48,9 @@ func (s *stubRowIterator) metadata() *sppb.ResultSetMetadata {
 }
 
 func (s *stubRowIterator) stats() RowIteratorStats {
+	if !s.stopped {
+		return RowIteratorStats{}
+	}
 	return s.wantStat
 }
 
@@ -217,6 +224,40 @@ func TestWriteRowIterator_writeErrorStillReturnsOutcome(t *testing.T) {
 	}
 	if got.Metadata != md {
 		t.Fatal("metadata not returned on error")
+	}
+	if !stub.stopped {
+		t.Fatal("stop not called")
+	}
+}
+
+func TestWriteRowIterator_nilWriter(t *testing.T) {
+	t.Parallel()
+
+	_, err := WriteRowIterator(&spanner.RowIterator{}, nil)
+	if !errors.Is(err, ErrNilWriter) {
+		t.Fatalf("error = %v, want ErrNilWriter", err)
+	}
+}
+
+func TestRunRowIterator_queryErrorDoesNotPrepare(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("query failed")
+	stub := &stubRowIterator{err: queryErr}
+
+	var prepared bool
+	hooks := RowIteratorHooks{
+		PrepareMetadata: func(*sppb.ResultSetMetadata) error {
+			prepared = true
+			return nil
+		},
+	}
+	_, err := runRowIterator(stub, hooks)
+	if !errors.Is(err, queryErr) {
+		t.Fatalf("error = %v, want %v", err, queryErr)
+	}
+	if prepared {
+		t.Fatal("PrepareMetadata should not be called on query error")
 	}
 	if !stub.stopped {
 		t.Fatal("stop not called")

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -450,12 +450,6 @@ func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareMetadata registers names and types from metadata.GetRowType(); same as
-// [WithMetadata]. Prefer this from [RunRowIterator] when streaming a RowIterator.
-func (w *DelimitedWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
-}
-
 // PrepareColumnNames registers column names only; same as [WithColumnNames] for non-empty
 // names. Unlike [WithColumnNames], an empty names slice returns [ErrMissingColumnNames];
 // for zero-column result sets use [DelimitedWriter.PrepareRowType] instead.
@@ -731,11 +725,6 @@ func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
-// PrepareMetadata registers names and types from metadata.GetRowType(); see [DelimitedWriter.PrepareMetadata].
-func (w *JSONLWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
-}
-
 // PrepareColumnNames registers column names; see [DelimitedWriter.PrepareColumnNames].
 func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
@@ -936,11 +925,6 @@ func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
 // Deprecated: Use [SQLInsertWriter.PrepareRowType], [SQLInsertWriter.PrepareColumnNames],
 // [WithRowType], [WithColumnNames], or [WithMetadata].
 func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
-	return w.PrepareRowType(rowTypeFromMetadata(metadata))
-}
-
-// PrepareMetadata registers names and types from metadata.GetRowType(); see [DelimitedWriter.PrepareMetadata].
-func (w *SQLInsertWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -60,9 +60,10 @@
 // [cloud.google.com/go/spanner.RowIterator] before the first Next). For streaming, call
 // [PrepareRowType] with iter.Metadata.GetRowType() after the first Next when the result may be empty
 // but still has columns (including when Next returns iterator.Done); call [DelimitedWriter.Flush]
-// after the loop and propagate its error (do not defer Flush—it returns an error). When every query
-// returns at least one row, [WriteRow] registers names from
-// the first row.
+// after the loop and propagate its error (do not defer Flush—it returns an error).
+// [RunRowIterator] and [WriteRowIterator] run that loop, call Finish (Flush for writers),
+// and return metadata and stats (including for zero-row results).
+// When every query returns at least one row, [WriteRow] registers names from the first row.
 //
 // [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
 // before the first data row, or on [DelimitedWriter.Flush] when no data row was written
@@ -449,6 +450,12 @@ func (w *DelimitedWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
+// PrepareMetadata registers names and types from metadata.GetRowType(); same as
+// [WithMetadata]. Prefer this from [RunRowIterator] when streaming a RowIterator.
+func (w *DelimitedWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
 // PrepareColumnNames registers column names only; same as [WithColumnNames] for non-empty
 // names. Unlike [WithColumnNames], an empty names slice returns [ErrMissingColumnNames];
 // for zero-column result sets use [DelimitedWriter.PrepareRowType] instead.
@@ -724,6 +731,11 @@ func (w *JSONLWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
 
+// PrepareMetadata registers names and types from metadata.GetRowType(); see [DelimitedWriter.PrepareMetadata].
+func (w *JSONLWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
 // PrepareColumnNames registers column names; see [DelimitedWriter.PrepareColumnNames].
 func (w *JSONLWriter) PrepareColumnNames(names []string) error {
 	return w.prepareColumnNames(names)
@@ -927,9 +939,14 @@ func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 	return w.PrepareRowType(rowTypeFromMetadata(metadata))
 }
 
+// PrepareMetadata registers names and types from metadata.GetRowType(); see [DelimitedWriter.PrepareMetadata].
+func (w *SQLInsertWriter) PrepareMetadata(metadata *sppb.ResultSetMetadata) error {
+	return w.PrepareRowType(rowTypeFromMetadata(metadata))
+}
+
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
-// When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use
-// iter.Metadata.GetRowType after the first Next. Nil rowType registers an empty schema;
+// When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use [RunRowIterator]
+// or iter.Metadata after the first Next. Nil rowType registers an empty schema;
 // [SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -930,7 +930,7 @@ func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
 // When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use [RunRowIterator]
-// or iter.Metadata after the first Next. Nil rowType registers an empty schema;
+// or [PrepareRowType] with iter.Metadata.GetRowType() after the first Next. Nil rowType registers an empty schema;
 // [SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)


### PR DESCRIPTION
## Summary

- Add `RunRowIterator` with `RowIteratorHooks` (`PrepareMetadata`, `WriteRow`, `Finish`) and `WriteRowIterator` for `DelimitedWriter`, `JSONLWriter`, and `SQLInsertWriter`.
- Return `*RowIteratorResult` with `iter.Metadata` and query stats (including zero-row `SELECT` and stats-only iterators) after always calling `Stop`.
- Update README to recommend the helper over a hand-written `iter.Next` loop and document schema registration entry points.

## Test plan

- [x] `make check`
- [x] Unit tests for nil iterator, empty metadata, zero-column metadata, rows + flush, `Finish` pointer identity, prepare on first `Next`, write errors, and `Stop` on the test stub


Made with [Cursor](https://cursor.com)