### PR TITLE
Add SpannerCLICompatibleTupleStructFormatConfig constructor

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,8 @@
 // # Primary API
 //
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
-// [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig], and [JSONFormatConfig] to pick
+// [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
+// [SpannerCLICompatibleTupleStructFormatConfig], and [JSONFormatConfig] to pick
 // a preset. Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from

--- a/example_test.go
+++ b/example_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 )
 
-func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
-	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
-	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
+func ExampleSpannerCLICompatibleTupleStructFormatConfig() {
+	fc := spanvalue.SpannerCLICompatibleTupleStructFormatConfig()
 
 	structElem, err := gcvctor.StructValueOf(
 		[]string{"id", "region"},

--- a/spanner_cli_compatible.go
+++ b/spanner_cli_compatible.go
@@ -32,6 +32,17 @@ func SpannerCLICompatibleFormatConfig() *FormatConfig {
 	}
 }
 
+// SpannerCLICompatibleTupleStructFormatConfig returns a [FormatConfig] like
+// [SpannerCLICompatibleFormatConfig] but renders STRUCT values with
+// [FormatTupleStruct] parentheses instead of [FormatBracketStruct] brackets.
+// Use it for GoogleSQL-style table output such as [(1, foo)] rather than
+// [[1, foo]] for ARRAY<STRUCT<...>>.
+func SpannerCLICompatibleTupleStructFormatConfig() *FormatConfig {
+	fc := SpannerCLICompatibleFormatConfig()
+	fc.FormatStruct.FormatStructParen = FormatTupleStruct
+	return fc
+}
+
 func FormatRowSpannerCLICompatible(row *spanner.Row) ([]string, error) {
 	return spannerCLICompatibleFormatConfig.FormatRow(row)
 }

--- a/spanner_cli_compatible_test.go
+++ b/spanner_cli_compatible_test.go
@@ -525,3 +525,30 @@ func TestDecodeRow(t *testing.T) {
 		})
 	}
 }
+
+func TestSpannerCLICompatibleTupleStructFormatConfig(t *testing.T) {
+	t.Parallel()
+
+	value := []struct {
+		X int64
+		Y spanner.NullString
+	}{
+		{
+			X: 10,
+			Y: spanner.NullString{StringVal: "Hello", Valid: true},
+		},
+		{
+			X: 20,
+			Y: spanner.NullString{StringVal: "", Valid: false},
+		},
+	}
+
+	got, err := SpannerCLICompatibleTupleStructFormatConfig().FormatToplevelColumn(createColumnValue(t, value))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "[(10, Hello), (20, NULL)]"
+	if got != want {
+		t.Fatalf("FormatToplevelColumn() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SpannerCLICompatibleTupleStructFormatConfig()` as a discoverable preset for tuple-style STRUCT rendering in Spanner CLI–compatible output.
- The constructor is like `SpannerCLICompatibleFormatConfig()` but uses `FormatTupleStruct` instead of `FormatBracketStruct`, so `ARRAY<STRUCT<...>>` renders as `[(1, foo)]` rather than `[[1, foo]]`.
- Update package docs and the example to point at the new constructor; add a focused regression test.

## Test plan

- [x] `make check`
- [x] `TestSpannerCLICompatibleTupleStructFormatConfig`
- [x] `ExampleSpannerCLICompatibleTupleStructFormatConfig`

Closes #81

Made with [Cursor](https://cursor.com)