### PR TITLE
writer: unexport SQLInsertWriter.Table and Formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 - **Native client:** `WriteRow` / `WriteRowIterator` / `RunRowIterator` for `*spanner.RowIterator`. `WriteRowIterator`/`RunRowIterator` with `RowIteratorHooksFromWriter` register metadata and call **`Flush`** in hooks. Manual `RowIterator.Next` loops need first-`Next` metadata and zero-row **`PrepareRowType` + `Flush`** (not `defer Flush`—return `Flush()` error). Do not pass `iter.Metadata` at construction when still nil.
 - **GCV slice path:** `WriteGCVs` + `WithMetadata` / `WithFormatter` / `WithUnnamedFieldNamer`. Same namer for **out-of-band headers** via root `ColumnNames(fields, namer)`.
 - **Delimited:** `NewCSVWriter(out)`, `NewDelimitedWriter(out, '\t')` = **quoted TSV** (`encoding/csv`), not legacy raw TAB; raw TAB = custom `Writer` (README).
-- **SQL INSERT:** `WithSQLInsertKind`, `WithSQLDialect` (identifier quoting), `WithSQLBatchSize` (>1 multi-row `VALUES`; **`Flush`** ends partial batch). `ErrInvalidSQLInsertKindForDialect`: PostgreSQL + `INSERT OR IGNORE`/`UPDATE`. After any write error, discard writer (documented). **`Table` / `Formatter` fields deprecated**—set via constructor/`WithFormatter` only; unexport planned ([#107](https://github.com/apstndb/spanvalue/issues/107), `breaking-change` label).
+- **SQL INSERT:** `WithSQLInsertKind`, `WithSQLDialect` (identifier quoting), `WithSQLBatchSize` (>1 multi-row `VALUES`; **`Flush`** ends partial batch). `ErrInvalidSQLInsertKindForDialect`: PostgreSQL + `INSERT OR IGNORE`/`UPDATE`. After any write error, discard writer (documented). Table and formatter are constructor-only (`TableName` / `FormatConfig` accessors on `SQLInsertWriter`).
 
 ## Adoption boundaries (do not expand spanvalue into)
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1096,10 +1096,12 @@ func (w *SQLInsertWriter) TableName() string {
 	return w.table
 }
 
-// FormatConfig returns the formatter used for INSERT value literals.
+// FormatConfig returns the effective formatter used for INSERT value literals.
+// When no formatter is configured, this returns [spanvalue.LiteralFormatConfig]
+// (the same default as [SQLInsertWriter.insertFormatter]).
 // Configure it only via [NewSQLInsertWriter] or [WithFormatter].
 func (w *SQLInsertWriter) FormatConfig() *spanvalue.FormatConfig {
-	return w.formatter
+	return w.insertFormatter()
 }
 
 func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -467,7 +467,11 @@ func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
 }
 
 func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) error {
-	w.formatter = o.formatter
+	if o.formatter != nil {
+		w.formatter = o.formatter
+	} else {
+		w.formatter = spanvalue.LiteralFormatConfig()
+	}
 	return nil
 }
 
@@ -1334,9 +1338,6 @@ func (w *SQLInsertWriter) setColumnNames(names []string) {
 }
 
 func (w *SQLInsertWriter) insertFormatter() *spanvalue.FormatConfig {
-	if w.formatter == nil {
-		w.formatter = spanvalue.LiteralFormatConfig()
-	}
 	return w.formatter
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1097,8 +1097,7 @@ func (w *SQLInsertWriter) TableName() string {
 }
 
 // FormatConfig returns the effective formatter used for INSERT value literals.
-// When no formatter is configured, this returns [spanvalue.LiteralFormatConfig]
-// (the same default as [SQLInsertWriter.insertFormatter]).
+// When no formatter is configured, this returns [spanvalue.LiteralFormatConfig].
 // Configure it only via [NewSQLInsertWriter] or [WithFormatter].
 func (w *SQLInsertWriter) FormatConfig() *spanvalue.FormatConfig {
 	return w.insertFormatter()

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1334,10 +1334,10 @@ func (w *SQLInsertWriter) setColumnNames(names []string) {
 }
 
 func (w *SQLInsertWriter) insertFormatter() *spanvalue.FormatConfig {
-	if w.formatter != nil {
-		return w.formatter
+	if w.formatter == nil {
+		w.formatter = spanvalue.LiteralFormatConfig()
 	}
-	return spanvalue.LiteralFormatConfig()
+	return w.formatter
 }
 
 func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (string, error) {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -137,7 +137,7 @@ const (
 )
 
 var (
-	// ErrEmptyTableName reports that SQLInsertWriter.Table is empty.
+	// ErrEmptyTableName reports that the SQL INSERT writer table name is empty.
 	ErrEmptyTableName = errors.New("empty table name")
 	// ErrEmptyColumnName reports that a SQL writer received an empty column name.
 	ErrEmptyColumnName = errors.New("empty column name")
@@ -166,7 +166,7 @@ var (
 	// or INSERT OR UPDATE with a PostgreSQL dialect. Those prefixes are GoogleSQL-only; use plain
 	// [SQLInsert] with [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL) instead.
 	ErrInvalidSQLInsertKindForDialect = errors.New("INSERT OR IGNORE/UPDATE not supported for PostgreSQL dialect")
-	// ErrTableNameChangedMidBatch reports that SQLInsertWriter.Table was mutated while
+	// ErrTableNameChangedMidBatch reports that the SQL INSERT table name was mutated while
 	// a multi-row INSERT batch was open.
 	ErrTableNameChangedMidBatch = errors.New("table name changed mid-batch")
 )
@@ -467,7 +467,7 @@ func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
 }
 
 func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) error {
-	w.Formatter = o.formatter
+	w.formatter = o.formatter
 	return nil
 }
 
@@ -1040,16 +1040,8 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 // [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
 // writer; partial batched INSERT output may be unrecoverable on retry.
 type SQLInsertWriter struct {
-	// Table is the qualified table name used in INSERT statements.
-	//
-	// Deprecated: Set only via [NewSQLInsertWriter]. Do not mutate Table after the
-	// first write; the field will be unexported in a future minor release.
-	Table string
-	// Formatter formats value literals in INSERT statements.
-	//
-	// Deprecated: Set only via [NewSQLInsertWriter] or [WithFormatter]. Do not mutate
-	// Formatter after the first write; the field will be unexported in a future minor release.
-	Formatter *spanvalue.FormatConfig
+	table     string
+	formatter *spanvalue.FormatConfig
 
 	insertKind        SQLInsertKind
 	sqlDialect        databasepb.DatabaseDialect
@@ -1091,11 +1083,23 @@ func NewSQLInsertWriterWithOptions(out io.Writer, table string, options ...SQLIn
 
 func newSQLInsertWriter(out io.Writer, table string) *SQLInsertWriter {
 	return &SQLInsertWriter{
-		Table:      table,
-		Formatter:  spanvalue.LiteralFormatConfig(),
+		table:      table,
+		formatter:  spanvalue.LiteralFormatConfig(),
 		sqlDialect: databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
 		out:        out,
 	}
+}
+
+// TableName returns the qualified table name used in INSERT statements.
+// Configure it only via [NewSQLInsertWriter]; create a new writer to use a different table.
+func (w *SQLInsertWriter) TableName() string {
+	return w.table
+}
+
+// FormatConfig returns the formatter used for INSERT value literals.
+// Configure it only via [NewSQLInsertWriter] or [WithFormatter].
+func (w *SQLInsertWriter) FormatConfig() *spanvalue.FormatConfig {
+	return w.formatter
 }
 
 func (w *SQLInsertWriter) WriteRow(row *spanner.Row) error {
@@ -1236,10 +1240,10 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}
-	if w.Table == "" {
+	if w.table == "" {
 		return ErrEmptyTableName
 	}
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.insertFormatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -1266,10 +1270,10 @@ func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValue
 }
 
 func (w *SQLInsertWriter) rejectTableChangeMidBatch() error {
-	if w.batchPending == 0 || w.quotedTableInput == "" || w.Table == w.quotedTableInput {
+	if w.batchPending == 0 || w.quotedTableInput == "" || w.table == w.quotedTableInput {
 		return nil
 	}
-	return fmt.Errorf("%w: %q to %q", ErrTableNameChangedMidBatch, w.quotedTableInput, w.Table)
+	return fmt.Errorf("%w: %q to %q", ErrTableNameChangedMidBatch, w.quotedTableInput, w.table)
 }
 
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
@@ -1328,9 +1332,9 @@ func (w *SQLInsertWriter) setColumnNames(names []string) {
 	w.quotedColumnNames = ""
 }
 
-func (w *SQLInsertWriter) formatter() *spanvalue.FormatConfig {
-	if w.Formatter != nil {
-		return w.Formatter
+func (w *SQLInsertWriter) insertFormatter() *spanvalue.FormatConfig {
+	if w.formatter != nil {
+		return w.formatter
 	}
 	return spanvalue.LiteralFormatConfig()
 }
@@ -1356,15 +1360,15 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 }
 
 func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
-	if w.quotedTable != "" && w.quotedTableInput == w.Table {
+	if w.quotedTable != "" && w.quotedTableInput == w.table {
 		return w.quotedTable, nil
 	}
-	quotedTable, err := quoteQualifiedIdentifier(w.Table, w.sqlDialect)
+	quotedTable, err := quoteQualifiedIdentifier(w.table, w.sqlDialect)
 	if err != nil {
 		return "", err
 	}
 	w.quotedTable = quotedTable
-	w.quotedTableInput = w.Table
+	w.quotedTableInput = w.table
 	return quotedTable, nil
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -467,7 +467,11 @@ func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
 }
 
 func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) error {
-	w.formatter = o.formatter
+	if o.formatter != nil {
+		w.formatter = o.formatter
+	} else {
+		w.formatter = spanvalue.LiteralFormatConfig()
+	}
 	return nil
 }
 
@@ -1335,7 +1339,8 @@ func (w *SQLInsertWriter) setColumnNames(names []string) {
 
 func (w *SQLInsertWriter) insertFormatter() *spanvalue.FormatConfig {
 	if w.formatter == nil {
-		w.formatter = spanvalue.LiteralFormatConfig()
+		// Zero-initialized writers are unsupported; avoid mutating w in this getter.
+		return spanvalue.LiteralFormatConfig()
 	}
 	return w.formatter
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -467,11 +467,7 @@ func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
 }
 
 func (o formatterOption) applySQLInsertOption(w *SQLInsertWriter) error {
-	if o.formatter != nil {
-		w.formatter = o.formatter
-	} else {
-		w.formatter = spanvalue.LiteralFormatConfig()
-	}
+	w.formatter = o.formatter
 	return nil
 }
 
@@ -1338,6 +1334,9 @@ func (w *SQLInsertWriter) setColumnNames(names []string) {
 }
 
 func (w *SQLInsertWriter) insertFormatter() *spanvalue.FormatConfig {
+	if w.formatter == nil {
+		w.formatter = spanvalue.LiteralFormatConfig()
+	}
 	return w.formatter
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1099,6 +1099,17 @@ func TestSQLInsertWriterWithOptions(t *testing.T) {
 		t.Fatalf("FormatConfig() = %p, want %p", w.FormatConfig(), cfg)
 	}
 
+	var nilFormatterOut bytes.Buffer
+	nilFormatterW := mustNewSQLInsertWriter(t,
+		&nilFormatterOut,
+		"users",
+		WithMetadata(metadataWithColumnNames("id")),
+		WithFormatter(nil),
+	)
+	if nilFormatterW.FormatConfig() == nil {
+		t.Fatal("FormatConfig() with nil formatter = nil, want effective literal formatter")
+	}
+
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.Int64Value(42),
 		gcvctor.StringValue("Alice"),

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -932,8 +932,7 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 		}
-		// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
-		w.Table = "archive.users"
+		w.table = "archive.users"
 		if err := w.WriteValues(columnNames, row(3, "c")); err != nil {
 			t.Fatalf("WriteValues() after table change error = %v", err)
 		}
@@ -956,9 +955,8 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		if err := w.WriteValues(columnNames, row(1, "a")); err != nil {
 			t.Fatalf("WriteValues() error = %v", err)
 		}
-		// Legacy mutation remains syntactically possible until Table is unexported,
-		// but a mid-batch change must not silently append rows to the previous table.
-		w.Table = "archive.users"
+		// Mid-batch table mutation must not silently append rows to the previous table.
+		w.table = "archive.users"
 		err := w.WriteValues(columnNames, row(2, "b"))
 		if !errors.Is(err, ErrTableNameChangedMidBatch) {
 			t.Fatalf("WriteValues() after table change error = %v, want ErrTableNameChangedMidBatch", err)
@@ -1087,12 +1085,19 @@ func TestSQLInsertWriterWithOptions(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
+	cfg := spanvalue.LiteralFormatConfig()
 	w := mustNewSQLInsertWriter(t,
 		&out,
 		"users",
 		WithMetadata(metadataWithColumnNames("id", "name")),
-		WithFormatter(spanvalue.LiteralFormatConfig()),
+		WithFormatter(cfg),
 	)
+	if w.TableName() != "users" {
+		t.Fatalf("TableName() = %q, want users", w.TableName())
+	}
+	if w.FormatConfig() != cfg {
+		t.Fatalf("FormatConfig() = %p, want %p", w.FormatConfig(), cfg)
+	}
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{
 		gcvctor.Int64Value(42),
@@ -1194,8 +1199,7 @@ func TestSQLInsertWriterWriteValuesTableChangeAfterCache(t *testing.T) {
 		t.Fatalf("first WriteValues() error = %v", err)
 	}
 
-	// Legacy: mutating Table after writes; legacy behavior until Table is unexported.
-	w.Table = "archive.users"
+	w.table = "archive.users"
 	err = w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(2)})
 	if err != nil {
 		t.Fatalf("WriteGCVs() after table change error = %v", err)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1106,8 +1106,12 @@ func TestSQLInsertWriterWithOptions(t *testing.T) {
 		WithMetadata(metadataWithColumnNames("id")),
 		WithFormatter(nil),
 	)
-	if nilFormatterW.FormatConfig() == nil {
+	gotFormatter := nilFormatterW.FormatConfig()
+	if gotFormatter == nil {
 		t.Fatal("FormatConfig() with nil formatter = nil, want effective literal formatter")
+	}
+	if nilFormatterW.FormatConfig() != gotFormatter {
+		t.Fatal("FormatConfig() should return the same cached formatter on repeat calls")
 	}
 
 	if err := w.WriteGCVs([]spanner.GenericColumnValue{


### PR DESCRIPTION
## Summary

Closes #107.

- Unexport `SQLInsertWriter` table and formatter fields (constructor/options only).
- Add `TableName()` and `FormatConfig()` for read-only access.
- Update tests to mutate the unexported `table` field only where table-change semantics are under test; assert accessors in `TestSQLInsertWriterWithOptions`.
- Refresh `AGENTS.md` writer SQL INSERT notes.

## Breaking change

Callers must not assign `w.Table` or `w.Formatter` after construction. Use `NewSQLInsertWriter(out, table, writer.WithFormatter(cfg), ...)` or create a new writer.

**Before:**

```go
w, err := writer.NewSQLInsertWriter(out, "T")
w.Formatter = spanvalue.LiteralFormatConfig()
w.Table = "other_table"
```

**After:**

```go
w, err := writer.NewSQLInsertWriter(out, "T",
    writer.WithFormatter(spanvalue.LiteralFormatConfig()),
)
// different table or formatter → new writer
```

## Test plan

- [x] `make check`

Made with [Cursor](https://cursor.com)