### PR TITLE
docs: RowIteratorHooks adapter guide (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,49 @@ after the first `Next`, write each row, then `Flush` — is still supported;
 prefer `WriteRowIterator` when you also need metadata or query stats from an
 empty result.
 
+### `RunRowIterator` hooks (custom adapters)
+
+Use [`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)
+when the sink is a built-in [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
+(`DelimitedWriter`, `JSONLWriter`, `SQLInsertWriter`). Use
+[`writer.RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator)
+with [`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks)
+when the sink is not one of those writers—for example a legacy formatter, a
+row transform into an app-owned type, or a presentation-specific export path
+that should stay outside spanvalue.
+
+`RunRowIterator` always calls `iter.Stop()`. Hook semantics (also on
+[`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks)
+godoc):
+
+- **`PrepareMetadata`** runs once after the first successful `Next` (including
+  when the only result is `iterator.Done`). It is skipped when the first `Next`
+  returns a non-`Done` error.
+- **`WriteRow`** runs for each data row.
+- **`Finish`** runs only after all rows are consumed **without error**. It is
+  **not** a `defer`-style cleanup when `PrepareMetadata` or `WriteRow` fails.
+- On abort, `RunRowIterator` still returns `*RowIteratorResult` with whatever
+  metadata and stats were available at the abort point.
+
+Minimal adapter shape:
+
+```go
+result, err := writer.RunRowIterator(iter, writer.RowIteratorHooks{
+	PrepareMetadata: func(md *sppb.ResultSetMetadata) error {
+		return sink.Init(md)
+	},
+	WriteRow: func(row *spanner.Row) error {
+		return sink.Write(row)
+	},
+	Finish: func(res *writer.RowIteratorResult) error {
+		return sink.Close(res)
+	},
+})
+```
+
+Nil hook fields are skipped. For header-only or row-skip patterns, see
+[Metadata-only finish after skipping rows](#metadata-only-finish-after-skipping-rows).
+
 ### Schema registration
 
 | Goal | API |

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ that should stay outside spanvalue.
 [`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks)
 godoc):
 
-- **`PrepareMetadata`** runs once after the first successful `Next` (including
-  when the only result is `iterator.Done`). It is skipped when the first `Next`
-  returns a non-`Done` error.
+- **`PrepareMetadata`** runs once after the first `Next`, including when that
+  call returns `iterator.Done` (zero data rows). It is not called when the first
+  `Next` returns any other error.
 - **`WriteRow`** runs for each data row.
 - **`Finish`** runs only after all rows are consumed **without error**. It is
   **not** a `defer`-style cleanup when `PrepareMetadata` or `WriteRow` fails.


### PR DESCRIPTION
## Summary

- Adds a README subsection on when to use `WriteRowIterator` vs `RunRowIterator` + `RowIteratorHooks`.
- Documents `PrepareMetadata` / `WriteRow` / `Finish` semantics (success-path `Finish`, abort behavior, `Stop`).
- Includes a minimal custom-adapter example for sinks that are not `RowIteratorWriter` implementations.

Closes #119.

## Test plan

- [x] Docs-only change (README)
- [ ] Review links and wording on GitHub preview


Made with [Cursor](https://cursor.com)