### PR TITLE
writer: helper for common formatter/metadata/namer options

### DIFF
--- a/writer/export_options.go
+++ b/writer/export_options.go
@@ -1,0 +1,34 @@
+package writer
+
+import (
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+
+	"github.com/apstndb/spanvalue"
+)
+
+// DelimitedGCVExportOptions returns [WithMetadata], [WithFormatter], and
+// [WithUnnamedFieldNamer] for delimited writers that stream [DelimitedWriter.WriteGCVs].
+func DelimitedGCVExportOptions(
+	metadata *sppb.ResultSetMetadata,
+	formatter *spanvalue.FormatConfig,
+	namer spanvalue.UnnamedFieldNamer,
+) []DelimitedOption {
+	return []DelimitedOption{
+		WithMetadata(metadata),
+		WithFormatter(formatter),
+		WithUnnamedFieldNamer(namer),
+	}
+}
+
+// JSONLGCVExportOptions returns the same trio for [NewJSONLWriter] and [JSONLWriter.WriteGCVs].
+func JSONLGCVExportOptions(
+	metadata *sppb.ResultSetMetadata,
+	formatter *spanvalue.FormatConfig,
+	namer spanvalue.UnnamedFieldNamer,
+) []JSONLOption {
+	return []JSONLOption{
+		WithMetadata(metadata),
+		WithFormatter(formatter),
+		WithUnnamedFieldNamer(namer),
+	}
+}

--- a/writer/export_options.go
+++ b/writer/export_options.go
@@ -8,27 +8,41 @@ import (
 
 // DelimitedGCVExportOptions returns [WithMetadata], [WithFormatter], and
 // [WithUnnamedFieldNamer] for delimited writers that stream [DelimitedWriter.WriteGCVs].
+// Nil arguments are omitted so defaults are not overwritten accidentally.
 func DelimitedGCVExportOptions(
 	metadata *sppb.ResultSetMetadata,
 	formatter *spanvalue.FormatConfig,
 	namer spanvalue.UnnamedFieldNamer,
 ) []DelimitedOption {
-	return []DelimitedOption{
-		WithMetadata(metadata),
-		WithFormatter(formatter),
-		WithUnnamedFieldNamer(namer),
+	var opts []DelimitedOption
+	if metadata != nil {
+		opts = append(opts, WithMetadata(metadata))
 	}
+	if formatter != nil {
+		opts = append(opts, WithFormatter(formatter))
+	}
+	if namer != nil {
+		opts = append(opts, WithUnnamedFieldNamer(namer))
+	}
+	return opts
 }
 
 // JSONLGCVExportOptions returns the same trio for [NewJSONLWriter] and [JSONLWriter.WriteGCVs].
+// Nil arguments are omitted so defaults are not overwritten accidentally.
 func JSONLGCVExportOptions(
 	metadata *sppb.ResultSetMetadata,
 	formatter *spanvalue.FormatConfig,
 	namer spanvalue.UnnamedFieldNamer,
 ) []JSONLOption {
-	return []JSONLOption{
-		WithMetadata(metadata),
-		WithFormatter(formatter),
-		WithUnnamedFieldNamer(namer),
+	var opts []JSONLOption
+	if metadata != nil {
+		opts = append(opts, WithMetadata(metadata))
 	}
+	if formatter != nil {
+		opts = append(opts, WithFormatter(formatter))
+	}
+	if namer != nil {
+		opts = append(opts, WithUnnamedFieldNamer(namer))
+	}
+	return opts
 }

--- a/writer/export_options_test.go
+++ b/writer/export_options_test.go
@@ -1,0 +1,32 @@
+package writer
+
+import (
+	"bytes"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDelimitedGCVExportOptions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	md := metadataWithColumnNames("name")
+	w := NewCSVWriter(&out, DelimitedGCVExportOptions(
+		md,
+		spanvalue.SimpleFormatConfig(),
+		spanvalue.IndexedUnnamedFieldNamer,
+	)...)
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	flushDelimitedWriter(t, w)
+
+	want := "name\nx\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/writer/export_options_test.go
+++ b/writer/export_options_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -28,5 +29,50 @@ func TestDelimitedGCVExportOptions(t *testing.T) {
 	want := "name\nx\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDelimitedGCVExportOptionsSkipsNil(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewCSVWriter(&out, DelimitedGCVExportOptions(nil, nil, nil)...)
+	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")})
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)
+	}
+}
+
+func TestJSONLGCVExportOptions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	md := metadataWithColumnNames("name")
+	w := NewJSONLWriter(&out, JSONLGCVExportOptions(
+		md,
+		spanvalue.JSONFormatConfig(),
+		spanvalue.IndexedUnnamedFieldNamer,
+	)...)
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	want := `{"name":"x"}` + "\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("JSONL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestJSONLGCVExportOptionsSkipsNil(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := NewJSONLWriter(&out, JSONLGCVExportOptions(nil, nil, nil)...)
+	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")})
+	if !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)
 	}
 }


### PR DESCRIPTION
## Summary

Add `DelimitedGCVExportOptions` and `JSONLGCVExportOptions` so callers can pass the shared `WithMetadata` / `WithFormatter` / `WithUnnamedFieldNamer` trio without duplicating three lines per writer kind.

## Test plan

- [x] `make check`
- [x] `TestDelimitedGCVExportOptions`

Closes #111

Made with [Cursor](https://cursor.com)