### PR TITLE
feat(writer): SQL INSERT batching via WithSQLBatchSize

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -31,8 +31,14 @@
 // accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
 // INSERT prefix (see Spanner INSERT DML syntax). [WithSQLDialect] selects identifier
 // quoting for table and column names in SQL INSERT output (GoogleSQL by default).
-// [WithSQLBatchSize] groups rows into multi-row INSERT statements; call
-// [SQLInsertWriter.Flush] after the last row when batching.
+// [WithSQLBatchSize] groups rows into multi-row INSERT statements. When batching,
+// call [SQLInsertWriter.Flush] after the final row to close a partial batch; Flush
+// is safe to call unconditionally (including when the last batch closed on a size
+// boundary).
+//
+// After any write error from [SQLInsertWriter.WriteRow], [SQLInsertWriter.WriteGCVs],
+// [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
+// writer and do not retry writes (same convention as [encoding/csv.Writer] after Error).
 // [RowData], [FormatDelimitedRow], and [FormatJSONLRow] format a single row without a writer.
 //
 // # Column names and field types
@@ -144,6 +150,10 @@ var (
 	ErrMissingFieldTypes = errors.New("missing field types schema")
 	// ErrMismatchedStructValueCount reports that WriteStructValues value count does not match the schema.
 	ErrMismatchedStructValueCount = errors.New("mismatched struct value count")
+	// ErrInvalidSQLInsertKindForDialect reports that [WithSQLInsertKind] selected INSERT OR IGNORE
+	// or INSERT OR UPDATE with a PostgreSQL dialect. Those prefixes are GoogleSQL-only; use plain
+	// [SQLInsert] with [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL) instead.
+	ErrInvalidSQLInsertKindForDialect = errors.New("INSERT OR IGNORE/UPDATE not supported for PostgreSQL dialect")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -201,6 +211,10 @@ type JSONLOption interface {
 // key already exists; INSERT OR UPDATE inserts or updates by primary key. They
 // cannot be combined with ON CONFLICT in the same statement, and INSERT is not
 // supported in Partitioned DML. See https://cloud.google.com/spanner/docs/reference/standard-sql/dml-syntax .
+//
+// [SQLInsertOrIgnore] and [SQLInsertOrUpdate] are invalid with
+// [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL); [NewSQLInsertWriter] rejects
+// that combination via [ErrInvalidSQLInsertKindForDialect] on the first write.
 type SQLInsertKind int
 
 const (
@@ -246,6 +260,9 @@ type sqlDialectOption struct {
 // output. It does not change INSERT statement prefixes ([WithSQLInsertKind]) or
 // value literal formatting ([WithFormatter]). The default is GoogleSQL
 // ([databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
+//
+// PostgreSQL dialect does not support [SQLInsertOrIgnore] or [SQLInsertOrUpdate]
+// prefixes; combining them returns [ErrInvalidSQLInsertKindForDialect] on write.
 func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 	return sqlDialectOption{dialect: dialect}
 }
@@ -257,11 +274,13 @@ func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) {
 // WithSQLBatchSize sets how many rows [SQLInsertWriter] combines into one INSERT
 // statement. Values 0 or 1 keep the default of one row per statement. Values greater
 // than 1 emit multi-row INSERT ... VALUES (...), (...); up to n rows per statement.
-// Call [SQLInsertWriter.Flush] after the final row to close a partial batch.
+// Call [SQLInsertWriter.Flush] after the final row to close a partial batch (Flush is
+// also safe when the last batch closed exactly on a size boundary).
 //
 // Batching applies the same [SQLInsertKind] prefix once per batched statement. Multi-row
-// INSERT OR IGNORE and INSERT OR UPDATE follow Spanner GoogleSQL DML rules. Identifier
-// quoting follows [WithSQLDialect]; value literals still use [WithFormatter].
+// INSERT OR IGNORE and INSERT OR UPDATE follow Spanner GoogleSQL DML rules and require
+// GoogleSQL dialect; PostgreSQL rejects those prefixes ([ErrInvalidSQLInsertKindForDialect]).
+// Identifier quoting follows [WithSQLDialect]; value literals still use [WithFormatter].
 func WithSQLBatchSize(n int) SQLInsertOption {
 	return sqlBatchSizeOption{batchSize: n}
 }
@@ -927,15 +946,24 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 }
 
 // SQLInsertWriter writes rows as SQL INSERT statements with dialect-aware identifier quoting.
+//
+// After any error from [SQLInsertWriter.WriteRow], [SQLInsertWriter.WriteGCVs],
+// [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
+// writer; partial batched INSERT output may be unrecoverable on retry.
 type SQLInsertWriter struct {
 	// Table is the qualified table name used in INSERT statements.
 	//
 	// Deprecated: Set only via [NewSQLInsertWriter]. Do not mutate Table after the
 	// first write; the field will be unexported in v0.6.
-	Table     string
+	Table string
+	// Formatter formats value literals in INSERT statements.
+	//
+	// Deprecated: Set only via [NewSQLInsertWriter] or [WithFormatter]. Do not mutate
+	// Formatter after the first write; the field will be unexported in v0.6.
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
+	configErr         error
 	sqlDialect        databasepb.DatabaseDialect
 	batchSize         int
 	batchPending      int
@@ -954,6 +982,7 @@ func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption)
 			opt.applySQLInsertOption(w)
 		}
 	}
+	w.configErr = w.validateSQLInsertConfig()
 	return w
 }
 
@@ -1068,7 +1097,8 @@ func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 }
 
 // Flush finalizes a partial multi-row INSERT batch started by [WithSQLBatchSize].
-// When batch size is 0 or 1, Flush is a no-op.
+// When batch size is 0 or 1, or when the last batch closed on a size boundary,
+// Flush is a no-op. Flush is safe to call unconditionally after the final row.
 func (w *SQLInsertWriter) Flush() error {
 	if w.sqlBatchSize() <= 1 || w.batchPending == 0 {
 		return nil
@@ -1094,7 +1124,22 @@ func (w *SQLInsertWriter) sqlBatchSize() int {
 	return w.batchSize
 }
 
+func (w *SQLInsertWriter) validateSQLInsertConfig() error {
+	if w.sqlDialect != databasepb.DatabaseDialect_POSTGRESQL {
+		return nil
+	}
+	switch w.insertKind {
+	case SQLInsertOrIgnore, SQLInsertOrUpdate:
+		return ErrInvalidSQLInsertKindForDialect
+	default:
+		return nil
+	}
+}
+
 func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedColumns string) error {
+	if w.configErr != nil {
+		return w.configErr
+	}
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -31,8 +31,9 @@
 // accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
 // INSERT prefix (see Spanner INSERT DML syntax). [WithSQLDialect] selects identifier
 // quoting for table and column names in SQL INSERT output (GoogleSQL by default).
-// [RowData], [FormatDelimitedRow], and
-// [FormatJSONLRow] format a single row without a writer.
+// [WithSQLBatchSize] groups rows into multi-row INSERT statements; call
+// [SQLInsertWriter.Flush] after the last row when batching.
+// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] format a single row without a writer.
 //
 // # Column names and field types
 //
@@ -159,8 +160,8 @@ type Writer interface {
 
 // Flusher finalizes any buffered output. Flush does not close the underlying
 // io.Writer. DelimitedWriter uses Flush to forward buffered CSV-style data;
-// JSONLWriter and SQLInsertWriter implement it as a no-op so adapters can use
-// one finalize path for all writer implementations.
+// JSONLWriter implements Flush as a no-op. [SQLInsertWriter.Flush] closes a
+// partial multi-row INSERT when [WithSQLBatchSize] is greater than 1.
 type Flusher interface {
 	Flush() error
 }
@@ -251,6 +252,26 @@ func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 
 func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) {
 	w.sqlDialect = o.dialect
+}
+
+// WithSQLBatchSize sets how many rows [SQLInsertWriter] combines into one INSERT
+// statement. Values 0 or 1 keep the default of one row per statement. Values greater
+// than 1 emit multi-row INSERT ... VALUES (...), (...); up to n rows per statement.
+// Call [SQLInsertWriter.Flush] after the final row to close a partial batch.
+//
+// Batching applies the same [SQLInsertKind] prefix once per batched statement. Multi-row
+// INSERT OR IGNORE and INSERT OR UPDATE follow Spanner GoogleSQL DML rules. Identifier
+// quoting follows [WithSQLDialect]; value literals still use [WithFormatter].
+func WithSQLBatchSize(n int) SQLInsertOption {
+	return sqlBatchSizeOption{batchSize: n}
+}
+
+type sqlBatchSizeOption struct {
+	batchSize int
+}
+
+func (o sqlBatchSizeOption) applySQLInsertOption(w *SQLInsertWriter) {
+	w.batchSize = o.batchSize
 }
 
 // SQLInsertOption configures a SQLInsertWriter created by [NewSQLInsertWriter].
@@ -912,6 +933,8 @@ type SQLInsertWriter struct {
 
 	insertKind        SQLInsertKind
 	sqlDialect        databasepb.DatabaseDialect
+	batchSize         int
+	batchPending      int
 	schema            columnSchema
 	quotedColumnNames string
 	quotedTable       string
@@ -1040,10 +1063,22 @@ func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	return w.writeGCVs(values, quotedColumns)
 }
 
-// Flush finalizes SQL INSERT output. SQLInsertWriter is unbuffered, so this is
-// a no-op.
+// Flush finalizes a partial multi-row INSERT batch started by [WithSQLBatchSize].
+// When batch size is 0 or 1, Flush is a no-op.
 func (w *SQLInsertWriter) Flush() error {
-	return nil
+	if w.sqlBatchSize() <= 1 || w.batchPending == 0 {
+		return nil
+	}
+	_, err := io.WriteString(w.out, ";\n")
+	w.batchPending = 0
+	return err
+}
+
+func (w *SQLInsertWriter) sqlBatchSize() int {
+	if w.batchSize <= 1 {
+		return 1
+	}
+	return w.batchSize
 }
 
 func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedColumns string) error {
@@ -1053,11 +1088,18 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if w.Table == "" {
 		return ErrEmptyTableName
 	}
-	quotedTable, err := w.quotedQualifiedTable()
+	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
+	if w.sqlBatchSize() <= 1 {
+		return w.writeSingleInsert(quotedColumns, formattedValues)
+	}
+	return w.appendBatchedInsert(quotedColumns, formattedValues)
+}
+
+func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValues []string) error {
+	quotedTable, err := w.quotedQualifiedTable()
 	if err != nil {
 		return err
 	}
@@ -1065,6 +1107,42 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES (", prefix, quotedTable, quotedColumns); err != nil {
 		return err
 	}
+	if err := w.writeFormattedValues(formattedValues); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w.out, ");\n")
+	return err
+}
+
+func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
+	if w.batchPending == 0 {
+		quotedTable, err := w.quotedQualifiedTable()
+		if err != nil {
+			return err
+		}
+		prefix := w.insertKind.String()
+		if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES\n  (", prefix, quotedTable, quotedColumns); err != nil {
+			return err
+		}
+	} else if _, err := io.WriteString(w.out, ",\n  ("); err != nil {
+		return err
+	}
+	if err := w.writeFormattedValues(formattedValues); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w.out, ")"); err != nil {
+		return err
+	}
+	w.batchPending++
+	if w.batchPending >= w.sqlBatchSize() {
+		_, err := io.WriteString(w.out, ";\n")
+		w.batchPending = 0
+		return err
+	}
+	return nil
+}
+
+func (w *SQLInsertWriter) writeFormattedValues(formattedValues []string) error {
 	for i, val := range formattedValues {
 		if i > 0 {
 			if _, err := io.WriteString(w.out, ", "); err != nil {
@@ -1075,8 +1153,7 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 			return err
 		}
 	}
-	_, err = io.WriteString(w.out, ");\n")
-	return err
+	return nil
 }
 
 func (w *SQLInsertWriter) setRowType(rowType *sppb.StructType) {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -928,6 +928,10 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 
 // SQLInsertWriter writes rows as SQL INSERT statements with dialect-aware identifier quoting.
 type SQLInsertWriter struct {
+	// Table is the qualified table name used in INSERT statements.
+	//
+	// Deprecated: Set only via [NewSQLInsertWriter]. Do not mutate Table after the
+	// first write; the field will be unexported in v0.6.
 	Table     string
 	Formatter *spanvalue.FormatConfig
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1069,9 +1069,18 @@ func (w *SQLInsertWriter) Flush() error {
 	if w.sqlBatchSize() <= 1 || w.batchPending == 0 {
 		return nil
 	}
-	_, err := io.WriteString(w.out, ";\n")
+	return w.closePendingBatch()
+}
+
+func (w *SQLInsertWriter) closePendingBatch() error {
+	if w.batchPending == 0 {
+		return nil
+	}
+	if _, err := io.WriteString(w.out, ";\n"); err != nil {
+		return err
+	}
 	w.batchPending = 0
-	return err
+	return nil
 }
 
 func (w *SQLInsertWriter) sqlBatchSize() int {
@@ -1118,9 +1127,7 @@ func (w *SQLInsertWriter) flushPendingBatchOnTableChange() error {
 	if w.batchPending == 0 || w.quotedTableInput == "" || w.Table == w.quotedTableInput {
 		return nil
 	}
-	_, err := io.WriteString(w.out, ";\n")
-	w.batchPending = 0
-	return err
+	return w.closePendingBatch()
 }
 
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
@@ -1147,9 +1154,7 @@ func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedVal
 	}
 	w.batchPending++
 	if w.batchPending >= w.sqlBatchSize() {
-		_, err := io.WriteString(w.out, ";\n")
-		w.batchPending = 0
-		return err
+		return w.closePendingBatch()
 	}
 	return nil
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -954,12 +954,12 @@ type SQLInsertWriter struct {
 	// Table is the qualified table name used in INSERT statements.
 	//
 	// Deprecated: Set only via [NewSQLInsertWriter]. Do not mutate Table after the
-	// first write; the field will be unexported in v0.6.
+	// first write; the field will be unexported in a future minor release.
 	Table string
 	// Formatter formats value literals in INSERT statements.
 	//
 	// Deprecated: Set only via [NewSQLInsertWriter] or [WithFormatter]. Do not mutate
-	// Formatter after the first write; the field will be unexported in v0.6.
+	// Formatter after the first write; the field will be unexported in a future minor release.
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1114,7 +1114,19 @@ func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValue
 	return err
 }
 
+func (w *SQLInsertWriter) flushPendingBatchOnTableChange() error {
+	if w.batchPending == 0 || w.quotedTableInput == "" || w.Table == w.quotedTableInput {
+		return nil
+	}
+	_, err := io.WriteString(w.out, ";\n")
+	w.batchPending = 0
+	return err
+}
+
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
+	if err := w.flushPendingBatchOnTableChange(); err != nil {
+		return err
+	}
 	if w.batchPending == 0 {
 		quotedTable, err := w.quotedQualifiedTable()
 		if err != nil {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -846,6 +846,111 @@ func TestSQLInsertWriterSQLDialect(t *testing.T) {
 	}
 }
 
+func TestSQLInsertWriterBatchSize(t *testing.T) {
+	t.Parallel()
+
+	columnNames := []string{"id", "name"}
+	row := func(id int64, name string) []spanner.GenericColumnValue {
+		return []spanner.GenericColumnValue{
+			gcvctor.Int64Value(id),
+			gcvctor.StringValue(name),
+		}
+	}
+
+	t.Run("default one row per statement", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users")
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		want := "" +
+			"INSERT INTO `users` (`id`, `name`) VALUES (1, \"a\");\n" +
+			"INSERT INTO `users` (`id`, `name`) VALUES (2, \"b\");\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("batch size two", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2))
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b"), row(3, "c")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		want := "" +
+			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
+			"  (1, \"a\"),\n" +
+			"  (2, \"b\");\n" +
+			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
+			"  (3, \"c\")"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("flush remainder", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2))
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b"), row(3, "c")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		if err := w.Flush(); err != nil {
+			t.Fatalf("Flush() error = %v", err)
+		}
+		want := "" +
+			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
+			"  (1, \"a\"),\n" +
+			"  (2, \"b\");\n" +
+			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
+			"  (3, \"c\");\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("batch size zero same as one", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(0))
+		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
+			t.Fatalf("WriteValues() error = %v", err)
+		}
+		want := "INSERT INTO `users` (`id`, `name`) VALUES (1, \"a\");\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("insert or ignore batched", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2), WithSQLInsertKind(SQLInsertOrIgnore))
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		want := "INSERT OR IGNORE INTO `users` (`id`, `name`) VALUES\n  (1, \"a\"),\n  (2, \"b\");\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
 func TestSQLInsertWriterInsertKind(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -956,6 +956,22 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		}
 	})
 
+	t.Run("PostgreSQL dialect batched", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2), WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL))
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		want := "INSERT INTO \"users\" (\"id\", \"name\") VALUES\n  (1, \"a\"),\n  (2, \"b\");\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("insert or ignore batched", func(t *testing.T) {
 		t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -942,6 +942,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
 			t.Fatalf("WriteValues() error = %v", err)
 		}
+		// Legacy: mutating Table after writes; supported until v0.6 unexports the field.
 		w.Table = "archive.users"
 		if err := w.WriteValues(columnNames, row(2, "b")); err != nil {
 			t.Fatalf("WriteValues() after table change error = %v", err)
@@ -1130,6 +1131,7 @@ func TestSQLInsertWriterWriteValuesTableChangeAfterCache(t *testing.T) {
 		t.Fatalf("first WriteValues() error = %v", err)
 	}
 
+	// Legacy: mutating Table after writes; supported until v0.6 unexports the field.
 	w.Table = "archive.users"
 	err = w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(2)})
 	if err != nil {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -934,6 +934,28 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		}
 	})
 
+	t.Run("table change mid-batch flushes pending", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
+		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
+			t.Fatalf("WriteValues() error = %v", err)
+		}
+		w.Table = "archive.users"
+		if err := w.WriteValues(columnNames, row(2, "b")); err != nil {
+			t.Fatalf("WriteValues() after table change error = %v", err)
+		}
+		want := "" +
+			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
+			"  (1, \"a\");\n" +
+			"INSERT INTO `archive`.`users` (`id`, `name`) VALUES\n" +
+			"  (2, \"b\")"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("insert or ignore batched", func(t *testing.T) {
 		t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -885,6 +885,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 		}
+		// Intentionally no Flush(): the third row leaves a partial batch without a trailing semicolon.
 		want := "" +
 			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
 			"  (1, \"a\"),\n" +
@@ -934,6 +935,31 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		}
 	})
 
+	t.Run("table change after batch boundary", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
+		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
+			if err := w.WriteValues(columnNames, values); err != nil {
+				t.Fatalf("WriteValues() error = %v", err)
+			}
+		}
+		w.Table = "archive.users"
+		if err := w.WriteValues(columnNames, row(3, "c")); err != nil {
+			t.Fatalf("WriteValues() after table change error = %v", err)
+		}
+		want := "" +
+			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
+			"  (1, \"a\"),\n" +
+			"  (2, \"b\");\n" +
+			"INSERT INTO `archive`.`users` (`id`, `name`) VALUES\n" +
+			"  (3, \"c\")"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("table change mid-batch flushes pending", func(t *testing.T) {
 		t.Parallel()
 
@@ -973,6 +999,23 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		}
 	})
 
+	t.Run("PostgreSQL identifiers with formatter value literals", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "users",
+			WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
+			WithFormatter(spanvalue.LiteralFormatConfig()),
+		)
+		if err := w.WriteValues([]string{"name"}, []spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
+			t.Fatalf("WriteValues() error = %v", err)
+		}
+		want := `INSERT INTO "users" ("name") VALUES ("Alice");` + "\n"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("insert or ignore batched", func(t *testing.T) {
 		t.Parallel()
 
@@ -988,6 +1031,30 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestSQLInsertWriterPostgreSQLInsertOrKindsRejected(t *testing.T) {
+	t.Parallel()
+
+	kinds := []SQLInsertKind{SQLInsertOrIgnore, SQLInsertOrUpdate}
+	for _, kind := range kinds {
+		t.Run(kind.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w := NewSQLInsertWriter(&out, "users",
+				WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
+				WithSQLInsertKind(kind),
+			)
+			err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)})
+			if !errors.Is(err, ErrInvalidSQLInsertKindForDialect) {
+				t.Fatalf("WriteValues() error = %v, want ErrInvalidSQLInsertKindForDialect", err)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("WriteValues() wrote %q, want no output", out.String())
+			}
+		})
+	}
 }
 
 func TestSQLInsertWriterInsertKind(t *testing.T) {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -968,7 +968,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
 			t.Fatalf("WriteValues() error = %v", err)
 		}
-		// Legacy: mutating Table after writes; supported until v0.6 unexports the field.
+		// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
 		w.Table = "archive.users"
 		if err := w.WriteValues(columnNames, row(2, "b")); err != nil {
 			t.Fatalf("WriteValues() after table change error = %v", err)
@@ -1198,7 +1198,7 @@ func TestSQLInsertWriterWriteValuesTableChangeAfterCache(t *testing.T) {
 		t.Fatalf("first WriteValues() error = %v", err)
 	}
 
-	// Legacy: mutating Table after writes; supported until v0.6 unexports the field.
+	// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
 	w.Table = "archive.users"
 	err = w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(2)})
 	if err != nil {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -961,12 +961,12 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 
 		var out bytes.Buffer
 		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2), WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL))
-		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
-			if err := w.WriteValues(columnNames, values); err != nil {
+		for _, id := range []int64{1, 2} {
+			if err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(id)}); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 		}
-		want := "INSERT INTO \"users\" (\"id\", \"name\") VALUES\n  (1, \"a\"),\n  (2, \"b\");\n"
+		want := "INSERT INTO \"users\" (\"id\") VALUES\n  (1),\n  (2);\n"
 		if diff := cmp.Diff(want, out.String()); diff != "" {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}


### PR DESCRIPTION
## Summary

- Add `WithSQLBatchSize(n)` on `SQLInsertWriter`: `n` 0 or 1 keeps one row per `INSERT`; `n` > 1 emits GoogleSQL multi-row `INSERT ... VALUES (...), (...)` up to `n` rows per statement.
- `Flush()` terminates a partial batch with `;\n` (required after the last row when batching).
- Document GoogleSQL / `SQLInsertKind` interaction in the option godoc.

Partial follow-up for #79: lower-level INSERT fragment helpers and PostgreSQL dialect export remain out of scope (see #101 / PR #104).

## Test plan

- [x] `make check`
- [x] Default and batch-size-0/1 behavior unchanged
- [x] Batch size 2, partial batch without flush, `Flush()` remainder
- [x] Batched `INSERT OR IGNORE`

Refs #79


Made with [Cursor](https://cursor.com)