### PR TITLE
writer: align reset and table mutation semantics

### DIFF
--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -2,7 +2,6 @@ package writer
 
 import (
 	"cloud.google.com/go/spanner"
-	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
 
 // RowOrdinal holds a 1-based row index for diagnostics while streaming rows.
@@ -90,14 +89,6 @@ func resetEachRun(base RowIteratorHooks, reset func()) RowIteratorHooks {
 			prev()
 		}
 		reset()
-	}
-	prep := base.PrepareMetadata
-	base.PrepareMetadata = func(md *sppb.ResultSetMetadata) error {
-		reset()
-		if prep != nil {
-			return prep(md)
-		}
-		return nil
 	}
 	return base
 }

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -302,3 +302,27 @@ func TestDecoratorResetOnQueryErrorBeforeMetadata(t *testing.T) {
 		t.Fatalf("after query error Current = %d, want 0", ord.Current)
 	}
 }
+
+func TestResetEachRunRunsOncePerRun(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resets int
+	hooks := resetEachRun(RowIteratorHooks{
+		WriteRow: func(*spanner.Row) error { return nil },
+	}, func() {
+		resets++
+	})
+	_, err = runRowIterator(&stubRowIterator{md: md, rows: []*spanner.Row{row}}, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resets != 1 {
+		t.Fatalf("resets = %d, want 1", resets)
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -166,6 +166,9 @@ var (
 	// or INSERT OR UPDATE with a PostgreSQL dialect. Those prefixes are GoogleSQL-only; use plain
 	// [SQLInsert] with [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL) instead.
 	ErrInvalidSQLInsertKindForDialect = errors.New("INSERT OR IGNORE/UPDATE not supported for PostgreSQL dialect")
+	// ErrTableNameChangedMidBatch reports that SQLInsertWriter.Table was mutated while
+	// a multi-row INSERT batch was open.
+	ErrTableNameChangedMidBatch = errors.New("table name changed mid-batch")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -1190,7 +1193,17 @@ func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValue
 	return err
 }
 
+func (w *SQLInsertWriter) rejectTableChangeMidBatch() error {
+	if w.batchPending == 0 || w.quotedTableInput == "" || w.Table == w.quotedTableInput {
+		return nil
+	}
+	return fmt.Errorf("%w: %q to %q", ErrTableNameChangedMidBatch, w.quotedTableInput, w.Table)
+}
+
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
+	if err := w.rejectTableChangeMidBatch(); err != nil {
+		return err
+	}
 	if w.batchPending == 0 {
 		quotedTable, err := w.quotedQualifiedTable()
 		if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1190,17 +1190,7 @@ func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValue
 	return err
 }
 
-func (w *SQLInsertWriter) flushPendingBatchOnTableChange() error {
-	if w.batchPending == 0 || w.quotedTableInput == "" || w.Table == w.quotedTableInput {
-		return nil
-	}
-	return w.closePendingBatch()
-}
-
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
-	if err := w.flushPendingBatchOnTableChange(); err != nil {
-		return err
-	}
 	if w.batchPending == 0 {
 		quotedTable, err := w.quotedQualifiedTable()
 		if err != nil {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -965,6 +965,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 		}
+		// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
 		w.Table = "archive.users"
 		if err := w.WriteValues(columnNames, row(3, "c")); err != nil {
 			t.Fatalf("WriteValues() after table change error = %v", err)
@@ -975,29 +976,6 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 			"  (2, \"b\");\n" +
 			"INSERT INTO `archive`.`users` (`id`, `name`) VALUES\n" +
 			"  (3, \"c\")"
-		if diff := cmp.Diff(want, out.String()); diff != "" {
-			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("table change mid-batch flushes pending", func(t *testing.T) {
-		t.Parallel()
-
-		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
-		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
-			t.Fatalf("WriteValues() error = %v", err)
-		}
-		// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
-		w.Table = "archive.users"
-		if err := w.WriteValues(columnNames, row(2, "b")); err != nil {
-			t.Fatalf("WriteValues() after table change error = %v", err)
-		}
-		want := "" +
-			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
-			"  (1, \"a\");\n" +
-			"INSERT INTO `archive`.`users` (`id`, `name`) VALUES\n" +
-			"  (2, \"b\")"
 		if diff := cmp.Diff(want, out.String()); diff != "" {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -981,6 +981,29 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		}
 	})
 
+	t.Run("table change mid-batch rejects", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
+		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
+			t.Fatalf("WriteValues() error = %v", err)
+		}
+		// Legacy mutation remains syntactically possible until Table is unexported,
+		// but a mid-batch change must not silently append rows to the previous table.
+		w.Table = "archive.users"
+		err := w.WriteValues(columnNames, row(2, "b"))
+		if !errors.Is(err, ErrTableNameChangedMidBatch) {
+			t.Fatalf("WriteValues() after table change error = %v, want ErrTableNameChangedMidBatch", err)
+		}
+		want := "" +
+			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
+			"  (1, \"a\")"
+		if diff := cmp.Diff(want, out.String()); diff != "" {
+			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("PostgreSQL dialect batched", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- Run row-iterator decorator resets only once at the start of each RunRowIterator call.
- Stop treating mid-batch SQLInsertWriter.Table mutation as a supported batching path.
- Keep legacy table mutation coverage only after a batch boundary.

Fixes #129.
Fixes #130.

## Compatibility note

This is a safety hardening for the new SQL INSERT batching option, not a breaking change from the previous stable release. Non-batched SQL INSERT output still follows `SQLInsertWriter.Table` changes as before, and batched output also follows table changes after a batch boundary. Only mutating `SQLInsertWriter.Table` while a partial batch is open now returns `ErrTableNameChangedMidBatch` instead of implicitly closing or silently mixing rows into the previous table.

## Tests

- go test ./writer
- make check
- git diff --check -- writer/row_iterator_decorators.go writer/row_iterator_decorators_test.go writer/writer.go writer/writer_test.go