### PR TITLE
docs: example WriteRowIterator after row skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ writers emit a header-only CSV when columns were present but no data rows were
 written:
 
 ```go
+defer iter.Stop()
+
 w := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
 for {
 	_, err := iter.Next()

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ defer iter.Stop()
 w := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
 for {
 	_, err := iter.Next()
-	if err == iterator.Done {
+	if errors.Is(err, iterator.Done) {
 		break
 	}
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -158,6 +158,35 @@ after the first `Next`, write each row, then `Flush` — is still supported;
 prefer `WriteRowIterator` when you also need metadata or query stats from an
 empty result.
 
+### Metadata-only finish after skipping rows
+
+When the application consumes a `RowIterator` but does not write every row body
+(for example a redacted or stats-only export path), metadata is still available
+after `iterator.Done`. Register the row type and call `Flush` so delimited
+writers emit a header-only CSV when columns were present but no data rows were
+written:
+
+```go
+w := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
+for {
+	_, err := iter.Next()
+	if err == iterator.Done {
+		break
+	}
+	if err != nil {
+		return err
+	}
+	// discard row body
+}
+if err := w.PrepareRowType(iter.Metadata.GetRowType()); err != nil {
+	return err
+}
+return w.Flush()
+```
+
+When every row is written normally, prefer [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)
+instead of reimplementing the loop.
+
 ### Schema registration
 
 | Goal | API |

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -96,6 +96,10 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 
 // WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
 // See [RunRowIterator] for iterator metadata, stats, and zero-row behavior.
+//
+// When an application skips row bodies but still needs a header-only delimited finish,
+// call [RowIteratorWriter.PrepareRowType] with iter.Metadata.GetRowType() after the Next
+// loop, then [Flusher.Flush]; see README "Metadata-only finish after skipping rows".
 func WriteRowIterator(iter *spanner.RowIterator, w RowIteratorWriter) (*RowIteratorResult, error) {
 	if iter == nil {
 		return nil, ErrNilRowIterator

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -97,6 +97,11 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 // WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
 // See [RunRowIterator] for iterator metadata, stats, and zero-row behavior.
 //
+// When an application drives [cloud.google.com/go/spanner.RowIterator.Next] directly
+// (instead of [WriteRowIterator] or [RunRowIterator]), call
+// [cloud.google.com/go/spanner.RowIterator.Stop] on return (typically defer iter.Stop())
+// so streams and resources are released.
+//
 // When an application skips row bodies but still needs a header-only delimited finish,
 // call [RowIteratorWriter.PrepareRowType] with iter.Metadata.GetRowType() after the Next
 // loop, then [Flusher.Flush]; see README "Metadata-only finish after skipping rows".


### PR DESCRIPTION
## Summary

Add README and `WriteRowIterator` godoc for metadata-only export finish when row bodies are skipped but column metadata and `Flush` are still required.

## Test plan

- [x] `make check`

Closes #112

Made with [Cursor](https://cursor.com)