### PR TITLE
writer: functional options return errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ jsonLine, err := spanvalue.FormatRowJSONObjectFromColumns(
 ```
 
 ```go
-w := writer.NewSQLInsertWriter(out, "analytics.daily_metrics")
+w, err := writer.NewSQLInsertWriter(out, "analytics.daily_metrics")
+if err != nil {
+	return err
+}
 if err := w.WriteValues(columnNames, gcvs); err != nil {
     return err
 }
@@ -116,12 +119,15 @@ column names from the first row and writes the header before the first data row:
 ```go
 iter := txn.Query(ctx, stmt)
 
-w := writer.NewDelimitedWriter(
+w, err := writer.NewDelimitedWriter(
 	out,
 	'\t',
 	writer.WithFormatter(cfg),
 	writer.WithHeader(true), // false for headerless CSV/TSV
 )
+if err != nil {
+	return err
+}
 if err := iter.Do(func(row *spanner.Row) error {
 	return w.WriteRow(row)
 }); err != nil {
@@ -139,12 +145,15 @@ and query stats even when the iterator is empty:
 ```go
 iter := txn.QueryWithStats(ctx, stmt) // WriteRowIterator stops iter for us
 
-w := writer.NewDelimitedWriter(
+w, err := writer.NewDelimitedWriter(
 	out,
 	'\t',
 	writer.WithFormatter(cfg),
 	writer.WithHeader(true),
 )
+if err != nil {
+	return err
+}
 result, err := writer.WriteRowIterator(iter, w)
 if err != nil {
 	return err
@@ -245,7 +254,7 @@ instead of reimplementing the loop.
 Registration is not the same as having zero columns: without `Prepare*` / `With*` and
 with no row written, `Flush` or `WriteHeader` returns `writer.ErrMissingColumnNames`.
 `PrepareColumnNames` with an empty slice returns `writer.ErrMissingColumnNames`;
-`WithColumnNames([])` at construction is ignored (writer stays unregistered). See
+`WithColumnNames([])` at construction returns `writer.ErrMissingColumnNames`. See
 `go doc writer`, sections "Column names and field types" and
 "Registered schema vs missing schema".
 
@@ -287,12 +296,15 @@ as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanva
 ```go
 namer := spanvalue.IndexedUnnamedFieldNamer
 names := []string{"id", "name"} // same names passed to WithColumnNames
-w := writer.NewCSVWriter(
+w, err := writer.NewCSVWriter(
 	out,
 	writer.WithColumnNames(names),
 	writer.WithFormatter(spanvalue.SimpleFormatConfig()),
 	writer.WithUnnamedFieldNamer(namer),
 )
+if err != nil {
+	return err
+}
 defer rows.Close()
 for rows.Next() {
 	var gcvs []spanner.GenericColumnValue
@@ -339,7 +351,10 @@ CSV output:
 
 ```go
 func writeCSV(out io.Writer, rows []*spanner.Row) error {
-	w := writer.NewCSVWriter(out)
+	w, err := writer.NewCSVWriter(out)
+	if err != nil {
+		return err
+	}
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err
@@ -358,7 +373,10 @@ Delimiters must be non-zero valid runes other than `"`, `\r`, `\n`, or
 
 ```go
 func writeTSV(out io.Writer, rows []*spanner.Row) error {
-	w := writer.NewDelimitedWriter(out, '\t')
+	w, err := writer.NewDelimitedWriter(out, '\t')
+	if err != nil {
+		return err
+	}
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err
@@ -380,7 +398,10 @@ JSONL output:
 
 ```go
 func writeJSONL(out io.Writer, rows []*spanner.Row) error {
-	w := writer.NewJSONLWriter(out)
+	w, err := writer.NewJSONLWriter(out)
+	if err != nil {
+		return err
+	}
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err
@@ -396,7 +417,10 @@ SQL INSERT output uses Spanner GoogleSQL quoting. Use
 
 ```go
 func writeInserts(out io.Writer, table string, rows []*spanner.Row) error {
-	w := writer.NewSQLInsertWriter(out, table)
+	w, err := writer.NewSQLInsertWriter(out, table)
+	if err != nil {
+		return err
+	}
 	for _, row := range rows {
 		if err := w.WriteRow(row); err != nil {
 			return err

--- a/README.md
+++ b/README.md
@@ -221,7 +221,10 @@ written:
 ```go
 defer iter.Stop()
 
-w := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
+w, err := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
+if err != nil {
+	return err
+}
 for {
 	_, err := iter.Next()
 	if errors.Is(err, iterator.Done) {

--- a/writer/export_options_test.go
+++ b/writer/export_options_test.go
@@ -16,7 +16,7 @@ func TestDelimitedGCVExportOptions(t *testing.T) {
 
 	var out bytes.Buffer
 	md := metadataWithColumnNames("name")
-	w := NewCSVWriter(&out, DelimitedGCVExportOptions(
+	w := mustNewCSVWriter(t, &out, DelimitedGCVExportOptions(
 		md,
 		spanvalue.SimpleFormatConfig(),
 		spanvalue.IndexedUnnamedFieldNamer,
@@ -36,7 +36,7 @@ func TestDelimitedGCVExportOptionsSkipsNil(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, DelimitedGCVExportOptions(nil, nil, nil)...)
+	w := mustNewCSVWriter(t, &out, DelimitedGCVExportOptions(nil, nil, nil)...)
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")})
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)
@@ -48,7 +48,7 @@ func TestJSONLGCVExportOptions(t *testing.T) {
 
 	var out bytes.Buffer
 	md := metadataWithColumnNames("name")
-	w := NewJSONLWriter(&out, JSONLGCVExportOptions(
+	w := mustNewJSONLWriter(t, &out, JSONLGCVExportOptions(
 		md,
 		spanvalue.JSONFormatConfig(),
 		spanvalue.IndexedUnnamedFieldNamer,
@@ -70,7 +70,7 @@ func TestJSONLGCVExportOptionsSkipsNil(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out, JSONLGCVExportOptions(nil, nil, nil)...)
+	w := mustNewJSONLWriter(t, &out, JSONLGCVExportOptions(nil, nil, nil)...)
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("x")})
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -66,7 +66,7 @@ func TestRunRowIterator_nilIterator(t *testing.T) {
 func TestWriteRowIterator_nilIterator(t *testing.T) {
 	t.Parallel()
 
-	_, err := WriteRowIterator(nil, NewDelimitedWriter(&bytes.Buffer{}, ','))
+	_, err := WriteRowIterator(nil, mustNewDelimitedWriter(t, &bytes.Buffer{}, ','))
 	if !errors.Is(err, ErrNilRowIterator) {
 		t.Fatalf("error = %v, want ErrNilRowIterator", err)
 	}
@@ -80,7 +80,7 @@ func TestWriteRowIterator_emptyWithMetadata(t *testing.T) {
 	stub := &stubRowIterator{md: md, wantStat: wantStats}
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +104,7 @@ func TestWriteRowIterator_emptyZeroColumnMetadata(t *testing.T) {
 	stub := &stubRowIterator{md: md}
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func TestWriteRowIterator_withRows(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
 	if err != nil {
 		t.Fatal(err)
@@ -214,7 +214,7 @@ func TestWriteRowIterator_writeErrorStillReturnsOutcome(t *testing.T) {
 	}
 	stub := &stubRowIterator{md: md, rows: []*spanner.Row{row}}
 
-	hooks := RowIteratorHooksFromWriter(NewDelimitedWriter(&bytes.Buffer{}, ','))
+	hooks := RowIteratorHooksFromWriter(mustNewDelimitedWriter(t, &bytes.Buffer{}, ','))
 	hooks.WriteRow = func(*spanner.Row) error {
 		return errors.New("write failed")
 	}

--- a/writer/test_helpers_test.go
+++ b/writer/test_helpers_test.go
@@ -1,0 +1,42 @@
+package writer
+
+import (
+	"io"
+	"testing"
+)
+
+func mustNewDelimitedWriter(t *testing.T, out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
+	t.Helper()
+	w, err := NewDelimitedWriter(out, delimiter, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func mustNewCSVWriter(t *testing.T, out io.Writer, opts ...DelimitedOption) *DelimitedWriter {
+	t.Helper()
+	w, err := NewCSVWriter(out, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func mustNewJSONLWriter(t *testing.T, out io.Writer, options ...JSONLOption) *JSONLWriter {
+	t.Helper()
+	w, err := NewJSONLWriter(out, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func mustNewSQLInsertWriter(t *testing.T, out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+	t.Helper()
+	w, err := NewSQLInsertWriter(out, table, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -40,7 +40,8 @@
 // # Constructors
 //
 // [NewDelimitedWriter], [NewCSVWriter], [NewJSONLWriter], and [NewSQLInsertWriter]
-// accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
+// return an error when an option fails (for example [WithColumnNames] with an empty
+// name list). They accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
 // INSERT prefix (see Spanner INSERT DML syntax). [WithSQLDialect] selects identifier
 // quoting for table and column names in SQL INSERT output (GoogleSQL by default).
 // [WithSQLBatchSize] groups rows into multi-row INSERT statements. When batching,
@@ -84,9 +85,8 @@
 //   - [PrepareColumnNames] requires at least one column name and returns [ErrMissingColumnNames]
 //     for an empty list. Do not use it when metadata has zero columns; use [PrepareRowType] or
 //     [WithRowType] with nil or an empty fields slice instead (for example DML without THEN RETURN).
-//   - [WithColumnNames] with an empty name list is ignored at construction (the writer stays
-//     unregistered); it does not return an error because options cannot report one (#95 tracks
-//     error-returning options). Prefer [PrepareRowType] for zero-column metadata.
+//   - [WithColumnNames] with an empty name list returns [ErrMissingColumnNames] at
+//     construction. Prefer [PrepareRowType] or [WithRowType] for zero-column metadata.
 //
 // [WithMetadata] registers the same names and types as [WithRowType]; call one or the other, not both.
 // Use it when metadata is already available (not iter.Metadata from a
@@ -212,12 +212,12 @@ type NameOption interface {
 
 // DelimitedOption configures a DelimitedWriter created by [NewDelimitedWriter] or [NewCSVWriter].
 type DelimitedOption interface {
-	applyDelimitedOption(*DelimitedWriter)
+	applyDelimitedOption(*DelimitedWriter) error
 }
 
 // JSONLOption configures a JSONLWriter created by [NewJSONLWriter].
 type JSONLOption interface {
-	applyJSONLOption(*JSONLWriter)
+	applyJSONLOption(*JSONLWriter) error
 }
 
 // SQLInsertKind selects the INSERT statement prefix written by [SQLInsertWriter].
@@ -263,8 +263,9 @@ type sqlInsertKindOption struct {
 	kind SQLInsertKind
 }
 
-func (o sqlInsertKindOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o sqlInsertKindOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.insertKind = o.kind
+	return nil
 }
 
 type sqlDialectOption struct {
@@ -282,8 +283,9 @@ func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 	return sqlDialectOption{dialect: dialect}
 }
 
-func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.sqlDialect = o.dialect
+	return nil
 }
 
 // WithSQLBatchSize sets how many rows [SQLInsertWriter] combines into one INSERT
@@ -304,19 +306,56 @@ type sqlBatchSizeOption struct {
 	batchSize int
 }
 
-func (o sqlBatchSizeOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o sqlBatchSizeOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.batchSize = o.batchSize
+	return nil
 }
 
 // SQLInsertOption configures a SQLInsertWriter created by [NewSQLInsertWriter].
 type SQLInsertOption interface {
-	applySQLInsertOption(*SQLInsertWriter)
+	applySQLInsertOption(*SQLInsertWriter) error
 }
 
-type delimitedOptionFunc func(*DelimitedWriter)
+type delimitedOptionFunc func(*DelimitedWriter) error
 
-func (f delimitedOptionFunc) applyDelimitedOption(w *DelimitedWriter) {
-	f(w)
+func (f delimitedOptionFunc) applyDelimitedOption(w *DelimitedWriter) error {
+	return f(w)
+}
+
+func applyDelimitedOptions(w *DelimitedWriter, options ...DelimitedOption) error {
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		if err := opt.applyDelimitedOption(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyJSONLOptions(w *JSONLWriter, options ...JSONLOption) error {
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		if err := opt.applyJSONLOption(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applySQLInsertOptions(w *SQLInsertWriter, options ...SQLInsertOption) error {
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		if err := opt.applySQLInsertOption(w); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type metadataOption struct {
@@ -333,16 +372,19 @@ func WithMetadata(metadata *sppb.ResultSetMetadata) Option {
 	return metadataOption{metadata: metadata}
 }
 
-func (o metadataOption) applyDelimitedOption(w *DelimitedWriter) {
+func (o metadataOption) applyDelimitedOption(w *DelimitedWriter) error {
 	w.setRowType(rowTypeFromMetadata(o.metadata))
+	return nil
 }
 
-func (o metadataOption) applyJSONLOption(w *JSONLWriter) {
+func (o metadataOption) applyJSONLOption(w *JSONLWriter) error {
 	w.setRowType(rowTypeFromMetadata(o.metadata))
+	return nil
 }
 
-func (o metadataOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o metadataOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.setRowType(rowTypeFromMetadata(o.metadata))
+	return nil
 }
 
 type rowTypeOption struct {
@@ -355,16 +397,19 @@ func WithRowType(rowType *sppb.StructType) Option {
 	return rowTypeOption{rowType: rowType}
 }
 
-func (o rowTypeOption) applyDelimitedOption(w *DelimitedWriter) {
+func (o rowTypeOption) applyDelimitedOption(w *DelimitedWriter) error {
 	w.setRowType(o.rowType)
+	return nil
 }
 
-func (o rowTypeOption) applyJSONLOption(w *JSONLWriter) {
+func (o rowTypeOption) applyJSONLOption(w *JSONLWriter) error {
 	w.setRowType(o.rowType)
+	return nil
 }
 
-func (o rowTypeOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o rowTypeOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.setRowType(o.rowType)
+	return nil
 }
 
 type columnNamesOption struct {
@@ -372,22 +417,34 @@ type columnNamesOption struct {
 }
 
 // WithColumnNames registers column names only and clears any registered field types.
-// An empty names slice is ignored (the writer stays unregistered); use [WithRowType]
-// for a zero-column result set.
+// An empty names slice returns [ErrMissingColumnNames]; use [WithRowType] for a
+// zero-column result set.
 func WithColumnNames(names []string) Option {
 	return columnNamesOption{names: slices.Clone(names)}
 }
 
-func (o columnNamesOption) applyDelimitedOption(w *DelimitedWriter) {
+func (o columnNamesOption) applyDelimitedOption(w *DelimitedWriter) error {
+	if len(o.names) == 0 {
+		return ErrMissingColumnNames
+	}
 	w.setColumnNames(o.names)
+	return nil
 }
 
-func (o columnNamesOption) applyJSONLOption(w *JSONLWriter) {
+func (o columnNamesOption) applyJSONLOption(w *JSONLWriter) error {
+	if len(o.names) == 0 {
+		return ErrMissingColumnNames
+	}
 	w.setColumnNames(o.names)
+	return nil
 }
 
-func (o columnNamesOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o columnNamesOption) applySQLInsertOption(w *SQLInsertWriter) error {
+	if len(o.names) == 0 {
+		return ErrMissingColumnNames
+	}
 	w.setColumnNames(o.names)
+	return nil
 }
 
 type formatterOption struct {
@@ -399,16 +456,19 @@ func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}
 }
 
-func (o formatterOption) applyDelimitedOption(w *DelimitedWriter) {
+func (o formatterOption) applyDelimitedOption(w *DelimitedWriter) error {
 	w.Formatter = o.formatter
+	return nil
 }
 
-func (o formatterOption) applyJSONLOption(w *JSONLWriter) {
+func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
 	w.Formatter = o.formatter
+	return nil
 }
 
-func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) {
+func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.Formatter = o.formatter
+	return nil
 }
 
 type unnamedFieldNamerOption struct {
@@ -422,20 +482,23 @@ func WithUnnamedFieldNamer(namer spanvalue.UnnamedFieldNamer) NameOption {
 	return unnamedFieldNamerOption{namer: namer}
 }
 
-func (o unnamedFieldNamerOption) applyDelimitedOption(w *DelimitedWriter) {
+func (o unnamedFieldNamerOption) applyDelimitedOption(w *DelimitedWriter) error {
 	w.UnnamedFieldNamer = o.namer
+	return nil
 }
 
-func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) {
+func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) error {
 	w.UnnamedFieldNamer = o.namer
+	return nil
 }
 
 // WithHeader sets whether [DelimitedWriter] emits a CSV/TSV header (default true).
 // The header is written before the first data row, or on [DelimitedWriter.Flush] if only
 // names were registered. See [DelimitedWriter.WriteHeader] to emit it earlier.
 func WithHeader(header bool) DelimitedOption {
-	return delimitedOptionFunc(func(w *DelimitedWriter) {
+	return delimitedOptionFunc(func(w *DelimitedWriter) error {
 		w.Header = header
+		return nil
 	})
 }
 
@@ -484,7 +547,7 @@ type DelimitedWriter struct {
 
 // NewCSVWriter returns a comma-delimited CSV writer configured by options.
 // It is a thin helper for NewDelimitedWriter(out, Comma, opts...).
-func NewCSVWriter(out io.Writer, opts ...DelimitedOption) *DelimitedWriter {
+func NewCSVWriter(out io.Writer, opts ...DelimitedOption) (*DelimitedWriter, error) {
 	return NewDelimitedWriter(out, Comma, opts...)
 }
 
@@ -504,21 +567,19 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // single-rune delimiters. Output follows encoding/csv quoting rules, not raw
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
 // See the package-level section "Quoted delimited text vs raw tab-separated".
-func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
+func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) (*DelimitedWriter, error) {
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter
-	for _, opt := range options {
-		if opt != nil {
-			opt.applyDelimitedOption(w)
-		}
+	if err := applyDelimitedOptions(w, options...); err != nil {
+		return nil, err
 	}
-	return w
+	return w, nil
 }
 
 // NewDelimitedWriterWithOptions forwards to [NewDelimitedWriter].
 //
 // Deprecated: Use [NewDelimitedWriter] instead.
-func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) *DelimitedWriter {
+func NewDelimitedWriterWithOptions(out io.Writer, delimiter rune, options ...DelimitedOption) (*DelimitedWriter, error) {
 	return NewDelimitedWriter(out, delimiter, options...)
 }
 
@@ -770,20 +831,18 @@ type JSONLWriter struct {
 }
 
 // NewJSONLWriter returns a JSONL writer configured by options.
-func NewJSONLWriter(out io.Writer, options ...JSONLOption) *JSONLWriter {
+func NewJSONLWriter(out io.Writer, options ...JSONLOption) (*JSONLWriter, error) {
 	w := newJSONLWriter(out)
-	for _, opt := range options {
-		if opt != nil {
-			opt.applyJSONLOption(w)
-		}
+	if err := applyJSONLOptions(w, options...); err != nil {
+		return nil, err
 	}
-	return w
+	return w, nil
 }
 
 // NewJSONLWriterWithOptions forwards to [NewJSONLWriter].
 //
 // Deprecated: Use [NewJSONLWriter] instead.
-func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) *JSONLWriter {
+func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) (*JSONLWriter, error) {
 	return NewJSONLWriter(out, options...)
 }
 
@@ -996,21 +1055,19 @@ type SQLInsertWriter struct {
 }
 
 // NewSQLInsertWriter returns a SQL INSERT writer configured by options.
-func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {
 	w := newSQLInsertWriter(out, table)
-	for _, opt := range options {
-		if opt != nil {
-			opt.applySQLInsertOption(w)
-		}
+	if err := applySQLInsertOptions(w, options...); err != nil {
+		return nil, err
 	}
 	w.configErr = w.validateSQLInsertConfig()
-	return w
+	return w, nil
 }
 
 // NewSQLInsertWriterWithOptions forwards to [NewSQLInsertWriter].
 //
 // Deprecated: Use [NewSQLInsertWriter] instead.
-func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) *SQLInsertWriter {
+func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {
 	return NewSQLInsertWriter(out, table, options...)
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1074,6 +1074,11 @@ func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption)
 	if err := w.validateSQLInsertConfig(); err != nil {
 		return nil, err
 	}
+	if len(w.schema.names) > 0 {
+		if _, err := w.initOrValidateQuotedColumns(nil); err != nil {
+			return nil, err
+		}
+	}
 	return w, nil
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -149,8 +149,8 @@ var (
 	// when none was registered yet, or column names/types are insufficient for the write
 	// (for example values without names). It is not returned for a registered zero-column
 	// schema (see package doc "Registered schema vs missing schema"). [PrepareColumnNames]
-	// with an empty name list returns this error; [WithColumnNames] with an empty list is
-	// ignored (writer stays unregistered). Use [PrepareRowType] for zero-column result sets.
+	// and [WithColumnNames] with an empty name list return this error; use [PrepareRowType]
+	// or [WithRowType] for zero-column result sets.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
 	ErrColumnNamesMismatch = errors.New("column names mismatch")
@@ -568,6 +568,12 @@ func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 // field joins. Delimiter must be non-zero and a valid encoding/csv delimiter.
 // See the package-level section "Quoted delimited text vs raw tab-separated".
 func NewDelimitedWriter(out io.Writer, delimiter rune, options ...DelimitedOption) (*DelimitedWriter, error) {
+	if out == nil {
+		return nil, ErrNilOutputWriter
+	}
+	if !validDelimiter(delimiter) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDelimiter, delimiter)
+	}
 	w := newDelimitedWriter(out)
 	w.delimiter = delimiter
 	if err := applyDelimitedOptions(w, options...); err != nil {
@@ -832,6 +838,9 @@ type JSONLWriter struct {
 
 // NewJSONLWriter returns a JSONL writer configured by options.
 func NewJSONLWriter(out io.Writer, options ...JSONLOption) (*JSONLWriter, error) {
+	if out == nil {
+		return nil, ErrNilOutputWriter
+	}
 	w := newJSONLWriter(out)
 	if err := applyJSONLOptions(w, options...); err != nil {
 		return nil, err
@@ -1043,7 +1052,6 @@ type SQLInsertWriter struct {
 	Formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
-	configErr         error
 	sqlDialect        databasepb.DatabaseDialect
 	batchSize         int
 	batchPending      int
@@ -1056,11 +1064,16 @@ type SQLInsertWriter struct {
 
 // NewSQLInsertWriter returns a SQL INSERT writer configured by options.
 func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {
+	if out == nil {
+		return nil, ErrNilOutputWriter
+	}
 	w := newSQLInsertWriter(out, table)
 	if err := applySQLInsertOptions(w, options...); err != nil {
 		return nil, err
 	}
-	w.configErr = w.validateSQLInsertConfig()
+	if err := w.validateSQLInsertConfig(); err != nil {
+		return nil, err
+	}
 	return w, nil
 }
 
@@ -1215,9 +1228,6 @@ func (w *SQLInsertWriter) validateSQLInsertConfig() error {
 }
 
 func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedColumns string) error {
-	if w.configErr != nil {
-		return w.configErr
-	}
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1128,6 +1128,15 @@ func TestSQLInsertWriterWriteRow(t *testing.T) {
 	}
 }
 
+func TestNewSQLInsertWriterEmptyColumnNameAtConstruction(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSQLInsertWriter(&bytes.Buffer{}, "users", WithColumnNames([]string{""}))
+	if !errors.Is(err, ErrEmptyColumnName) {
+		t.Fatalf("NewSQLInsertWriter() error = %v, want ErrEmptyColumnName", err)
+	}
+}
+
 func TestSQLInsertWriterWriteValuesEmptyColumnName(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -169,33 +169,18 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 func TestDelimitedWriterWriteValuesZeroDelimiterInvalid(t *testing.T) {
 	t.Parallel()
 
-	var out bytes.Buffer
-	w := mustNewDelimitedWriter(t, &out, 0)
-
-	err := w.WriteValues(
-		[]string{"name", "note"},
-		[]spanner.GenericColumnValue{
-			gcvctor.StringValue("Alice"),
-			gcvctor.StringValue("comma, ok"),
-		},
-	)
+	_, err := NewDelimitedWriter(&bytes.Buffer{}, 0)
 	if !errors.Is(err, ErrInvalidDelimiter) {
-		t.Fatalf("WriteValues() error = %v, want ErrInvalidDelimiter", err)
+		t.Fatalf("NewDelimitedWriter() error = %v, want ErrInvalidDelimiter", err)
 	}
 }
 
 func TestDelimitedWriterWriteValuesInvalidDelimiter(t *testing.T) {
 	t.Parallel()
 
-	var out bytes.Buffer
-	w := mustNewDelimitedWriter(t, &out, '\n')
-
-	err := w.WriteValues(
-		[]string{"name"},
-		[]spanner.GenericColumnValue{gcvctor.StringValue("Alice")},
-	)
+	_, err := NewDelimitedWriter(&bytes.Buffer{}, '\n')
 	if !errors.Is(err, ErrInvalidDelimiter) {
-		t.Fatalf("WriteValues() error = %v, want ErrInvalidDelimiter", err)
+		t.Fatalf("NewDelimitedWriter() error = %v, want ErrInvalidDelimiter", err)
 	}
 }
 
@@ -508,18 +493,18 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := mustNewDelimitedWriter(t, nil, Comma).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+	_, err := NewDelimitedWriter(nil, Comma)
 	if !errors.Is(err, ErrNilOutputWriter) {
-		t.Fatalf("WriteGCVs() error = %v, want ErrNilOutputWriter", err)
+		t.Fatalf("NewDelimitedWriter() error = %v, want ErrNilOutputWriter", err)
 	}
 }
 
 func TestDelimitedWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := mustNewDelimitedWriter(t, nil, Comma).WriteHeader()
+	_, err := NewDelimitedWriter(nil, Comma)
 	if !errors.Is(err, ErrNilOutputWriter) {
-		t.Fatalf("WriteHeader() error = %v, want ErrNilOutputWriter", err)
+		t.Fatalf("NewDelimitedWriter() error = %v, want ErrNilOutputWriter", err)
 	}
 }
 
@@ -533,22 +518,22 @@ func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := mustNewDelimitedWriter(t, nil, Comma, WithMetadata(metadataWithColumnNames("name")))
-				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+				_, err := NewDelimitedWriter(nil, Comma, WithMetadata(metadataWithColumnNames("name")))
+				return err
 			},
 		},
 		{
 			name: "jsonl",
 			run: func() error {
-				w := mustNewJSONLWriter(t, nil, WithMetadata(metadataWithColumnNames("name")))
-				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+				_, err := NewJSONLWriter(nil, WithMetadata(metadataWithColumnNames("name")))
+				return err
 			},
 		},
 		{
 			name: "sql",
 			run: func() error {
-				w := mustNewSQLInsertWriter(t, nil, "users", WithMetadata(metadataWithColumnNames("name")))
-				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+				_, err := NewSQLInsertWriter(nil, "users", WithMetadata(metadataWithColumnNames("name")))
+				return err
 			},
 		},
 	}
@@ -1063,16 +1048,15 @@ func TestSQLInsertWriterPostgreSQLInsertOrKindsRejected(t *testing.T) {
 			t.Parallel()
 
 			var out bytes.Buffer
-			w := mustNewSQLInsertWriter(t, &out, "users",
+			_, err := NewSQLInsertWriter(&out, "users",
 				WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
 				WithSQLInsertKind(kind),
 			)
-			err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)})
 			if !errors.Is(err, ErrInvalidSQLInsertKindForDialect) {
-				t.Fatalf("WriteValues() error = %v, want ErrInvalidSQLInsertKindForDialect", err)
+				t.Fatalf("NewSQLInsertWriter() error = %v, want ErrInvalidSQLInsertKindForDialect", err)
 			}
 			if out.Len() != 0 {
-				t.Fatalf("WriteValues() wrote %q, want no output", out.String())
+				t.Fatalf("NewSQLInsertWriter() wrote %q, want no output", out.String())
 			}
 		})
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -65,7 +65,7 @@ func TestNewCSVWriterHelper(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, WithMetadata(metadataWithColumnNames("name")))
+	w := mustNewCSVWriter(t, &out, WithMetadata(metadataWithColumnNames("name")))
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
@@ -82,7 +82,7 @@ func TestDelimitedWriterWriteValues(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 
 	err := w.WriteValues(
 		[]string{"name", ""},
@@ -117,7 +117,7 @@ func TestDelimitedWriterWriteValuesWithCustomDelimiter(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, '\t')
+	w := mustNewDelimitedWriter(t, &out, '\t')
 
 	err := w.WriteValues(
 		[]string{"name", "note", "with_tab"},
@@ -142,7 +142,7 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriterWithOptions(
+	w := mustNewDelimitedWriter(t,
 		&out,
 		'\t',
 		WithMetadata(metadataWithColumnNames("name", "age")),
@@ -170,7 +170,7 @@ func TestDelimitedWriterWriteValuesZeroDelimiterInvalid(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, 0)
+	w := mustNewDelimitedWriter(t, &out, 0)
 
 	err := w.WriteValues(
 		[]string{"name", "note"},
@@ -188,7 +188,7 @@ func TestDelimitedWriterWriteValuesInvalidDelimiter(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, '\n')
+	w := mustNewDelimitedWriter(t, &out, '\n')
 
 	err := w.WriteValues(
 		[]string{"name"},
@@ -203,7 +203,7 @@ func TestDelimitedWriterPrepare(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 	if err := w.Prepare(metadataWithColumnNames("name", "age")); err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -231,7 +231,7 @@ func TestJSONLWriterPrepare(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out)
+	w := mustNewJSONLWriter(t, &out)
 	if err := w.Prepare(metadataWithColumnNames("", "age")); err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -258,7 +258,7 @@ func TestSQLInsertWriterPrepare(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "users")
+	w := mustNewSQLInsertWriter(t, &out, "users")
 	if err := w.Prepare(metadataWithColumnNames("id", "name")); err != nil {
 		t.Fatalf("Prepare() error = %v", err)
 	}
@@ -291,7 +291,7 @@ func TestWritersPrepareNilMetadataRegistersEmptySchema(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := NewDelimitedWriter(&bytes.Buffer{}, Comma, WithHeader(true))
+				w := mustNewDelimitedWriter(t, &bytes.Buffer{}, Comma, WithHeader(true))
 				if err := w.Prepare(nil); err != nil {
 					return err
 				}
@@ -301,7 +301,7 @@ func TestWritersPrepareNilMetadataRegistersEmptySchema(t *testing.T) {
 		{
 			name: "jsonl",
 			run: func() error {
-				w := NewJSONLWriter(&bytes.Buffer{})
+				w := mustNewJSONLWriter(t, &bytes.Buffer{})
 				if err := w.Prepare(nil); err != nil {
 					return err
 				}
@@ -311,7 +311,7 @@ func TestWritersPrepareNilMetadataRegistersEmptySchema(t *testing.T) {
 		{
 			name: "sql",
 			run: func() error {
-				w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+				w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
 				if err := w.Prepare(nil); err != nil {
 					return err
 				}
@@ -335,7 +335,7 @@ func TestDelimitedWriterWriteGCVsWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
+	w := mustNewDelimitedWriter(t, &out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.StringValue("Alice"),
@@ -356,7 +356,7 @@ func TestNewCSVWriter_numericWireAsIs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewCSVWriter(&out, WithMetadata(metadataWithColumnNames("amount")))
+	w := mustNewCSVWriter(t, &out, WithMetadata(metadataWithColumnNames("amount")))
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.StringBasedValueFromCode(sppb.TypeCode_NUMERIC, "99.5"),
 	}); err != nil {
@@ -374,7 +374,7 @@ func TestDelimitedWriterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 
 	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
 	if err != nil {
@@ -396,7 +396,7 @@ func TestDelimitedWriterWriteHeaderWithMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
+	w := mustNewDelimitedWriter(t, &out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -418,11 +418,11 @@ func TestUnbufferedWritersFlushIsNoop(t *testing.T) {
 	}{
 		{
 			name:   "jsonl",
-			writer: NewJSONLWriter(&bytes.Buffer{}),
+			writer: mustNewJSONLWriter(t, &bytes.Buffer{}),
 		},
 		{
 			name:   "sql",
-			writer: NewSQLInsertWriter(&bytes.Buffer{}, "users"),
+			writer: mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users"),
 		},
 	}
 
@@ -441,7 +441,7 @@ func TestDelimitedWriterWriteHeaderThenWriteGCVs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
+	w := mustNewDelimitedWriter(t, &out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 
 	if err := w.WriteHeader(); err != nil {
 		t.Fatalf("WriteHeader() error = %v", err)
@@ -465,7 +465,7 @@ func TestDelimitedWriterWriteHeaderWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 
 	err := w.WriteHeader()
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -477,7 +477,7 @@ func TestDelimitedWriterWriteHeaderAfterData(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
+	w := mustNewDelimitedWriter(t, &out, Comma, WithMetadata(metadataWithColumnNames("name", "age")))
 	w.Header = false
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -497,7 +497,7 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -508,7 +508,7 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(nil, Comma).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
+	err := mustNewDelimitedWriter(t, nil, Comma).WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrNilOutputWriter", err)
 	}
@@ -517,7 +517,7 @@ func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
 func TestDelimitedWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(nil, Comma).WriteHeader()
+	err := mustNewDelimitedWriter(t, nil, Comma).WriteHeader()
 	if !errors.Is(err, ErrNilOutputWriter) {
 		t.Fatalf("WriteHeader() error = %v, want ErrNilOutputWriter", err)
 	}
@@ -533,21 +533,21 @@ func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				w := NewDelimitedWriter(nil, Comma, WithMetadata(metadataWithColumnNames("name")))
+				w := mustNewDelimitedWriter(t, nil, Comma, WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
 		{
 			name: "jsonl",
 			run: func() error {
-				w := NewJSONLWriter(nil, WithMetadata(metadataWithColumnNames("name")))
+				w := mustNewJSONLWriter(t, nil, WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
 		{
 			name: "sql",
 			run: func() error {
-				w := NewSQLInsertWriter(nil, "users", WithMetadata(metadataWithColumnNames("name")))
+				w := mustNewSQLInsertWriter(t, nil, "users", WithMetadata(metadataWithColumnNames("name")))
 				return w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")})
 			},
 		},
@@ -575,19 +575,19 @@ func TestWritersReturnErrNilRow(t *testing.T) {
 		{
 			name: "csv",
 			run: func() error {
-				return NewDelimitedWriter(&bytes.Buffer{}, Comma).WriteRow(nil)
+				return mustNewDelimitedWriter(t, &bytes.Buffer{}, Comma).WriteRow(nil)
 			},
 		},
 		{
 			name: "jsonl",
 			run: func() error {
-				return NewJSONLWriter(&bytes.Buffer{}).WriteRow(nil)
+				return mustNewJSONLWriter(t, &bytes.Buffer{}).WriteRow(nil)
 			},
 		},
 		{
 			name: "sql",
 			run: func() error {
-				return NewSQLInsertWriter(&bytes.Buffer{}, "users").WriteRow(nil)
+				return mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users").WriteRow(nil)
 			},
 		},
 	}
@@ -608,7 +608,7 @@ func TestDelimitedWriterWriteValuesColumnNamesMismatch(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, Comma)
+	w := mustNewDelimitedWriter(t, &out, Comma)
 
 	if err := w.WriteValues(
 		[]string{"name"},
@@ -633,7 +633,7 @@ func TestJSONLWriterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out)
+	w := mustNewJSONLWriter(t, &out)
 	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
@@ -653,7 +653,7 @@ func TestJSONLWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriterWithOptions(
+	w := mustNewJSONLWriter(t,
 		&out,
 		WithMetadata(metadataWithColumnNames("", "age")),
 		WithUnnamedFieldNamer(nil),
@@ -676,7 +676,7 @@ func TestJSONLWriterWriteGCVsAfterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out)
+	w := mustNewJSONLWriter(t, &out)
 
 	row, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(42), "hello"})
 	if err != nil {
@@ -704,7 +704,7 @@ func TestJSONLWriterWriteGCVsKeepsResolvedNamesAfterNamerChange(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out)
+	w := mustNewJSONLWriter(t, &out)
 
 	row, err := spanner.NewRow([]string{"", ""}, []interface{}{int64(42), "hello"})
 	if err != nil {
@@ -733,7 +733,7 @@ func TestJSONLWriterWriteGCVs_MismatchedCachedKeys(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out, WithMetadata(metadataWithColumnNames("name", "age")))
+	w := mustNewJSONLWriter(t, &out, WithMetadata(metadataWithColumnNames("name", "age")))
 	w.marshaledKeys = [][]byte{[]byte(`"name"`)}
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{
@@ -790,7 +790,7 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 			t.Parallel()
 
 			var out bytes.Buffer
-			w := NewSQLInsertWriter(&out, tt.table)
+			w := mustNewSQLInsertWriter(t, &out, tt.table)
 
 			err := w.WriteValues(tt.columnNames, tt.values)
 			if err != nil {
@@ -853,7 +853,7 @@ func TestSQLInsertWriterSQLDialect(t *testing.T) {
 			t.Parallel()
 
 			var out bytes.Buffer
-			w := NewSQLInsertWriter(&out, tt.table, WithSQLDialect(tt.dialect))
+			w := mustNewSQLInsertWriter(t, &out, tt.table, WithSQLDialect(tt.dialect))
 
 			if err := w.WriteValues(tt.columnNames, tt.values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -881,7 +881,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users")
+		w := mustNewSQLInsertWriter(t, &out, "users")
 		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -899,7 +899,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2))
+		w := mustNewSQLInsertWriter(t, &out, "users", WithSQLBatchSize(2))
 		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b"), row(3, "c")} {
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -921,7 +921,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2))
+		w := mustNewSQLInsertWriter(t, &out, "users", WithSQLBatchSize(2))
 		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b"), row(3, "c")} {
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -945,7 +945,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(0))
+		w := mustNewSQLInsertWriter(t, &out, "users", WithSQLBatchSize(0))
 		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
 			t.Fatalf("WriteValues() error = %v", err)
 		}
@@ -959,7 +959,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
+		w := mustNewSQLInsertWriter(t, &out, "db.users", WithSQLBatchSize(2))
 		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -985,7 +985,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "db.users", WithSQLBatchSize(2))
+		w := mustNewSQLInsertWriter(t, &out, "db.users", WithSQLBatchSize(2))
 		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
 			t.Fatalf("WriteValues() error = %v", err)
 		}
@@ -1008,7 +1008,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2), WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL))
+		w := mustNewSQLInsertWriter(t, &out, "users", WithSQLBatchSize(2), WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL))
 		for _, id := range []int64{1, 2} {
 			if err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(id)}); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -1024,7 +1024,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users",
+		w := mustNewSQLInsertWriter(t, &out, "users",
 			WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
 			WithFormatter(spanvalue.LiteralFormatConfig()),
 		)
@@ -1041,7 +1041,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		t.Parallel()
 
 		var out bytes.Buffer
-		w := NewSQLInsertWriter(&out, "users", WithSQLBatchSize(2), WithSQLInsertKind(SQLInsertOrIgnore))
+		w := mustNewSQLInsertWriter(t, &out, "users", WithSQLBatchSize(2), WithSQLInsertKind(SQLInsertOrIgnore))
 		for _, values := range [][]spanner.GenericColumnValue{row(1, "a"), row(2, "b")} {
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
@@ -1063,7 +1063,7 @@ func TestSQLInsertWriterPostgreSQLInsertOrKindsRejected(t *testing.T) {
 			t.Parallel()
 
 			var out bytes.Buffer
-			w := NewSQLInsertWriter(&out, "users",
+			w := mustNewSQLInsertWriter(t, &out, "users",
 				WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
 				WithSQLInsertKind(kind),
 			)
@@ -1106,7 +1106,7 @@ func TestSQLInsertWriterInsertKind(t *testing.T) {
 			t.Parallel()
 
 			var out bytes.Buffer
-			w := NewSQLInsertWriter(&out, "users", WithSQLInsertKind(tt.kind))
+			w := mustNewSQLInsertWriter(t, &out, "users", WithSQLInsertKind(tt.kind))
 			if err := w.WriteValues(columnNames, values); err != nil {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
@@ -1121,7 +1121,7 @@ func TestSQLInsertWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriterWithOptions(
+	w := mustNewSQLInsertWriter(t,
 		&out,
 		"users",
 		WithMetadata(metadataWithColumnNames("id", "name")),
@@ -1145,7 +1145,7 @@ func TestSQLInsertWriterWriteRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "db.user`table")
+	w := mustNewSQLInsertWriter(t, &out, "db.user`table")
 
 	row, err := spanner.NewRow([]string{"na`me", "payload"}, []interface{}{"Alice", "semi;\nline"})
 	if err != nil {
@@ -1166,7 +1166,7 @@ func TestSQLInsertWriterWriteValuesEmptyColumnName(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "users")
+	w := mustNewSQLInsertWriter(t, &out, "users")
 
 	err := w.WriteValues(
 		[]string{""},
@@ -1181,7 +1181,7 @@ func TestSQLInsertWriterWriteValuesRecoverAfterEmptyColumnName(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "users")
+	w := mustNewSQLInsertWriter(t, &out, "users")
 
 	err := w.WriteValues(
 		[]string{""},
@@ -1209,7 +1209,7 @@ func TestSQLInsertWriterWriteValuesTableChangeAfterCache(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "db.users")
+	w := mustNewSQLInsertWriter(t, &out, "db.users")
 
 	err := w.WriteValues(
 		[]string{"id"},
@@ -1238,7 +1238,7 @@ func TestSQLInsertWriterWriteValuesEmptyTableName(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "")
+	w := mustNewSQLInsertWriter(t, &out, "")
 
 	err := w.WriteValues(
 		[]string{"id"},
@@ -1253,7 +1253,7 @@ func TestSQLInsertWriterWriteValuesEmptyQualifiedTableSegment(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "db..users")
+	w := mustNewSQLInsertWriter(t, &out, "db..users")
 
 	err := w.WriteValues(
 		[]string{"id"},
@@ -1268,7 +1268,7 @@ func TestSQLInsertWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "users")
+	w := mustNewSQLInsertWriter(t, &out, "users")
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
 	if !errors.Is(err, ErrMissingColumnNames) {
@@ -1280,7 +1280,7 @@ func TestSQLInsertWriterWriteGCVsEmptyTableName(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewSQLInsertWriter(&out, "", WithMetadata(metadataWithColumnNames("id")))
+	w := mustNewSQLInsertWriter(t, &out, "", WithMetadata(metadataWithColumnNames("id")))
 
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
 	if !errors.Is(err, ErrEmptyTableName) {
@@ -1383,7 +1383,7 @@ func TestDelimitedWriterFlushWritesHeaderWithNoRows(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
 	if err := w.Flush(); err != nil {
 		t.Fatalf("Flush() error = %v", err)
 	}
@@ -1398,7 +1398,7 @@ func TestDelimitedWriterFlushDoesNotDuplicateHeader(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(true))
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.Int64Value(1),
 		gcvctor.StringValue("a"),
@@ -1418,7 +1418,7 @@ func TestDelimitedWriterFlushDoesNotDuplicateHeader(t *testing.T) {
 func TestDelimitedWriterFlushWithoutColumnNames(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithHeader(true)).Flush()
+	err := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',', WithHeader(true)).Flush()
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("Flush() error = %v, want ErrMissingColumnNames", err)
 	}
@@ -1428,7 +1428,7 @@ func TestDelimitedWriterPrepareRowTypeNilRegistersEmptySchema(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	if err := w.PrepareRowType(nil); err != nil {
 		t.Fatalf("PrepareRowType(nil) error = %v", err)
 	}
@@ -1443,7 +1443,7 @@ func TestDelimitedWriterPrepareRowTypeNilRegistersEmptySchema(t *testing.T) {
 func TestDelimitedWriterPrepareRowTypeEmptyAfterNonEmptyErrors(t *testing.T) {
 	t.Parallel()
 
-	w := NewDelimitedWriter(&bytes.Buffer{}, ',')
+	w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',')
 	if err := w.PrepareRowType(rowTypeWithColumnNames("id")); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1459,18 +1459,18 @@ func TestDelimitedWriterPrepareRowTypeEmptyAfterNonEmptyErrors(t *testing.T) {
 func TestDelimitedWriterPrepareColumnNamesEmptyErrors(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(&bytes.Buffer{}, ',').PrepareColumnNames(nil)
+	err := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',').PrepareColumnNames(nil)
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("PrepareColumnNames(nil) error = %v, want ErrMissingColumnNames", err)
 	}
 }
 
-func TestDelimitedWriterWithColumnNamesEmptyIgnored(t *testing.T) {
+func TestDelimitedWriterWithColumnNamesEmptyErrors(t *testing.T) {
 	t.Parallel()
 
-	err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithColumnNames(nil), WithHeader(true)).Flush()
+	_, err := NewDelimitedWriter(&bytes.Buffer{}, ',', WithColumnNames(nil), WithHeader(true))
 	if !errors.Is(err, ErrMissingColumnNames) {
-		t.Fatalf("Flush() error = %v, want ErrMissingColumnNames (writer still unregistered)", err)
+		t.Fatalf("NewDelimitedWriter error = %v, want ErrMissingColumnNames", err)
 	}
 }
 
@@ -1478,7 +1478,7 @@ func TestDelimitedWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	if err := w.PrepareRowType(emptyRowType()); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1494,7 +1494,7 @@ func TestDelimitedWriterPrepareEmptyRowTypeWriteGCVsNoOp(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithHeader(true))
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true))
 	if err := w.PrepareRowType(emptyRowType()); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1513,7 +1513,7 @@ func TestJSONLWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out)
+	w := mustNewJSONLWriter(t, &out)
 	if err := w.PrepareRowType(emptyRowType()); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1528,7 +1528,7 @@ func TestJSONLWriterPrepareEmptyRowTypeFlushWritesNothing(t *testing.T) {
 func TestSQLInsertWriterPrepareEmptyRowTypeFlushNoOp(t *testing.T) {
 	t.Parallel()
 
-	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
 	if err := w.PrepareRowType(emptyRowType()); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1545,7 +1545,7 @@ func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(false))
+	w := mustNewDelimitedWriter(t, &out, ',', WithColumnNames([]string{"id", "name"}), WithHeader(false))
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.Int64Value(1),
 		gcvctor.StringValue("a"),
@@ -1568,7 +1568,7 @@ func TestDelimitedWriterWriteGCVsEnumProto(t *testing.T) {
 		protoFQN = "examples.spanner.music.SingerInfo"
 	)
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',', WithColumnNames([]string{"status", "payload"}))
+	w := mustNewDelimitedWriter(t, &out, ',', WithColumnNames([]string{"status", "payload"}))
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.EnumValue(enumFQN, 1),
 		gcvctor.ProtoValue(protoFQN, []byte("abcd")),
@@ -1588,7 +1588,7 @@ func TestWithColumnNamesWriteGCVs(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, '\t', WithColumnNames([]string{"id", "name"}))
+	w := mustNewDelimitedWriter(t, &out, '\t', WithColumnNames([]string{"id", "name"}))
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.Int64Value(1),
 		gcvctor.StringValue("a"),
@@ -1607,7 +1607,7 @@ func TestWithRowTypeWriteStructValues(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewJSONLWriter(&out, WithRowType(rowTypeWithColumnNames("id", "name")))
+	w := mustNewJSONLWriter(t, &out, WithRowType(rowTypeWithColumnNames("id", "name")))
 	if err := w.WriteStructValues([]*structpb.Value{
 		structpb.NewStringValue("42"),
 		structpb.NewStringValue("Alice"),
@@ -1624,7 +1624,7 @@ func TestWithRowTypeWriteStructValues(t *testing.T) {
 func TestWriteStructValuesMissingFieldTypes(t *testing.T) {
 	t.Parallel()
 
-	w := NewDelimitedWriter(&bytes.Buffer{}, ',')
+	w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',')
 	err := w.WriteStructValues([]*structpb.Value{structpb.NewStringValue("1")})
 	if !errors.Is(err, ErrMissingFieldTypes) {
 		t.Fatalf("WriteStructValues() error = %v, want ErrMissingFieldTypes", err)
@@ -1639,7 +1639,7 @@ func TestWriteStructValuesNilFieldType(t *testing.T) {
 			{Name: "id", Type: nil},
 		},
 	}
-	w := NewSQLInsertWriter(&bytes.Buffer{}, "users", WithRowType(rowType))
+	w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users", WithRowType(rowType))
 	err := w.WriteStructValues([]*structpb.Value{structpb.NewStringValue("1")})
 	if !errors.Is(err, spanvalue.ErrNilStructField) {
 		t.Fatalf("WriteStructValues() error = %v, want ErrNilStructField", err)
@@ -1650,7 +1650,7 @@ func TestDelimitedWriterPrepareColumnNamesAfterConstruction(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	w := NewDelimitedWriter(&out, ',')
+	w := mustNewDelimitedWriter(t, &out, ',')
 	if err := w.PrepareColumnNames([]string{"name", "age"}); err != nil {
 		t.Fatalf("PrepareColumnNames() error = %v", err)
 	}
@@ -1676,7 +1676,7 @@ func TestDelimitedWriterPrepareColumnNamesAfterConstruction(t *testing.T) {
 func TestSQLInsertWriterPrepareColumnNamesRecoversAfterQuoteError(t *testing.T) {
 	t.Parallel()
 
-	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
 	err := w.PrepareColumnNames([]string{""})
 	if !errors.Is(err, ErrEmptyColumnName) {
 		t.Fatalf("PrepareColumnNames() error = %v, want ErrEmptyColumnName", err)
@@ -1692,7 +1692,7 @@ func TestSQLInsertWriterPrepareColumnNamesRecoversAfterQuoteError(t *testing.T) 
 func TestSQLInsertWriterPrepareRowTypeCachesQuotedColumns(t *testing.T) {
 	t.Parallel()
 
-	w := NewSQLInsertWriter(&bytes.Buffer{}, "users")
+	w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
 	if err := w.PrepareRowType(rowTypeWithColumnNames("id", "name")); err != nil {
 		t.Fatalf("PrepareRowType() error = %v", err)
 	}
@@ -1706,8 +1706,8 @@ func TestPrepareRowTypeAfterConstruction(t *testing.T) {
 
 	rowType := rowTypeWithColumnNames("id", "name")
 	var delimited, jsonl bytes.Buffer
-	dw := NewDelimitedWriter(&delimited, ',')
-	jw := NewJSONLWriter(&jsonl)
+	dw := mustNewDelimitedWriter(t, &delimited, ',')
+	jw := mustNewJSONLWriter(t, &jsonl)
 	if err := dw.PrepareRowType(rowType); err != nil {
 		t.Fatalf("DelimitedWriter.PrepareRowType() error = %v", err)
 	}
@@ -1734,8 +1734,8 @@ func TestWithRowTypeConsistentAcrossWriters(t *testing.T) {
 
 	rowType := rowTypeWithColumnNames("id", "name")
 	var delimited, jsonl bytes.Buffer
-	dw := NewDelimitedWriter(&delimited, ',', WithRowType(rowType))
-	jw := NewJSONLWriter(&jsonl, WithRowType(rowType))
+	dw := mustNewDelimitedWriter(t, &delimited, ',', WithRowType(rowType))
+	jw := mustNewJSONLWriter(t, &jsonl, WithRowType(rowType))
 	if err := dw.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("a")}); err != nil {
 		t.Fatalf("WriteGCVs() error = %v", err)
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -490,24 +490,6 @@ func TestDelimitedWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	}
 }
 
-func TestDelimitedWriterWriteGCVsNilOutputWithoutMetadata(t *testing.T) {
-	t.Parallel()
-
-	_, err := NewDelimitedWriter(nil, Comma)
-	if !errors.Is(err, ErrNilOutputWriter) {
-		t.Fatalf("NewDelimitedWriter() error = %v, want ErrNilOutputWriter", err)
-	}
-}
-
-func TestDelimitedWriterWriteHeaderNilOutputWithoutMetadata(t *testing.T) {
-	t.Parallel()
-
-	_, err := NewDelimitedWriter(nil, Comma)
-	if !errors.Is(err, ErrNilOutputWriter) {
-		t.Fatalf("NewDelimitedWriter() error = %v, want ErrNilOutputWriter", err)
-	}
-}
-
 func TestWritersReturnErrNilOutputWriter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `NewDelimitedWriter`, `NewCSVWriter`, `NewJSONLWriter`, and `NewSQLInsertWriter` return `(*Writer, error)`.
- Options apply in order; the first failing option returns an error without a partially configured writer.
- `WithColumnNames` with an empty slice returns `ErrMissingColumnNames` at construction (aligned with `PrepareColumnNames`).
- README examples updated to `w, err := writer.New...`.

Closes #95

## Test plan
- [x] `make check`
- [x] `TestDelimitedWriterWithColumnNamesEmptyErrors` covers constructor validation


Made with [Cursor](https://cursor.com)