### PR TITLE
Document tuple STRUCT customization for Spanner CLI preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ quotedColumn := spanvalue.QuoteIdentifier(
 [SpannerCLICompatibleFormatConfig](https://pkg.go.dev/github.com/apstndb/spanvalue#SpannerCLICompatibleFormatConfig)
 matches official [spanner-cli](https://github.com/cloudspannerecosystem/spanner-cli)
 output, including bracket-style STRUCT in arrays (`[[1, east]]`). For tuple
-parentheses (`[(1, east)]`) while keeping CLI scalar rules, customize the config
-returned by the constructor and set
-[FormatTupleStruct](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatTupleStruct):
+parentheses (`[(1, east)]`) while keeping CLI scalar rules, clone the preset and
+set [FormatTupleStruct](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatTupleStruct):
 
 ```go
-fc := spanvalue.SpannerCLICompatibleFormatConfig()
+fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
 fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ quotedColumn := spanvalue.QuoteIdentifier(
 // quotedColumn == "`select`"
 ```
 
+## Tuple-style STRUCT with Spanner CLI scalars
+
+[SpannerCLICompatibleFormatConfig](https://pkg.go.dev/github.com/apstndb/spanvalue#SpannerCLICompatibleFormatConfig)
+matches official [spanner-cli](https://github.com/cloudspannerecosystem/spanner-cli)
+output, including bracket-style STRUCT in arrays (`[[1, east]]`). For tuple
+parentheses (`[(1, east)]`) while keeping CLI scalar rules, customize the config
+returned by the constructor and set
+[FormatTupleStruct](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatTupleStruct):
+
+```go
+fc := spanvalue.SpannerCLICompatibleFormatConfig()
+fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
+```
+
+See [ExampleSpannerCLICompatibleFormatConfig_tupleStruct](https://pkg.go.dev/github.com/apstndb/spanvalue#example-SpannerCLICompatibleFormatConfig-TupleStruct).
+Keep product-specific combinations in your application (not as new spanvalue presets).
+
 ## Adoption snippets
 
 Use the small helper APIs directly when replacing ad hoc downstream formatting
@@ -205,9 +222,8 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 }
 ```
 
-Quoted TSV uses the same CSV-style writer with a tab delimiter (`encoding/csv`
-quoting: embedded tabs, quotes, and newlines in a field are escaped). For CSV output,
-`NewCSVWriter` is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
+TSV output uses the same CSV-style writer with a tab delimiter. `NewCSVWriter`
+is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
 `writer.Comma` when using the generic delimited constructor for CSV output.
 Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
 `utf8.RuneError`.
@@ -223,14 +239,6 @@ func writeTSV(out io.Writer, rows []*spanner.Row) error {
 	return w.Flush()
 }
 ```
-
-Some CLIs expose a legacy **TAB** format that joins pre-formatted column strings
-with `\t` and does not apply CSV-style quoting. That is not what
-`NewDelimitedWriter(out, '\t')` emits. To keep raw tab-separated output while
-still using spanvalue formatters, implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
-(or [`writer.RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
-when streaming via [`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)): format each column, `strings.Join(fields, "\t")`,
-then write the line.
 
 JSONL output:
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ func writeCSV(out io.Writer, rows []*spanner.Row) error {
 }
 ```
 
-TSV output uses the same CSV-style writer with a tab delimiter. `NewCSVWriter`
-is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
+Quoted TSV uses the same CSV-style writer with a tab delimiter (`encoding/csv`
+quoting: embedded tabs, quotes, and newlines in a field are escaped). For CSV output,
+`NewCSVWriter` is a thin helper for `NewDelimitedWriter(out, writer.Comma)`. Pass
 `writer.Comma` when using the generic delimited constructor for CSV output.
 Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
 `utf8.RuneError`.
@@ -238,6 +239,14 @@ func writeTSV(out io.Writer, rows []*spanner.Row) error {
 	return w.Flush()
 }
 ```
+
+Some CLIs expose a legacy **TAB** format that joins pre-formatted column strings
+with `\t` and does not apply CSV-style quoting. That is not what
+`NewDelimitedWriter(out, '\t')` emits. To keep raw tab-separated output while
+still using spanvalue formatters, implement [`writer.Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer)
+(or [`writer.RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
+when streaming via [`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)): format each column, `strings.Join(fields, "\t")`,
+then write the line.
 
 JSONL output:
 

--- a/doc.go
+++ b/doc.go
@@ -12,9 +12,10 @@
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from
 // [FormatConfig.FormatComplexPlugins] to use Decode + [FormatNullable].
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is replaced.
-// Constructors return a new [FormatConfig]; use [FormatConfig.Clone] when sharing a config.
-// For tuple STRUCT with Spanner CLI scalars, set [FormatTupleStruct] on
-// [SpannerCLICompatibleFormatConfig] (see README).
+// Constructors return a new [FormatConfig]; call [FormatConfig.Clone] before mutating
+// a config you may reuse ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
+// For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]
+// and set [FormatTupleStruct] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in
 // ARRAY, STRUCT, and scalar formatting.
 // Convenience entry points include [FormatRowLiteral], [FormatColumnLiteral],

--- a/doc.go
+++ b/doc.go
@@ -10,9 +10,11 @@
 // a preset. Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from
-// [FormatConfig.FormatComplexPlugins] on a clone to use Decode + [FormatNullable].
+// [FormatConfig.FormatComplexPlugins] to use Decode + [FormatNullable].
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is replaced.
-// Customize a preset with [FormatConfig.Clone].
+// Constructors return a new [FormatConfig]; use [FormatConfig.Clone] when sharing a config.
+// For tuple STRUCT with Spanner CLI scalars, set [FormatTupleStruct] on
+// [SpannerCLICompatibleFormatConfig] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in
 // ARRAY, STRUCT, and scalar formatting.
 // Convenience entry points include [FormatRowLiteral], [FormatColumnLiteral],
@@ -24,11 +26,10 @@
 // Lower-level callbacks and plugin types are intended for custom output formats:
 // [FormatArrayFunc], [FormatStructFieldFunc], [FormatStructParenFunc], [FormatComplexFunc],
 // [ErrFallthrough], [FormatStruct], [FormatTupleStruct], [TypedStructFormat], and
-// [JSONObjectStructFormat]. Copy a preset with [FormatConfig.Clone] before changing
-// callbacks. Convenience formatters such as [FormatRowSpannerCLICompatible] use
-// internal singleton configs; call [FormatConfig.Clone] on a preset from
-// [LiteralFormatConfig], [SimpleFormatConfig], or the other constructors before
-// changing callbacks.
+// [JSONObjectStructFormat]. Customize a [FormatConfig] from a constructor, or
+// [FormatConfig.Clone] when reusing one. Convenience formatters such as
+// [FormatRowSpannerCLICompatible] use internal singleton configs; call
+// [FormatConfig.FormatRow] on your own config instead of those helpers.
 //
 // # Related packages
 //

--- a/example_test.go
+++ b/example_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 )
 
+// Tuple-style STRUCT in `ARRAY<STRUCT<...>>` while keeping Spanner CLI scalar formatting.
 func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
-	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc := spanvalue.SpannerCLICompatibleFormatConfig()
 	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 
 	structElem, err := gcvctor.StructValueOf(

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 
 // Tuple-style STRUCT in `ARRAY<STRUCT<...>>` while keeping Spanner CLI scalar formatting.
 func ExampleSpannerCLICompatibleFormatConfig_tupleStruct() {
-	fc := spanvalue.SpannerCLICompatibleFormatConfig()
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
 	fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 
 	structElem, err := gcvctor.StructValueOf(

--- a/format_func.go
+++ b/format_func.go
@@ -14,6 +14,9 @@ func formatTypedStructParen(typ *sppb.Type, toplevel bool, fieldStrings []string
 	return fmt.Sprintf("%v(%v)", lo.Ternary(toplevel, spantype.FormatTypeVerbose(typ), ""), strings.Join(fieldStrings, ", ")), nil
 }
 
+// FormatTupleStruct renders STRUCT values with parentheses, for example (1, east).
+// [SimpleFormatConfig] uses it by default. To combine tuple STRUCT with Spanner CLI
+// scalars, see [SpannerCLICompatibleFormatConfig] and the README tuple STRUCT example.
 func FormatTupleStruct(typ *sppb.Type, toplevel bool, fieldStrings []string) (string, error) {
 	return fmt.Sprintf("(%v)", strings.Join(fieldStrings, ", ")), nil
 }

--- a/spanner_cli_compatible.go
+++ b/spanner_cli_compatible.go
@@ -21,9 +21,10 @@ var spannerCLICompatibleFormatConfig = SpannerCLICompatibleFormatConfig()
 //
 // Tuple-style STRUCT parentheses such as [(1, east)] are not spanner-cli output.
 // To keep Spanner CLI scalar formatting but render STRUCT with [FormatTupleStruct],
-// customize the returned config:
+// clone and customize (constructors return a new config; [FormatConfig.Clone] copies
+// [FormatConfig.FormatComplexPlugins] before you mutate):
 //
-//	fc := SpannerCLICompatibleFormatConfig()
+//	fc := SpannerCLICompatibleFormatConfig().Clone()
 //	fc.FormatStruct.FormatStructParen = FormatTupleStruct
 //
 // See the repository README for a tuple STRUCT example. Application-specific presets

--- a/spanner_cli_compatible.go
+++ b/spanner_cli_compatible.go
@@ -16,7 +16,21 @@ import (
 var spannerCLICompatibleFormatConfig = SpannerCLICompatibleFormatConfig()
 
 // SpannerCLICompatibleFormatConfig returns a new FormatConfig that matches
-// the output format of spanner-cli.
+// the output format of the official [spanner-cli] tool (bracket-style STRUCT
+// fields in arrays, for example [[1, east]] for `ARRAY<STRUCT<...>>`).
+//
+// Tuple-style STRUCT parentheses such as [(1, east)] are not spanner-cli output.
+// To keep Spanner CLI scalar formatting but render STRUCT with [FormatTupleStruct],
+// customize the returned config:
+//
+//	fc := SpannerCLICompatibleFormatConfig()
+//	fc.FormatStruct.FormatStructParen = FormatTupleStruct
+//
+// See the repository README for a tuple STRUCT example. Application-specific presets
+// (for example spanner-mycli table modes) should compose [FormatConfig] in the caller
+// rather than adding new constructors here.
+//
+// [spanner-cli]: https://github.com/cloudspannerecosystem/spanner-cli
 func SpannerCLICompatibleFormatConfig() *FormatConfig {
 	return &FormatConfig{
 		NullString:  nullStringUpperCase,


### PR DESCRIPTION
## Summary

- Closes #81 with documentation only (PR #103 closed: tuple STRUCT is not spanner-cli compatible).
- Expand `SpannerCLICompatibleFormatConfig` godoc with Clone + `FormatTupleStruct` and link to the existing example.
- Add README section and cross-links on `FormatTupleStruct` / package doc.

## Test plan

- [x] `make check`
- [x] Existing `ExampleSpannerCLICompatibleFormatConfig_tupleStruct` unchanged (output verified)


Made with [Cursor](https://cursor.com)