### PR TITLE
writer: expose RowIteratorHooks decorator extensibility

### DIFF
--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -69,6 +69,28 @@ type RowIteratorHooks struct {
 	onRunStart func()
 }
 
+// MarkOmitRowsRead configures the hooks so successful WriteRow calls do not
+// increment [RowIteratorResult.RowsRead]. Use when WriteRow exists only for
+// side effects (for example a custom decorator) and should not count as exported rows.
+func (h *RowIteratorHooks) MarkOmitRowsRead() {
+	h.omitRowsRead = true
+}
+
+// OnRunStart registers fn to run once at the beginning of each [RunRowIterator]
+// call. Multiple calls chain in registration order. A nil fn is ignored.
+func (h *RowIteratorHooks) OnRunStart(fn func()) {
+	if fn == nil {
+		return
+	}
+	prev := h.onRunStart
+	h.onRunStart = func() {
+		if prev != nil {
+			prev()
+		}
+		fn()
+	}
+}
+
 // RowIteratorWriter streams rows from a [cloud.google.com/go/spanner.RowIterator]
 // through [WriteRowIterator]. [DelimitedWriter], [JSONLWriter], and
 // [SQLInsertWriter] implement it.

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -72,15 +72,16 @@ type RowIteratorHooks struct {
 // MarkOmitRowsRead configures the hooks so successful WriteRow calls do not
 // increment [RowIteratorResult.RowsRead]. Use when WriteRow exists only for
 // side effects (for example a custom decorator) and should not count as exported rows.
-func (h *RowIteratorHooks) MarkOmitRowsRead() {
+func (h RowIteratorHooks) MarkOmitRowsRead() RowIteratorHooks {
 	h.omitRowsRead = true
+	return h
 }
 
 // OnRunStart registers fn to run once at the beginning of each [RunRowIterator]
 // call. Multiple calls chain in registration order. A nil fn is ignored.
-func (h *RowIteratorHooks) OnRunStart(fn func()) {
+func (h RowIteratorHooks) OnRunStart(fn func()) RowIteratorHooks {
 	if fn == nil {
-		return
+		return h
 	}
 	prev := h.onRunStart
 	h.onRunStart = func() {
@@ -89,6 +90,7 @@ func (h *RowIteratorHooks) OnRunStart(fn func()) {
 		}
 		fn()
 	}
+	return h
 }
 
 // RowIteratorWriter streams rows from a [cloud.google.com/go/spanner.RowIterator]

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -25,7 +25,9 @@ func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
 	}
 	writeRow := base.WriteRow
 	base = resetEachRun(base, func() { ord.Current = 0 })
-	base.omitRowsRead = base.omitRowsRead || writeRow == nil
+	if writeRow == nil {
+		base.MarkOmitRowsRead()
+	}
 	base.WriteRow = func(row *spanner.Row) error {
 		ord.Current++
 		if writeRow != nil {
@@ -46,7 +48,9 @@ func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowI
 	writeRow := base.WriteRow
 	var rowNum int
 	base = resetEachRun(base, func() { rowNum = 0 })
-	base.omitRowsRead = base.omitRowsRead || writeRow == nil
+	if writeRow == nil {
+		base.MarkOmitRowsRead()
+	}
 	base.WriteRow = func(row *spanner.Row) error {
 		rowNum++
 		if err := observe(rowNum); err != nil {
@@ -70,7 +74,9 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 		return base
 	}
 	writeRow := base.WriteRow
-	base.omitRowsRead = base.omitRowsRead || writeRow == nil
+	if writeRow == nil {
+		base.MarkOmitRowsRead()
+	}
 	base.WriteRow = func(row *spanner.Row) error {
 		if writeRow != nil {
 			if err := writeRow(row); err != nil {
@@ -83,12 +89,6 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 }
 
 func resetEachRun(base RowIteratorHooks, reset func()) RowIteratorHooks {
-	prev := base.onRunStart
-	base.onRunStart = func() {
-		if prev != nil {
-			prev()
-		}
-		reset()
-	}
+	base.OnRunStart(reset)
 	return base
 }

--- a/writer/row_iterator_decorators.go
+++ b/writer/row_iterator_decorators.go
@@ -26,7 +26,7 @@ func WithRowOrdinal(base RowIteratorHooks, ord *RowOrdinal) RowIteratorHooks {
 	writeRow := base.WriteRow
 	base = resetEachRun(base, func() { ord.Current = 0 })
 	if writeRow == nil {
-		base.MarkOmitRowsRead()
+		base = base.MarkOmitRowsRead()
 	}
 	base.WriteRow = func(row *spanner.Row) error {
 		ord.Current++
@@ -49,7 +49,7 @@ func ObserveWriteRow(base RowIteratorHooks, observe func(rowNum int) error) RowI
 	var rowNum int
 	base = resetEachRun(base, func() { rowNum = 0 })
 	if writeRow == nil {
-		base.MarkOmitRowsRead()
+		base = base.MarkOmitRowsRead()
 	}
 	base.WriteRow = func(row *spanner.Row) error {
 		rowNum++
@@ -75,7 +75,7 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 	}
 	writeRow := base.WriteRow
 	if writeRow == nil {
-		base.MarkOmitRowsRead()
+		base = base.MarkOmitRowsRead()
 	}
 	base.WriteRow = func(row *spanner.Row) error {
 		if writeRow != nil {
@@ -89,6 +89,5 @@ func AfterEachSuccessfulWriteRow(base RowIteratorHooks, after func() error) RowI
 }
 
 func resetEachRun(base RowIteratorHooks, reset func()) RowIteratorHooks {
-	base.OnRunStart(reset)
-	return base
+	return base.OnRunStart(reset)
 }

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -326,3 +326,32 @@ func TestResetEachRunRunsOncePerRun(t *testing.T) {
 		t.Fatalf("resets = %d, want 1", resets)
 	}
 }
+
+func TestRowIteratorHooksExtensibility(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id")
+	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
+
+	var runStarts int
+	hooks := RowIteratorHooks{
+		WriteRow: func(*spanner.Row) error { return nil },
+	}
+	hooks.MarkOmitRowsRead()
+	hooks.OnRunStart(func() { runStarts++ })
+
+	got, err := runRowIterator(stub, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runStarts != 1 {
+		t.Fatalf("runStarts = %d, want 1", runStarts)
+	}
+	if got.RowsRead != 0 {
+		t.Fatalf("RowsRead = %d, want 0 with MarkOmitRowsRead", got.RowsRead)
+	}
+}

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -337,19 +337,19 @@ func TestRowIteratorHooksExtensibility(t *testing.T) {
 	}
 	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row, row}}
 
-	var runStarts int
+	var runStarts []string
 	hooks := RowIteratorHooks{
 		WriteRow: func(*spanner.Row) error { return nil },
-	}
-	hooks.MarkOmitRowsRead()
-	hooks.OnRunStart(func() { runStarts++ })
+	}.MarkOmitRowsRead().
+		OnRunStart(func() { runStarts = append(runStarts, "first") }).
+		OnRunStart(func() { runStarts = append(runStarts, "second") })
 
 	got, err := runRowIterator(stub, hooks)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if runStarts != 1 {
-		t.Fatalf("runStarts = %d, want 1", runStarts)
+	if len(runStarts) != 2 || runStarts[0] != "first" || runStarts[1] != "second" {
+		t.Fatalf("runStarts = %v, want [first, second]", runStarts)
 	}
 	if got.RowsRead != 0 {
 		t.Fatalf("RowsRead = %d, want 0 with MarkOmitRowsRead", got.RowsRead)


### PR DESCRIPTION
## Summary
- Add `RowIteratorHooks.MarkOmitRowsRead` and `RowIteratorHooks.OnRunStart` for third-party hook decorators.
- Refactor built-in decorators to use the new helpers.

Closes #128

## Test plan
- [x] `make check`
- [x] `TestRowIteratorHooksExtensibility` covers custom decorator usage


Made with [Cursor](https://cursor.com)