### PR TITLE
feat(writer): dialect-aware SQL INSERT identifier quoting

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -230,7 +230,9 @@ type sqlDialectOption struct {
 }
 
 // WithSQLDialect sets identifier quoting for table and column names in SQL INSERT
-// output. The default is GoogleSQL ([databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
+// output. It does not change INSERT statement prefixes ([WithSQLInsertKind]) or
+// value literal formatting ([WithFormatter]). The default is GoogleSQL
+// ([cloud.google.com/go/spanner/admin/database/apiv1/databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
 func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 	return sqlDialectOption{dialect: dialect}
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -17,7 +17,9 @@
 //
 // [NewDelimitedWriter], [NewCSVWriter], [NewJSONLWriter], and [NewSQLInsertWriter]
 // accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
-// INSERT prefix (see Spanner INSERT DML syntax). [RowData], [FormatDelimitedRow], and
+// INSERT prefix (see Spanner INSERT DML syntax). [WithSQLDialect] selects identifier
+// quoting for table and column names in SQL INSERT output (GoogleSQL by default).
+// [RowData], [FormatDelimitedRow], and
 // [FormatJSONLRow] format a single row without a writer.
 //
 // # Column names and field types
@@ -221,6 +223,20 @@ type sqlInsertKindOption struct {
 
 func (o sqlInsertKindOption) applySQLInsertOption(w *SQLInsertWriter) {
 	w.insertKind = o.kind
+}
+
+type sqlDialectOption struct {
+	dialect databasepb.DatabaseDialect
+}
+
+// WithSQLDialect sets identifier quoting for table and column names in SQL INSERT
+// output. The default is GoogleSQL ([databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
+func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
+	return sqlDialectOption{dialect: dialect}
+}
+
+func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.sqlDialect = o.dialect
 }
 
 // SQLInsertOption configures a SQLInsertWriter created by [NewSQLInsertWriter].
@@ -871,12 +887,13 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 	return marshaledKeys, nil
 }
 
-// SQLInsertWriter writes rows as GoogleSQL INSERT statements.
+// SQLInsertWriter writes rows as SQL INSERT statements with dialect-aware identifier quoting.
 type SQLInsertWriter struct {
 	Table     string
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
+	sqlDialect        databasepb.DatabaseDialect
 	schema            columnSchema
 	quotedColumnNames string
 	quotedTable       string
@@ -904,9 +921,10 @@ func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLIn
 
 func newSQLInsertWriter(out io.Writer, table string) *SQLInsertWriter {
 	return &SQLInsertWriter{
-		Table:     table,
-		Formatter: spanvalue.LiteralFormatConfig(),
-		out:       out,
+		Table:      table,
+		Formatter:  spanvalue.LiteralFormatConfig(),
+		sqlDialect: databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		out:        out,
 	}
 }
 
@@ -952,7 +970,7 @@ func (w *SQLInsertWriter) prepareRowType(rowType *sppb.StructType) error {
 		w.setRowType(rowType)
 		return nil
 	}
-	quotedColumns, err := quoteIdentifiers(columnNames)
+	quotedColumns, err := quoteIdentifiers(columnNames, w.sqlDialect)
 	if err != nil {
 		return err
 	}
@@ -1071,7 +1089,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if err != nil {
 		return "", err
 	}
-	quotedColumns, err := quoteIdentifiers(names)
+	quotedColumns, err := quoteIdentifiers(names, w.sqlDialect)
 	if err != nil {
 		return "", err
 	}
@@ -1087,7 +1105,7 @@ func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
 	if w.quotedTable != "" && w.quotedTableInput == w.Table {
 		return w.quotedTable, nil
 	}
-	quotedTable, err := quoteQualifiedIdentifier(w.Table)
+	quotedTable, err := quoteQualifiedIdentifier(w.Table, w.sqlDialect)
 	if err != nil {
 		return "", err
 	}
@@ -1294,26 +1312,26 @@ func validatePrepareRowTypeTransition(schema *columnSchema, columnNames []string
 	return err
 }
 
-// quoteIdentifiers quotes GoogleSQL identifiers and rejects empty names.
-func quoteIdentifiers(names []string) ([]string, error) {
+// quoteIdentifiers quotes identifiers for dialect and rejects empty names.
+func quoteIdentifiers(names []string, dialect databasepb.DatabaseDialect) ([]string, error) {
 	quoted := make([]string, len(names))
 	for i, name := range names {
 		if name == "" {
 			return nil, ErrEmptyColumnName
 		}
-		quoted[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, name)
+		quoted[i] = spanvalue.QuoteIdentifier(dialect, name)
 	}
 	return quoted, nil
 }
 
-// quoteQualifiedIdentifier quotes each identifier segment in a dotted path.
-func quoteQualifiedIdentifier(name string) (string, error) {
+// quoteQualifiedIdentifier quotes each identifier segment in a dotted path for dialect.
+func quoteQualifiedIdentifier(name string, dialect databasepb.DatabaseDialect) (string, error) {
 	parts := strings.Split(name, ".")
 	for i, part := range parts {
 		if part == "" {
 			return "", fmt.Errorf("%w: qualified table name contains empty segment", ErrEmptyTableName)
 		}
-		parts[i] = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, part)
+		parts[i] = spanvalue.QuoteIdentifier(dialect, part)
 	}
 	return strings.Join(parts, "."), nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -232,7 +232,7 @@ type sqlDialectOption struct {
 // WithSQLDialect sets identifier quoting for table and column names in SQL INSERT
 // output. It does not change INSERT statement prefixes ([WithSQLInsertKind]) or
 // value literal formatting ([WithFormatter]). The default is GoogleSQL
-// ([cloud.google.com/go/spanner/admin/database/apiv1/databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
+// ([databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
 func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 	return sqlDialectOption{dialect: dialect}
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -802,9 +802,9 @@ func TestSQLInsertWriterSQLDialect(t *testing.T) {
 			columnNames: []string{"id", `na"me`},
 			values: []spanner.GenericColumnValue{
 				gcvctor.Int64Value(42),
-				gcvctor.StringValue("Alice"),
+				gcvctor.Int64Value(7),
 			},
-			want: `INSERT INTO "user""table" ("id", "na""me") VALUES (42, "Alice");` + "\n",
+			want: `INSERT INTO "user""table" ("id", "na""me") VALUES (42, 7);` + "\n",
 		},
 		{
 			name:        "PostgreSQL qualified table name escaping",

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
@@ -773,6 +774,68 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 
 			err := w.WriteValues(tt.columnNames, tt.values)
 			if err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, out.String()); diff != "" {
+				t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSQLInsertWriterSQLDialect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dialect     databasepb.DatabaseDialect
+		table       string
+		columnNames []string
+		values      []spanner.GenericColumnValue
+		want        string
+	}{
+		{
+			name:        "PostgreSQL identifier escaping",
+			dialect:     databasepb.DatabaseDialect_POSTGRESQL,
+			table:       `user"table`,
+			columnNames: []string{"id", `na"me`},
+			values: []spanner.GenericColumnValue{
+				gcvctor.Int64Value(42),
+				gcvctor.StringValue("Alice"),
+			},
+			want: `INSERT INTO "user""table" ("id", "na""me") VALUES (42, "Alice");` + "\n",
+		},
+		{
+			name:        "PostgreSQL qualified table name escaping",
+			dialect:     databasepb.DatabaseDialect_POSTGRESQL,
+			table:       `my"db.users`,
+			columnNames: []string{"id"},
+			values: []spanner.GenericColumnValue{
+				gcvctor.Int64Value(42),
+			},
+			want: `INSERT INTO "my""db"."users" ("id") VALUES (42);` + "\n",
+		},
+		{
+			name:        "default GoogleSQL unchanged",
+			dialect:     databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED,
+			table:       "users",
+			columnNames: []string{"id"},
+			values: []spanner.GenericColumnValue{
+				gcvctor.Int64Value(42),
+			},
+			want: "INSERT INTO `users` (`id`) VALUES (42);\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w := NewSQLInsertWriter(&out, tt.table, WithSQLDialect(tt.dialect))
+
+			if err := w.WriteValues(tt.columnNames, tt.values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 


### PR DESCRIPTION
## Summary

- Add `WithSQLDialect(databasepb.DatabaseDialect)` on `SQLInsertWriter` so table and column identifiers use `spanvalue.QuoteIdentifier` for the chosen dialect.
- Default remains `GOOGLE_STANDARD_SQL`, so existing callers keep backtick quoting.
- Add tests for PostgreSQL quoting and for unspecified dialect defaulting to GoogleSQL.

Closes #101

## Test plan

- [x] `make check`
- [x] `TestSQLInsertWriterSQLDialect` covers PostgreSQL and default GoogleSQL quoting


Made with [Cursor](https://cursor.com)