### PR TITLE
docs: adoption guide for go-sql-spanner GCV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ When the app already holds `*spannerpb.ResultSetMetadata` (for example proto dec
 is appropriate. For display headers outside the writer, use
 [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames)
 on the **same** field list with the **same**
-[`UnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#UnnamedFieldNamer)
+[`spanvalue.UnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#UnnamedFieldNamer)
 as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithUnnamedFieldNamer).
 
 **CSV / JSONL:** register schema and formatting at construction, stream rows, then

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ may be empty but metadata still lists columns, use the `iter.Next` loop below an
 `PrepareRowType(iter.Metadata.GetRowType())` on the first loop iteration (even when `Next` returns
 `iterator.Done`), then `WriteRow` in the loop and `return w.Flush()` after the loop (do not
 `defer w.Flush()`—that discards Flush errors). You do not need to build `[]GenericColumnValue` per row or call
-`WriteStructValues` on that path. If you already hold `*sppb.ResultSetMetadata` outside a
+`WriteStructValues` on that path. If you already hold `*spannerpb.ResultSetMetadata` outside a
 `RowIterator` (for example an in-memory `spannerpb.ResultSet`), `WithMetadata(md)` at
 construction is fine.
 
@@ -186,7 +186,7 @@ Minimal adapter shape:
 
 ```go
 result, err := writer.RunRowIterator(iter, writer.RowIteratorHooks{
-	PrepareMetadata: func(md *sppb.ResultSetMetadata) error {
+	PrepareMetadata: func(md *spannerpb.ResultSetMetadata) error {
 		return sink.Init(md)
 	},
 	WriteRow: func(row *spanner.Row) error {
@@ -270,10 +270,10 @@ export with spanvalue writers. spanvalue does **not** wrap `database/sql` or
 [`writer.WriteGCVs`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.WriteGCVs)).
 
 **Column names:** `database/sql` does not surface Spanner
-`*spanpb.ResultSetMetadata`; register columns with
+`*spannerpb.ResultSetMetadata`; register columns with
 [`writer.WithColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithColumnNames)
 from your scan metadata (or `rows.Columns()` plus any unnamed-field policy).
-When the app already holds `*sppb.ResultSetMetadata` (for example proto decode),
+When the app already holds `*spannerpb.ResultSetMetadata` (for example proto decode),
 [`writer.WithMetadata`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithMetadata)
 is appropriate. For display headers outside the writer, use
 [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames)
@@ -293,6 +293,7 @@ w := writer.NewCSVWriter(
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )
+var gcvs []spanner.GenericColumnValue
 for rows.Next() {
 	// decode the scanned row into gcvs
 	if err := w.WriteGCVs(gcvs); err != nil {

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ w := writer.NewCSVWriter(
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )
-var gcvs []spanner.GenericColumnValue
 for rows.Next() {
+	var gcvs []spanner.GenericColumnValue
 	// decode the scanned row into gcvs
 	if err := w.WriteGCVs(gcvs); err != nil {
 		return err

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ DML or other statements with no result columns: call `PrepareRowType` on
 
 [go-sql-spanner](https://github.com/googleapis/go-sql-spanner) apps often decode query
 rows into `[]spanner.GenericColumnValue` (for example via proto decode options) and
-export with spanvalue writers. spanvalue does **not** wrap `database/sql` or
+export with `spanvalue` writers. `spanvalue` does **not** wrap `database/sql` or
 `*sql.Rows`; keep a thin application loop (scan → GCV slice →
 [`writer.WriteGCVs`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.WriteGCVs)).
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,49 @@ DML or other statements with no result columns: call `PrepareRowType` on
 `iter.Metadata.GetRowType()` (possibly nil or zero fields), then `Flush`—do not rely on
 `PrepareColumnNames` with an empty name list.
 
+### go-sql-spanner and GenericColumnValue export
+
+[go-sql-spanner](https://github.com/googleapis/go-sql-spanner) apps often decode query
+rows into `[]spanner.GenericColumnValue` (for example via proto decode options) and
+export with spanvalue writers. spanvalue does **not** wrap `database/sql` or
+`*sql.Rows`; keep a thin application loop (scan → GCV slice →
+[`writer.WriteGCVs`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.WriteGCVs)).
+
+**Column names:** derive display or file headers with
+[`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames)
+on `metadata.GetRowType().GetFields()`, using the **same**
+[`UnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#UnnamedFieldNamer)
+as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithUnnamedFieldNamer)
+(default: [`IndexedUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#IndexedUnnamedFieldNamer)).
+Do not use raw `StructType.Field` names alone when the writer applies a namer.
+
+**CSV / JSONL:** register schema and formatting at construction, stream rows, then
+`Flush` (CSV may emit a header on zero-row `SELECT`; JSONL `Flush` is a no-op):
+
+```go
+namer := spanvalue.IndexedUnnamedFieldNamer
+w := writer.NewCSVWriter(
+	out,
+	writer.WithMetadata(md),
+	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
+	writer.WithUnnamedFieldNamer(namer),
+)
+for /* each scanned row */ {
+	if err := w.WriteGCVs(gcvs); err != nil {
+		return err
+	}
+}
+return w.Flush()
+```
+
+**Native Spanner client:** for `*spanner.RowIterator`, use
+[`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)
+or [`writer.RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator)
+instead of building GCV slices per row.
+
+Metadata pseudo-rows, `NextResultSet` progression, and stats-only result sets stay
+in the application (for example [spannersh](https://github.com/apstndb/spannersh)).
+
 ### ENUM and PROTO in CSV
 
 Delimited output uses [`SimpleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SimpleFormatConfig)

--- a/README.md
+++ b/README.md
@@ -195,22 +195,27 @@ export with spanvalue writers. spanvalue does **not** wrap `database/sql` or
 `*sql.Rows`; keep a thin application loop (scan → GCV slice →
 [`writer.WriteGCVs`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.WriteGCVs)).
 
-**Column names:** derive display or file headers with
+**Column names:** `database/sql` does not surface Spanner
+`*spanpb.ResultSetMetadata`; register columns with
+[`writer.WithColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithColumnNames)
+from your scan metadata (or `rows.Columns()` plus any unnamed-field policy).
+When the app already holds `*sppb.ResultSetMetadata` (for example proto decode),
+[`writer.WithMetadata`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithMetadata)
+is appropriate. For display headers outside the writer, use
 [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames)
-on `metadata.GetRowType().GetFields()`, using the **same**
+on the **same** field list with the **same**
 [`UnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#UnnamedFieldNamer)
-as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithUnnamedFieldNamer)
-(default: [`IndexedUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#IndexedUnnamedFieldNamer)).
-Do not use raw `StructType.Field` names alone when the writer applies a namer.
+as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithUnnamedFieldNamer).
 
 **CSV / JSONL:** register schema and formatting at construction, stream rows, then
 `Flush` (CSV may emit a header on zero-row `SELECT`; JSONL `Flush` is a no-op):
 
 ```go
 namer := spanvalue.IndexedUnnamedFieldNamer
+names := []string{"id", "name"} // same names passed to WithColumnNames
 w := writer.NewCSVWriter(
 	out,
-	writer.WithMetadata(md),
+	writer.WithColumnNames(names),
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ w := writer.NewCSVWriter(
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )
+defer rows.Close()
 for rows.Next() {
 	var gcvs []spanner.GenericColumnValue
 	// decode the scanned row into gcvs

--- a/README.md
+++ b/README.md
@@ -214,10 +214,14 @@ w := writer.NewCSVWriter(
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )
-for /* each scanned row */ {
+for rows.Next() {
+	// decode the scanned row into gcvs
 	if err := w.WriteGCVs(gcvs); err != nil {
 		return err
 	}
+}
+if err := rows.Err(); err != nil {
+	return err
 }
 return w.Flush()
 ```

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,6 +1,11 @@
 // Package writer provides small streaming helpers for exporting Spanner rows
 // using spanvalue formatters.
 //
+// For [database/sql] clients that decode rows into []spanner.GenericColumnValue
+// (for example go-sql-spanner), use WriteGCVs with WithMetadata, WithFormatter,
+// and WithUnnamedFieldNamer; match out-of-band headers with spanvalue.ColumnNames.
+// See the README section "go-sql-spanner and GenericColumnValue export".
+//
 // DelimitedWriter is the primary writer for CSV-style delimited text.
 // NewCSVWriter is a thin helper for the common comma-delimited CSV case, while
 // NewDelimitedWriter accepts an explicit delimiter for TSV and other delimited

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -3,12 +3,14 @@
 //
 // For [database/sql] clients that decode rows into
 // [][cloud.google.com/go/spanner.GenericColumnValue] (for example
-// [github.com/googleapis/go-sql-spanner]), use [DelimitedWriter.WriteGCVs] with
-// [WithColumnNames] (typical—[database/sql] does not expose Spanner
-// [cloud.google.com/go/spanner/apiv1/spannerpb.ResultSetMetadata]), or
-// [WithMetadata] when the app already holds metadata (for example proto decode).
-// Also set [WithFormatter] and [WithUnnamedFieldNamer]; match out-of-band headers
-// with [github.com/apstndb/spanvalue.ColumnNames] on the same field list.
+// [github.com/googleapis/go-sql-spanner]), use [DelimitedWriter.WriteGCVs].
+// Register columns with [WithColumnNames] when scan metadata supplies names.
+// [database/sql] does not expose Spanner
+// [cloud.google.com/go/spanner/apiv1/spannerpb.ResultSetMetadata].
+// Use [WithMetadata] when the app already holds metadata (for example proto decode).
+// Also set [WithFormatter] and [WithUnnamedFieldNamer].
+// Match out-of-band headers with [github.com/apstndb/spanvalue.ColumnNames] on the
+// same field list and [spanvalue.UnnamedFieldNamer] policy.
 // See the README section "go-sql-spanner and GenericColumnValue export".
 //
 // DelimitedWriter is the primary writer for CSV-style delimited text.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -10,7 +10,7 @@
 // Use [WithMetadata] when the app already holds metadata (for example proto decode).
 // Also set [WithFormatter] and [WithUnnamedFieldNamer].
 // Match out-of-band headers with [github.com/apstndb/spanvalue.ColumnNames] on the
-// same field list and [spanvalue.UnnamedFieldNamer] policy.
+// same field list and [github.com/apstndb/spanvalue.UnnamedFieldNamer] policy.
 // See the README section "go-sql-spanner and GenericColumnValue export".
 //
 // DelimitedWriter is the primary writer for CSV-style delimited text.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,9 +1,11 @@
 // Package writer provides small streaming helpers for exporting Spanner rows
 // using spanvalue formatters.
 //
-// For [database/sql] clients that decode rows into []spanner.GenericColumnValue
-// (for example go-sql-spanner), use WriteGCVs with WithMetadata, WithFormatter,
-// and WithUnnamedFieldNamer; match out-of-band headers with spanvalue.ColumnNames.
+// For [database/sql] clients that decode rows into
+// [][cloud.google.com/go/spanner.GenericColumnValue] (for example
+// [github.com/googleapis/go-sql-spanner]), use [DelimitedWriter.WriteGCVs] with
+// [WithMetadata], [WithFormatter], and [WithUnnamedFieldNamer]; match out-of-band
+// headers with [github.com/apstndb/spanvalue.ColumnNames].
 // See the README section "go-sql-spanner and GenericColumnValue export".
 //
 // DelimitedWriter is the primary writer for CSV-style delimited text.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -4,8 +4,11 @@
 // For [database/sql] clients that decode rows into
 // [][cloud.google.com/go/spanner.GenericColumnValue] (for example
 // [github.com/googleapis/go-sql-spanner]), use [DelimitedWriter.WriteGCVs] with
-// [WithMetadata], [WithFormatter], and [WithUnnamedFieldNamer]; match out-of-band
-// headers with [github.com/apstndb/spanvalue.ColumnNames].
+// [WithColumnNames] (typical—[database/sql] does not expose Spanner
+// [cloud.google.com/go/spanner/apiv1/spannerpb.ResultSetMetadata]), or
+// [WithMetadata] when the app already holds metadata (for example proto decode).
+// Also set [WithFormatter] and [WithUnnamedFieldNamer]; match out-of-band headers
+// with [github.com/apstndb/spanvalue.ColumnNames] on the same field list.
 // See the README section "go-sql-spanner and GenericColumnValue export".
 //
 // DelimitedWriter is the primary writer for CSV-style delimited text.


### PR DESCRIPTION
## Summary

Add README and writer package doc for applications using go-sql-spanner with `[]GenericColumnValue` and spanvalue writers, without adding `*sql.Rows` support.

## Test plan

- [x] `make check`

Closes #109

Made with [Cursor](https://cursor.com)