### PR TITLE
docs(writer): clarify quoted TSV vs raw tab-separated output

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 }
 ```
 
-TSV output uses the same CSV-style writer with a tab delimiter. `NewCSVWriter`
+Quoted TSV uses the same CSV-style writer with a tab delimiter (`encoding/csv`
+quoting: embedded tabs, quotes, and newlines in a field are escaped). `NewCSVWriter`
 is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
 `writer.Comma` when using the generic delimited constructor for CSV output.
 Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
@@ -222,6 +223,15 @@ func writeTSV(out io.Writer, rows []*spanner.Row) error {
 	return w.Flush()
 }
 ```
+
+Some CLIs expose a legacy **TAB** format that joins pre-formatted column strings
+with `\t` and does not apply CSV-style quoting. That is not what
+`NewDelimitedWriter(out, '\t')` emits. To keep raw tab-separated output while
+still using spanvalue formatters and [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator),
+implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
+(and [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
+when streaming from a `RowIterator`): format each column, `strings.Join(fields, "\t")`,
+then write the line.
 
 JSONL output:
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ Some CLIs expose a legacy **TAB** format that joins pre-formatted column strings
 with `\t` and does not apply CSV-style quoting. That is not what
 `NewDelimitedWriter(out, '\t')` emits. To keep raw tab-separated output while
 still using spanvalue formatters, implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
-(or [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
-when streaming via [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)): format each column, `strings.Join(fields, "\t")`,
+(or [`writer.RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
+when streaming via [`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)): format each column, `strings.Join(fields, "\t")`,
 then write the line.
 
 JSONL output:

--- a/README.md
+++ b/README.md
@@ -227,10 +227,9 @@ func writeTSV(out io.Writer, rows []*spanner.Row) error {
 Some CLIs expose a legacy **TAB** format that joins pre-formatted column strings
 with `\t` and does not apply CSV-style quoting. That is not what
 `NewDelimitedWriter(out, '\t')` emits. To keep raw tab-separated output while
-still using spanvalue formatters and [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator),
-implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
-(and [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
-when streaming from a `RowIterator`): format each column, `strings.Join(fields, "\t")`,
+still using spanvalue formatters, implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
+(or [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
+when streaming via [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)): format each column, `strings.Join(fields, "\t")`,
 then write the line.
 
 JSONL output:

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 ```
 
 Quoted TSV uses the same CSV-style writer with a tab delimiter (`encoding/csv`
-quoting: embedded tabs, quotes, and newlines in a field are escaped). `NewCSVWriter`
-is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
+quoting: embedded tabs, quotes, and newlines in a field are escaped). For CSV output,
+`NewCSVWriter` is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
 `writer.Comma` when using the generic delimited constructor for CSV output.
 Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
 `utf8.RuneError`.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -9,6 +9,18 @@
 // names avoid collisions with existing names. DelimitedWriter buffers through
 // encoding/csv, so callers must call Flush after the final write.
 //
+// # Quoted delimited text vs raw tab-separated
+//
+// [DelimitedWriter] uses encoding/csv rules: fields that contain the delimiter,
+// double quotes, or newlines are quoted and inner quotes are doubled (RFC 4180-style).
+// [NewDelimitedWriter] with delimiter '\t' produces quoted TSV, not a raw join of
+// formatted column strings with tab characters only.
+//
+// Downstream tools that must preserve legacy TAB output (for example tab-separated
+// CLI export without CSV escaping) can implement [Writer] and format each column with
+// spanvalue, then join with '\t'. For [WriteRowIterator], implement [RowIteratorWriter]
+// ([FlushWriter] plus [PrepareRowType]); [Flush] may be a no-op when no header is needed.
+//
 // [Writer] streams *spanner.Row values; concrete writers also offer WriteValues,
 // WriteGCVs, and WriteStructValues. [FlushWriter] adds Flush (required for buffered
 // DelimitedWriter). Flush does not close the underlying io.Writer.
@@ -409,6 +421,10 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // NewDelimitedWriter returns a CSV-style writer using delimiter as the field
 // delimiter and configured by options. Pass Comma for CSV output or '\t' for TSV
 // output. Delimiter must be non-zero and a valid encoding/csv delimiter.
+// NewDelimitedWriter returns a delimited writer for CSV (delimiter [Comma]), quoted
+// TSV (delimiter '\t'), or other single-rune delimiters. Output follows encoding/csv
+// quoting rules, not raw field joins. See package doc "Quoted delimited text vs raw
+// tab-separated".
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -424,7 +424,7 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // It supports CSV (delimiter [Comma]), quoted TSV (delimiter '\t'), or other
 // single-rune delimiters. Output follows encoding/csv quoting rules, not raw
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
-// See [Quoted delimited text vs raw tab-separated].
+// See the package-level section "Quoted delimited text vs raw tab-separated".
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -424,7 +424,7 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // It supports CSV (delimiter [Comma]), quoted TSV (delimiter '\t'), or other
 // single-rune delimiters. Output follows encoding/csv quoting rules, not raw
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
-// See the package-level section "Quoted delimited text vs raw tab-separated".
+// See [Quoted delimited text vs raw tab-separated].
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -19,7 +19,7 @@
 // Downstream tools that must preserve legacy TAB output (for example tab-separated
 // CLI export without CSV escaping) can implement [Writer] and format each column with
 // spanvalue, then join with '\t'. For [WriteRowIterator], implement [RowIteratorWriter]
-// ([FlushWriter] plus [PrepareRowType]); [Flush] may be a no-op when no header is needed.
+// ([FlushWriter] plus [RowIteratorWriter.PrepareRowType]); [Flusher.Flush] may be a no-op when no header is needed.
 //
 // [Writer] streams *spanner.Row values; concrete writers also offer WriteValues,
 // WriteGCVs, and WriteStructValues. [FlushWriter] adds Flush (required for buffered
@@ -419,12 +419,12 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 }
 
 // NewDelimitedWriter returns a CSV-style writer using delimiter as the field
-// delimiter and configured by options. Pass Comma for CSV output or '\t' for TSV
-// output. Delimiter must be non-zero and a valid encoding/csv delimiter.
-// NewDelimitedWriter returns a delimited writer for CSV (delimiter [Comma]), quoted
-// TSV (delimiter '\t'), or other single-rune delimiters. Output follows encoding/csv
-// quoting rules, not raw field joins. See package doc "Quoted delimited text vs raw
-// tab-separated".
+// delimiter and configured by options.
+//
+// It supports CSV (delimiter [Comma]), quoted TSV (delimiter '\t'), or other
+// single-rune delimiters. Output follows encoding/csv quoting rules, not raw
+// field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
+// See package doc "Quoted delimited text vs raw tab-separated".
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -424,7 +424,7 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // It supports CSV (delimiter [Comma]), quoted TSV (delimiter '\t'), or other
 // single-rune delimiters. Output follows encoding/csv quoting rules, not raw
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
-// See package doc "Quoted delimited text vs raw tab-separated".
+// See the package-level documentation section [#Quoted delimited text vs raw tab-separated].
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -424,7 +424,7 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // It supports CSV (delimiter [Comma]), quoted TSV (delimiter '\t'), or other
 // single-rune delimiters. Output follows encoding/csv quoting rules, not raw
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
-// See the package-level documentation section [#Quoted delimited text vs raw tab-separated].
+// See the package-level section "Quoted delimited text vs raw tab-separated".
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter


### PR DESCRIPTION
## Summary

Closes #100.

- Package doc section **Quoted delimited text vs raw tab-separated**
- `NewDelimitedWriter` godoc points to quoting semantics
- README: rename TSV example to "quoted TSV"; add legacy TAB vs `Writer` / `WriteRowIterator` note

## Test plan

- [x] `make check`

Made with [Cursor](https://cursor.com)