### PR TITLE
writer: RowsRead on RowIteratorResult and hook decorators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 
 ## Git & review
 
+- **Parallel PR work:** check out active PR branches in dedicated worktrees beside the main clone, e.g. `spanvalue-wt-<issue-or-pr>` (`git worktree add ../spanvalue-wt-124 <branch>`). Keep the main repo on docs or integration branches; run `make check` and push from the PR worktree.
 - **English only** on github.com (issues, PRs, review threads).
 - **Merge:** `squash and merge`; branch updates via **merge**, not rebase+force-push to `main`.
 - **During review response:** avoid **rebase** on the PR branch; squash merge cleans history.

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -30,11 +30,13 @@ type RowIteratorStats struct {
 // the abort point and may be zero until [iterator.Done] (QueryStats and RowCount
 // are only fully populated after a successful run).
 //
-// RowsRead counts data rows successfully passed through hooks.WriteRow during
-// the run, including on the error path when iteration aborts mid-stream. It is
-// zero when WriteRow is nil or no row was written. RowsRead is distinct from
-// [RowIteratorStats.RowCount], which follows Spanner iterator semantics (DML
-// row count after iterator.Done).
+// RowsRead counts data rows for which hooks.WriteRow returned nil during the
+// run, including on the error path when iteration aborts mid-stream. It stays
+// zero when WriteRow is nil (rows may still be consumed from the iterator).
+// Hook decorators that install a WriteRow wrapper only for ordinal or observe
+// side effects do not increment RowsRead unless the wrapped hooks already had
+// WriteRow set. RowsRead is distinct from [RowIteratorStats.RowCount], which
+// follows Spanner iterator semantics (DML row count after iterator.Done).
 type RowIteratorResult struct {
 	Metadata *sppb.ResultSetMetadata
 	Stats    RowIteratorStats
@@ -59,6 +61,12 @@ type RowIteratorHooks struct {
 	PrepareMetadata func(*sppb.ResultSetMetadata) error
 	WriteRow        func(*spanner.Row) error
 	Finish          func(*RowIteratorResult) error
+
+	// omitRowsRead is set by hook decorators that add WriteRow only for side
+	// effects when the wrapped hooks had no WriteRow.
+	omitRowsRead bool
+	// onRunStart runs once at the beginning of each RunRowIterator call.
+	onRunStart func()
 }
 
 // RowIteratorWriter streams rows from a [cloud.google.com/go/spanner.RowIterator]
@@ -163,6 +171,10 @@ func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIterator
 	}
 	defer stopOnce()
 
+	if hooks.onRunStart != nil {
+		hooks.onRunStart()
+	}
+
 	var rowsRead int
 	outcome := func() *RowIteratorResult {
 		return &RowIteratorResult{
@@ -197,7 +209,9 @@ func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIterator
 			if err := hooks.WriteRow(row); err != nil {
 				return abort(err)
 			}
-			rowsRead++
+			if !hooks.omitRowsRead {
+				rowsRead++
+			}
 		}
 	}
 	stopOnce()

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -29,9 +29,16 @@ type RowIteratorStats struct {
 // On the error path, stats fields reflect whatever the iterator had populated at
 // the abort point and may be zero until [iterator.Done] (QueryStats and RowCount
 // are only fully populated after a successful run).
+//
+// RowsRead counts data rows successfully passed through hooks.WriteRow during
+// the run, including on the error path when iteration aborts mid-stream. It is
+// zero when WriteRow is nil or no row was written. RowsRead is distinct from
+// [RowIteratorStats.RowCount], which follows Spanner iterator semantics (DML
+// row count after iterator.Done).
 type RowIteratorResult struct {
 	Metadata *sppb.ResultSetMetadata
 	Stats    RowIteratorStats
+	RowsRead int
 }
 
 // RowIteratorHooks drives [RunRowIterator]. Nil function fields are skipped.
@@ -156,10 +163,12 @@ func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIterator
 	}
 	defer stopOnce()
 
+	var rowsRead int
 	outcome := func() *RowIteratorResult {
 		return &RowIteratorResult{
 			Metadata: fac.metadata(),
 			Stats:    fac.stats(),
+			RowsRead: rowsRead,
 		}
 	}
 	abort := func(err error) (*RowIteratorResult, error) {
@@ -188,6 +197,7 @@ func runRowIterator(fac rowIteratorFacade, hooks RowIteratorHooks) (*RowIterator
 			if err := hooks.WriteRow(row); err != nil {
 				return abort(err)
 			}
+			rowsRead++
 		}
 	}
 	stopOnce()

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -16,7 +16,8 @@ type RowOrdinal struct {
 
 // WithRowOrdinal wraps base so ord.Current is set to the 1-based row index
 // immediately before each WriteRow attempt on base. ord.Current resets to 0 at
-// the start of each run via PrepareMetadata. A nil ord is ignored and base is
+// the start of each [RunRowIterator] call (including when the first Next returns
+// a query error before PrepareMetadata). A nil ord is ignored and base is
 // returned as-is. When base.WriteRow is nil, the wrapper still runs so ord is
 // updated for each streamed row.
 func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
@@ -24,7 +25,8 @@ func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
 		return base
 	}
 	writeRow := base.WriteRow
-	base = resetOnPrepareMetadata(base, func() { ord.Current = 0 })
+	base = resetEachRun(base, func() { ord.Current = 0 })
+	base.omitRowsRead = base.omitRowsRead || writeRow == nil
 	base.WriteRow = func(row *spanner.Row) error {
 		ord.Current++
 		if writeRow != nil {
@@ -44,7 +46,8 @@ func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowI
 	}
 	writeRow := base.WriteRow
 	var rowNum int
-	base = resetOnPrepareMetadata(base, func() { rowNum = 0 })
+	base = resetEachRun(base, func() { rowNum = 0 })
+	base.omitRowsRead = base.omitRowsRead || writeRow == nil
 	base.WriteRow = func(row *spanner.Row) error {
 		rowNum++
 		if err := observe(rowNum); err != nil {
@@ -68,6 +71,7 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 		return base
 	}
 	writeRow := base.WriteRow
+	base.omitRowsRead = base.omitRowsRead || writeRow == nil
 	base.WriteRow = func(row *spanner.Row) error {
 		if writeRow != nil {
 			if err := writeRow(row); err != nil {
@@ -79,7 +83,14 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 	return base
 }
 
-func resetOnPrepareMetadata(base RowIteratorHooks, reset func()) RowIteratorHooks {
+func resetEachRun(base RowIteratorHooks, reset func()) RowIteratorHooks {
+	prev := base.onRunStart
+	base.onRunStart = func() {
+		if prev != nil {
+			prev()
+		}
+		reset()
+	}
 	prep := base.PrepareMetadata
 	base.PrepareMetadata = func(md *sppb.ResultSetMetadata) error {
 		reset()

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
 
 // RowOrdinal holds a 1-based row index for diagnostics while streaming rows.
@@ -14,42 +15,45 @@ type RowOrdinal struct {
 }
 
 // WithRowOrdinal wraps base so ord.Current is set to the 1-based row index
-// immediately before each WriteRow attempt on base. Reset ord.Current to 0
-// before each RunRowIterator when reusing the returned hooks. PrepareMetadata
-// and Finish are forwarded unchanged. A nil ord is ignored and base is returned as-is.
+// immediately before each WriteRow attempt on base. ord.Current resets to 0 at
+// the start of each run via PrepareMetadata. A nil ord is ignored and base is
+// returned as-is. When base.WriteRow is nil, the wrapper still runs so ord is
+// updated for each streamed row.
 func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
 	if ord == nil {
 		return base
 	}
 	writeRow := base.WriteRow
-	if writeRow == nil {
-		return base
-	}
+	base = resetOnPrepareMetadata(base, func() { ord.Current = 0 })
 	base.WriteRow = func(row *spanner.Row) error {
 		ord.Current++
-		return writeRow(row)
+		if writeRow != nil {
+			return writeRow(row)
+		}
+		return nil
 	}
 	return base
 }
 
 // ObserveWriteRow wraps base.WriteRow to call observe with the 1-based row index
 // before delegating. Returning an error from observe aborts without calling
-// base.WriteRow. PrepareMetadata and Finish are forwarded unchanged.
+// base.WriteRow. When base.WriteRow is nil, observe still runs for each row.
 func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowIteratorHooks {
 	if observe == nil {
 		return base
 	}
 	writeRow := base.WriteRow
-	if writeRow == nil {
-		return base
-	}
-	next := 0
+	var rowNum int
+	base = resetOnPrepareMetadata(base, func() { rowNum = 0 })
 	base.WriteRow = func(row *spanner.Row) error {
-		next++
-		if err := observe(next); err != nil {
+		rowNum++
+		if err := observe(rowNum); err != nil {
 			return err
 		}
-		return writeRow(row)
+		if writeRow != nil {
+			return writeRow(row)
+		}
+		return nil
 	}
 	return base
 }
@@ -57,20 +61,32 @@ func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowI
 // AfterEachSuccessfulWriteRow wraps base.WriteRow to call after on each
 // successful delegation. after is typically a buffered I/O flush for interactive
 // streaming; do not pass [SQLInsertWriter.Flush] here because that finalizes an
-// open INSERT batch and disables batching.
+// open INSERT batch and disables batching. When base.WriteRow is nil, after
+// still runs once per streamed row.
 func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowIteratorHooks {
 	if after == nil {
 		return base
 	}
 	writeRow := base.WriteRow
-	if writeRow == nil {
-		return base
-	}
 	base.WriteRow = func(row *spanner.Row) error {
-		if err := writeRow(row); err != nil {
-			return err
+		if writeRow != nil {
+			if err := writeRow(row); err != nil {
+				return err
+			}
 		}
 		return after()
+	}
+	return base
+}
+
+func resetOnPrepareMetadata(base RowIteratorHooks, reset func()) RowIteratorHooks {
+	prep := base.PrepareMetadata
+	base.PrepareMetadata = func(md *sppb.ResultSetMetadata) error {
+		reset()
+		if prep != nil {
+			return prep(md)
+		}
+		return nil
 	}
 	return base
 }

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -14,20 +14,19 @@ type RowOrdinal struct {
 }
 
 // WithRowOrdinal wraps base so ord.Current is set to the 1-based row index
-// immediately before each WriteRow attempt on base. PrepareMetadata and Finish
-// are forwarded unchanged. A nil ord is ignored and base is returned as-is.
+// immediately before each WriteRow attempt on base. Reset ord.Current to 0
+// before each RunRowIterator when reusing the returned hooks. PrepareMetadata
+// and Finish are forwarded unchanged. A nil ord is ignored and base is returned as-is.
 func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
 	if ord == nil {
 		return base
 	}
-	next := 0
 	writeRow := base.WriteRow
 	if writeRow == nil {
 		return base
 	}
 	base.WriteRow = func(row *spanner.Row) error {
-		next++
-		ord.Current = next
+		ord.Current++
 		return writeRow(row)
 	}
 	return base

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -1,0 +1,77 @@
+package writer
+
+import (
+	"cloud.google.com/go/spanner"
+)
+
+// RowOrdinal holds a 1-based row index for diagnostics while streaming rows.
+// Use [WithRowOrdinal] to keep it updated around WriteRow.
+type RowOrdinal struct {
+	// Current is the 1-based index of the row about to be written, or the last
+	// row whose WriteRow completed without error. It remains 0 until the first
+	// data row is reached. On WriteRow error, Current is the failing row index.
+	Current int
+}
+
+// WithRowOrdinal wraps base so ord.Current is set to the 1-based row index
+// immediately before each WriteRow attempt on base. PrepareMetadata and Finish
+// are forwarded unchanged. A nil ord is ignored and base is returned as-is.
+func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
+	if ord == nil {
+		return base
+	}
+	next := 0
+	writeRow := base.WriteRow
+	if writeRow == nil {
+		return base
+	}
+	base.WriteRow = func(row *spanner.Row) error {
+		next++
+		ord.Current = next
+		return writeRow(row)
+	}
+	return base
+}
+
+// ObserveWriteRow wraps base.WriteRow to call observe with the 1-based row index
+// before delegating. Returning an error from observe aborts without calling
+// base.WriteRow. PrepareMetadata and Finish are forwarded unchanged.
+func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowIteratorHooks {
+	if observe == nil {
+		return base
+	}
+	writeRow := base.WriteRow
+	if writeRow == nil {
+		return base
+	}
+	next := 0
+	base.WriteRow = func(row *spanner.Row) error {
+		next++
+		if err := observe(next); err != nil {
+			return err
+		}
+		return writeRow(row)
+	}
+	return base
+}
+
+// AfterEachSuccessfulWriteRow wraps base.WriteRow to call after on each
+// successful delegation. after is typically a buffered I/O flush for interactive
+// streaming; do not pass [SQLInsertWriter.Flush] here because that finalizes an
+// open INSERT batch and disables batching.
+func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowIteratorHooks {
+	if after == nil {
+		return base
+	}
+	writeRow := base.WriteRow
+	if writeRow == nil {
+		return base
+	}
+	base.WriteRow = func(row *spanner.Row) error {
+		if err := writeRow(row); err != nil {
+			return err
+		}
+		return after()
+	}
+	return base
+}

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -71,16 +71,19 @@ func TestRunRowIterator_rowsRead(t *testing.T) {
 		}
 	})
 
-	t.Run("decorator nil WriteRow still counts ordinal", func(t *testing.T) {
+	t.Run("decorator nil WriteRow updates ordinal not RowsRead", func(t *testing.T) {
 		t.Parallel()
 		var ord RowOrdinal
 		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
-		_, err := runRowIterator(stub, WithRowOrdinal(RowIteratorHooks{}, &ord))
+		got, err := runRowIterator(stub, WithRowOrdinal(RowIteratorHooks{}, &ord))
 		if err != nil {
 			t.Fatal(err)
 		}
 		if ord.Current != 1 {
 			t.Fatalf("Current = %d, want 1", ord.Current)
+		}
+		if got.RowsRead != 0 {
+			t.Fatalf("RowsRead = %d, want 0 with nil base WriteRow", got.RowsRead)
 		}
 	})
 }
@@ -195,20 +198,107 @@ func TestAfterEachSuccessfulWriteRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
-
-	var flushes int
-	hooks := AfterEachSuccessfulWriteRow(RowIteratorHooks{
-		WriteRow: func(*spanner.Row) error { return nil },
-	}, func() error {
-		flushes++
-		return nil
-	})
-	_, err = runRowIterator(stub, hooks)
+	row2, err := spanner.NewRow([]string{"id"}, []interface{}{int64(2)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if flushes != 2 {
-		t.Fatalf("flushes = %d, want 2", flushes)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
+		var flushes int
+		hooks := AfterEachSuccessfulWriteRow(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error { return nil },
+		}, func() error {
+			flushes++
+			return nil
+		})
+		_, err = runRowIterator(stub, hooks)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if flushes != 2 {
+			t.Fatalf("flushes = %d, want 2", flushes)
+		}
+	})
+
+	t.Run("WriteRow error skips after", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row2}}
+		var flushes int
+		var n int
+		hooks := AfterEachSuccessfulWriteRow(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error {
+				n++
+				if n == 2 {
+					return errors.New("write failed")
+				}
+				return nil
+			},
+		}, func() error {
+			flushes++
+			return nil
+		})
+		_, err = runRowIterator(stub, hooks)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if flushes != 1 {
+			t.Fatalf("flushes = %d, want 1", flushes)
+		}
+	})
+
+	t.Run("after error aborts", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row2}}
+		var flushes int
+		hooks := AfterEachSuccessfulWriteRow(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error { return nil },
+		}, func() error {
+			flushes++
+			if flushes == 2 {
+				return errors.New("flush failed")
+			}
+			return nil
+		})
+		_, err = runRowIterator(stub, hooks)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if flushes != 2 {
+			t.Fatalf("flushes = %d, want 2", flushes)
+		}
+	})
+}
+
+func TestDecoratorResetOnQueryErrorBeforeMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	queryErr := errors.New("query failed")
+
+	var ord RowOrdinal
+	hooks := WithRowOrdinal(RowIteratorHooks{}, &ord)
+
+	okStub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+	_, err = runRowIterator(okStub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ord.Current != 1 {
+		t.Fatalf("after success Current = %d, want 1", ord.Current)
+	}
+
+	failStub := &stubRowIterator{err: queryErr}
+	_, err = runRowIterator(failStub, hooks)
+	if !errors.Is(err, queryErr) {
+		t.Fatalf("error = %v, want %v", err, queryErr)
+	}
+	if ord.Current != 0 {
+		t.Fatalf("after query error Current = %d, want 0", ord.Current)
 	}
 }

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -1,0 +1,182 @@
+package writer
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestRunRowIterator_rowsRead(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	row2, err := spanner.NewRow([]string{"id"}, []interface{}{int64(2)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row2}}
+		var written int
+		got, err := runRowIterator(stub, RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error {
+				written++
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if written != 2 || got.RowsRead != 2 {
+			t.Fatalf("written=%d RowsRead=%d, want 2", written, got.RowsRead)
+		}
+	})
+
+	t.Run("partial abort", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row2}}
+		var n int
+		got, err := runRowIterator(stub, RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error {
+				n++
+				if n == 2 {
+					return errors.New("write failed")
+				}
+				return nil
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got.RowsRead != 1 {
+			t.Fatalf("RowsRead = %d, want 1", got.RowsRead)
+		}
+	})
+
+	t.Run("nil WriteRow", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+		got, err := runRowIterator(stub, RowIteratorHooks{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.RowsRead != 0 {
+			t.Fatalf("RowsRead = %d, want 0", got.RowsRead)
+		}
+	})
+}
+
+func TestWithRowOrdinal(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("zero rows", func(t *testing.T) {
+		t.Parallel()
+		var ord RowOrdinal
+		_, err := runRowIterator(&stubRowIterator{md: md}, WithRowOrdinal(RowIteratorHooks{}, &ord))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ord.Current != 0 {
+			t.Fatalf("Current = %d, want 0", ord.Current)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var ord RowOrdinal
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
+		_, err := runRowIterator(stub, WithRowOrdinal(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error { return nil },
+		}, &ord))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ord.Current != 2 {
+			t.Fatalf("Current = %d, want 2", ord.Current)
+		}
+	})
+
+	t.Run("write error", func(t *testing.T) {
+		t.Parallel()
+		var ord RowOrdinal
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
+		_, err := runRowIterator(stub, WithRowOrdinal(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error {
+				if ord.Current == 2 {
+					return errors.New("fail")
+				}
+				return nil
+			},
+		}, &ord))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if ord.Current != 2 {
+			t.Fatalf("Current = %d, want 2 on failure", ord.Current)
+		}
+	})
+}
+
+func TestObserveWriteRow(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+
+	var seen []int
+	hooks := ObserveWriteRow(RowIteratorHooks{
+		WriteRow: func(*spanner.Row) error { return nil },
+	}, func(n int) error {
+		seen = append(seen, n)
+		return nil
+	})
+	_, err = runRowIterator(stub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 1 || seen[0] != 1 {
+		t.Fatalf("seen = %v, want [1]", seen)
+	}
+}
+
+func TestAfterEachSuccessfulWriteRow(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
+
+	var flushes int
+	hooks := AfterEachSuccessfulWriteRow(RowIteratorHooks{
+		WriteRow: func(*spanner.Row) error { return nil },
+	}, func() error {
+		flushes++
+		return nil
+	})
+	_, err = runRowIterator(stub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flushes != 2 {
+		t.Fatalf("flushes = %d, want 2", flushes)
+	}
+}

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -70,6 +70,19 @@ func TestRunRowIterator_rowsRead(t *testing.T) {
 			t.Fatalf("RowsRead = %d, want 0", got.RowsRead)
 		}
 	})
+
+	t.Run("decorator nil WriteRow still counts ordinal", func(t *testing.T) {
+		t.Parallel()
+		var ord RowOrdinal
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+		_, err := runRowIterator(stub, WithRowOrdinal(RowIteratorHooks{}, &ord))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ord.Current != 1 {
+			t.Fatalf("Current = %d, want 1", ord.Current)
+		}
+	})
 }
 
 func TestWithRowOrdinal(t *testing.T) {
@@ -137,22 +150,41 @@ func TestObserveWriteRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
 
-	var seen []int
-	hooks := ObserveWriteRow(RowIteratorHooks{
-		WriteRow: func(*spanner.Row) error { return nil },
-	}, func(n int) error {
-		seen = append(seen, n)
-		return nil
+	t.Run("with WriteRow", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+		var seen []int
+		hooks := ObserveWriteRow(RowIteratorHooks{
+			WriteRow: func(*spanner.Row) error { return nil },
+		}, func(n int) error {
+			seen = append(seen, n)
+			return nil
+		})
+		_, err := runRowIterator(stub, hooks)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(seen) != 1 || seen[0] != 1 {
+			t.Fatalf("seen = %v, want [1]", seen)
+		}
 	})
-	_, err = runRowIterator(stub, hooks)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(seen) != 1 || seen[0] != 1 {
-		t.Fatalf("seen = %v, want [1]", seen)
-	}
+
+	t.Run("nil WriteRow", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
+		var seen []int
+		_, err := runRowIterator(stub, ObserveWriteRow(RowIteratorHooks{}, func(n int) error {
+			seen = append(seen, n)
+			return nil
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(seen) != 1 || seen[0] != 1 {
+			t.Fatalf("seen = %v, want [1]", seen)
+		}
+	})
 }
 
 func TestAfterEachSuccessfulWriteRow(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `RowIteratorResult.RowsRead`: count of data rows successfully passed through `WriteRow`, populated on success and on partial abort (distinct from `Stats.RowCount` / DML semantics).
- Add optional `RowIteratorHooks` decorators: `WithRowOrdinal`, `ObserveWriteRow`, and `AfterEachSuccessfulWriteRow` (caller-supplied flush; not `SQLInsertWriter.Flush`).

## Test plan

- [x] `make check`
- [x] New tests for `RowsRead`, ordinal wrapper, observe, and per-row after hooks

Closes #120
Closes #121
Closes #122

Made with [Cursor](https://cursor.com)