### PR TITLE
docs(writer): package README and godoc for future module split

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,40 @@
+# spanvalue — Gemini Code Assist review style guide
+
+## For editors
+
+Gemini Code Review **does not run tools** and **does not receive tool output** (no `make lint`, no CI logs). It only sees the PR diff and this file.
+
+Write **assumptions** for the model (lint already ran; do not duplicate diagnostics), not lectures about what the bot cannot do. Config: `.golangci.yml` (`godoclint` on non-`*_test.go` files).
+
+---
+
+## Go doc comments
+
+One **optional slice** of review—not the main job. Behavior, tests, API design, and Markdown still get normal scrutiny.
+
+Standard godoc hygiene on production `.go` files is already checked in **CI and local `make lint`**. Those findings appear on the PR; **do not repeat them** or nit comment formatting CI would flag.
+
+### When Go doc is worth a review note
+
+Only if it helps readers beyond what lint already covers:
+
+| Angle | Example |
+|-------|---------|
+| Link clarity on pkg.go.dev | Package doc uses `[WriteRow]` where `[Writer.WriteRow]` would link |
+| Clearly wrong bracket target | `[Nonexistent.Method]` with no such symbol |
+| Intentional package docs | `writer/doc.go` uses qualified links like `[Writer.WriteRow]`—do not “simplify” to `[WriteRow]` |
+
+Frame optional notes as **reader / pkg.go.dev clarity**, not “lint failed” or “run make lint.”
+
+### Common model mistakes (Go doc)
+
+Avoid these false review threads:
+
+| Mistake | Reality |
+|---------|---------|
+| Treating `[WriteRow]` vs `[Writer.WriteRow]` as a CI/lint issue | Lint does not check symbol link resolution; optional doc quality only. |
+| Requiring godoc on every export | Not required by this repo’s lint config. |
+| Requiring `[fmt.Stringer]` instead of plain `fmt.Stringer` | Optional style; not enforced in CI. |
+| Demanding godoc fixes in `*_test.go` | Test files are outside godoc lint in `.golangci.yml`. |
+| Applying godoc rules to `README.md` | Markdown is separate from Go comment lint. |
+| Copying lint diagnostic text into the review | Already on the PR from CI. |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,12 @@ linters:
   enable:
     - godoclint
   exclusions:
-    # godoc-lint README: exclude test files from godoclint by default practice.
     rules:
       - path: _test\.go$
         linters:
           - godoclint
-
-linters-settings:
-  godoclint:
-    default: basic
-    enable:
-      - no-unused-link
+  settings:
+    godoclint:
+      default: basic
+      enable:
+        - no-unused-link

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - godoclint
+  exclusions:
+    # godoc-lint README: exclude test files from godoclint by default practice.
+    rules:
+      - path: _test\.go$
+        linters:
+          - godoclint
+
+linters-settings:
+  godoclint:
+    default: basic
+    enable:
+      - no-unused-link

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 - **English only** on github.com (issues, PRs, review threads).
 - **Merge:** `squash and merge`; branch updates via **merge**, not rebase+force-push to `main`.
 - **During review response:** avoid **rebase** on the PR branch; squash merge cleans history.
-- After pushing fixes: `gh copilot-review request <pr> --wait` ([gh-copilot-review](https://github.com/apstndb/gh-copilot-review)); `/gemini review` on PR when needed. Local diff reviews: **review-router** (include Codex 5.5 + Antigravity when asked).
+- **Gemini on PRs:** automatic review on open; do **not** post `/gemini review` right after `gh pr create` (only after review-response pushes when needed). **Go doc comment syntax** is enforced by **`godoclint`** in `make lint`—see `.gemini/styleguide.md`; do not duplicate those findings in bot review. **Temporarily** skip GitHub Copilot PR reviews. Local diff reviews: **review-router** when asked.
 - **Do not merge** unless the user asks. **Do not commit** unless asked.
 
 ## Shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 |------|------|
 | Root | `FormatConfig`, presets, `ColumnNames`, `FormatRowColumns`, identifier quoting |
 | `gcvctor/` | Build `GenericColumnValue` from Go types (strict; no format) |
-| `writer/` | CSV/TSV/JSONL/SQL INSERT; `WriteGCVs`, `WriteRowIterator` |
+| `writer/` | CSV/TSV/JSONL/SQL INSERT; `WriteGCVs`, `WriteRowIterator` ([writer/README.md](writer/README.md)) |
 | `internal/` | Escape/literal/iterator helpers |
 
 ## Formatting

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Helpers for working with Cloud Spanner’s [`spanner.GenericColumnValue`](https:
 |--------|------|
 | [`github.com/apstndb/spanvalue`](https://pkg.go.dev/github.com/apstndb/spanvalue) | Format `spanner.GenericColumnValue` and `*spanner.Row` using [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig) and presets such as [`LiteralFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#LiteralFormatConfig), [`JSONFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#JSONFormatConfig), [`SpannerCLICompatibleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SpannerCLICompatibleFormatConfig). |
 | [`github.com/apstndb/spanvalue/gcvctor`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor) | Build `spanner.GenericColumnValue` (scalars, `ARRAY`, `STRUCT`, typed nulls). Types are often composed with [`github.com/apstndb/spantype/typector`](https://pkg.go.dev/github.com/apstndb/spantype/typector). |
-| [`github.com/apstndb/spanvalue/writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) | Stream Spanner rows to CSV, TSV, JSONL, or SQL INSERT statements using spanvalue formatters. |
+| [`github.com/apstndb/spanvalue/writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) | Stream Spanner rows to CSV, TSV, JSONL, or SQL INSERT ([writer/README.md](writer/README.md)). |
 
 ## Identifier quoting helpers
 
@@ -79,52 +79,22 @@ return w.Flush()
 
 ## Streaming row exports
 
-The `writer` package streams rows at several levels: `WriteRow` for
-`*spanner.Row` (Spanner client), `WriteStructValues` for `[]*structpb.Value` with
-a registered field-type schema (spannerpb + structpb at the boundary), and
-`WriteGCVs` when values are already `GenericColumnValue`. Use `writer.Writer`
-when an adapter only needs `WriteRow`. Use `writer.FlushWriter` when an adapter
-owns both row streaming and finalization.
+Package [`writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) streams
+`*spanner.Row`, structpb cells, or `[]spanner.GenericColumnValue` to CSV, quoted TSV,
+JSONL, or SQL INSERT using spanvalue formatters. **[writer/README.md](writer/README.md)**
+covers `RowIterator` lifecycle ([`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator),
+[`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator),
+hooks and decorators, `RowsRead`), schema registration, format edge cases, and v0.5.x
+expectations if `writer` becomes a separate module.
 
-**Production streaming (Spanner client):** `iter.Metadata` is set only after the first
-`Next()`. Do not pass `iter.Metadata` to `WithMetadata` at writer construction—it is still
-`nil` there and registers an empty schema. When every query returns at least one row,
-`iter.Do` and `WriteRow` are enough (the first row supplies column names). When the result
-may be empty but metadata still lists columns, use the `iter.Next` loop below and call
-`PrepareRowType(iter.Metadata.GetRowType())` on the first loop iteration (even when `Next` returns
-`iterator.Done`), then `WriteRow` in the loop and `return w.Flush()` after the loop (do not
-`defer w.Flush()`—that discards Flush errors). You do not need to build `[]GenericColumnValue` per row or call
-`WriteStructValues` on that path. If you already hold `*spannerpb.ResultSetMetadata` outside a
-`RowIterator` (for example an in-memory `spannerpb.ResultSet`), `WithMetadata(md)` at
-construction is fine.
-
-**In-memory fixtures:** after `WithMetadata` or `WithRowType`, prefer `WriteStructValues`
-with `[]*structpb.Value` cells (or `WriteGCVs` with `gcvctor` helpers). Do not zip
-`RowType` field types with `ListValue` cells manually when types are already registered.
-`DelimitedWriter` and `JSONLWriter` preserve explicit duplicate column names.
-Empty column names are the only names passed to `UnnamedFieldNamer`, and
-generated names avoid collisions with existing explicit names. Set
-`UnnamedFieldNamer` to `nil` when callers need empty names to remain empty.
-
-Call `Flush` after the final row when using `writer.FlushWriter`; see the
-`Writer`, `FlushWriter`, and `Flusher` godoc for the interface lifecycle
-contract.
-
-With the [Spanner client](https://pkg.go.dev/cloud.google.com/go/spanner#section-readme),
-export through a `RowIterator` with `WriteRow` and `writer.WithHeader(true)` (default).
-
-When every query returns at least one row, `iter.Do` is enough—`WriteRow` picks up
-column names from the first row and writes the header before the first data row:
+When every query returns at least one row, `iter.Do` plus `WriteRow` and `Flush` is enough
+(the first row registers column names). When a `SELECT` may return zero rows but metadata
+still lists columns, use `WriteRowIterator` (see writer README).
 
 ```go
 iter := txn.Query(ctx, stmt)
 
-w, err := writer.NewDelimitedWriter(
-	out,
-	'\t',
-	writer.WithFormatter(cfg),
-	writer.WithHeader(true), // false for headerless CSV/TSV
-)
+w, err := writer.NewCSVWriter(out, writer.WithFormatter(cfg))
 if err != nil {
 	return err
 }
@@ -136,144 +106,9 @@ if err := iter.Do(func(row *spanner.Row) error {
 return w.Flush()
 ```
 
-When a `SELECT` may return zero rows but metadata still lists result columns, use
-`writer.WriteRowIterator` (or the generic `writer.RunRowIterator` with hooks). It
-registers `iter.Metadata` on the first `Next`, streams rows, and finishes with
-`Flush` (header-only when no data rows were written). It returns `iter.Metadata`
-and query stats even when the iterator is empty:
-
-```go
-iter := txn.QueryWithStats(ctx, stmt) // WriteRowIterator stops iter for us
-
-w, err := writer.NewDelimitedWriter(
-	out,
-	'\t',
-	writer.WithFormatter(cfg),
-	writer.WithHeader(true),
-)
-if err != nil {
-	return err
-}
-result, err := writer.WriteRowIterator(iter, w)
-if err != nil {
-	return err
-}
-_ = result.Metadata
-_ = result.Stats.QueryStats
-```
-
-An equivalent manual loop — call `PrepareRowType(iter.Metadata.GetRowType())`
-after the first `Next`, write each row, then `Flush` — is still supported;
-prefer `WriteRowIterator` when you also need metadata or query stats from an
-empty result.
-
-### `RunRowIterator` hooks (custom adapters)
-
-Use [`writer.WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)
-when the sink is a built-in [`RowIteratorWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorWriter)
-(`DelimitedWriter`, `JSONLWriter`, `SQLInsertWriter`). Use
-[`writer.RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator)
-with [`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks)
-when the sink is not one of those writers—for example a legacy formatter, a
-row transform into an app-owned type, or a presentation-specific export path
-that should stay outside spanvalue.
-
-`RunRowIterator` always calls `iter.Stop()`. Hook semantics (also on
-[`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks)
-godoc):
-
-- **`PrepareMetadata`** runs once after the first `Next`, including when that
-  call returns `iterator.Done` (zero data rows). It is not called when the first
-  `Next` returns any other error.
-- **`WriteRow`** runs for each data row.
-- **`Finish`** runs only after all rows are consumed **without error**. It is
-  **not** a `defer`-style cleanup when `PrepareMetadata` or `WriteRow` fails.
-- On abort, `RunRowIterator` still returns `*RowIteratorResult` with whatever
-  metadata and stats were available at the abort point.
-
-Minimal adapter shape:
-
-```go
-result, err := writer.RunRowIterator(iter, writer.RowIteratorHooks{
-	PrepareMetadata: func(md *spannerpb.ResultSetMetadata) error {
-		return sink.Init(md)
-	},
-	WriteRow: func(row *spanner.Row) error {
-		return sink.Write(row)
-	},
-	Finish: func(res *writer.RowIteratorResult) error {
-		return sink.Close(res)
-	},
-})
-```
-
-Nil hook fields are skipped. For header-only or row-skip patterns, see
-[Metadata-only finish after skipping rows](#metadata-only-finish-after-skipping-rows).
-
-### Metadata-only finish after skipping rows
-
-When the application consumes a `RowIterator` but does not write every row body
-(for example a redacted or stats-only export path), metadata is still available
-after `iterator.Done`. Register the row type and call `Flush` so delimited
-writers emit a header-only CSV when columns were present but no data rows were
-written:
-
-```go
-defer iter.Stop()
-
-w, err := writer.NewDelimitedWriter(out, writer.Comma, writer.WithFormatter(cfg))
-if err != nil {
-	return err
-}
-for {
-	_, err := iter.Next()
-	if errors.Is(err, iterator.Done) {
-		break
-	}
-	if err != nil {
-		return err
-	}
-	// discard row body
-}
-if err := w.PrepareRowType(iter.Metadata.GetRowType()); err != nil {
-	return err
-}
-return w.Flush()
-```
-
-When every row is written normally, prefer [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator)
-instead of reimplementing the loop.
-
-### Schema registration
-
-| Goal | API |
-|------|-----|
-| Streaming `RowIterator` | [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) / [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator), or `PrepareRowType` after first `Next` then `WriteRow` (or `iter.Do` when every query has ≥1 row) |
-| Known column names only | `WithColumnNames` / `PrepareColumnNames` (at least one name) |
-| Names and types from metadata | `WithRowType` / `PrepareRowType` / `WithMetadata` (when `md` is already available) |
-| Zero columns (e.g. DML without `THEN RETURN`) | `PrepareRowType(nil)` or `PrepareRowType(metadata.GetRowType())` when fields are empty—**not** `PrepareColumnNames` |
-| Zero-row `SELECT` (columns in metadata, no rows) | `PrepareRowType` after first `Next`, then `Flush` for header-only CSV |
-
-Registration is not the same as having zero columns: without `Prepare*` / `With*` and
-with no row written, `Flush` or `WriteHeader` returns `writer.ErrMissingColumnNames`.
-`PrepareColumnNames` with an empty slice returns `writer.ErrMissingColumnNames`;
-`WithColumnNames([])` at construction returns `writer.ErrMissingColumnNames`. See
-`go doc writer`, sections "Column names and field types" and
-"Registered schema vs missing schema".
-
-### Result-set shape vs CSV output
-
-| Metadata | Rows | `Flush` with `Header=true` |
-|----------|------|----------------------------|
-| Zero fields (partitioned DML, etc.) | 0 | Empty file (no header line) |
-| Normal `SELECT` row type | 0 | Header row only |
-| Normal `SELECT` row type | ≥1 | Header then data rows |
-
-DML or other statements with no result columns: call `PrepareRowType` on
-`iter.Metadata.GetRowType()` (possibly nil or zero fields), then `Flush`—do not rely on
-`PrepareColumnNames` with an empty name list.
-
 ### go-sql-spanner and GenericColumnValue export
+
+Writer package details (GCV export options, `RowIterator` vs `WriteGCVs`): [writer/README.md](writer/README.md).
 
 [go-sql-spanner](https://github.com/googleapis/go-sql-spanner) apps often decode query
 rows into `[]spanner.GenericColumnValue` (for example via proto decode options) and
@@ -369,7 +204,7 @@ by default. Build cells with [`gcvctor.EnumValue`](https://pkg.go.dev/github.com
 and [`gcvctor.ProtoValue`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ProtoValue),
 then `WriteGCVs` (see `TestDelimitedWriterWriteGCVsEnumProto` in the `writer` package).
 Delimited, JSONL, and SQL encodings differ after
-spanvalue formats each column; see the `writer` package documentation. For
+spanvalue formats each column; see [writer/README.md](writer/README.md). For
 non-streaming paths, use
 `writer.RowData`, `writer.FormatDelimitedRow`, or `writer.FormatJSONLRow`
 directly. Pass the JSON field-name policy explicitly, for example:

--- a/format_throughput_bench_test.go
+++ b/format_throughput_bench_test.go
@@ -1,6 +1,3 @@
-// Throughput benchmarks: build many GenericColumnValues up front, then repeatedly
-// format and discard every cell. Use to compare scalar FormatComplexFunc plugins vs the
-// legacy Decode + FormatNullable path on a realistic mixed-type row shape.
 package spanvalue
 
 import (
@@ -76,6 +73,9 @@ func benchmarkFormatThroughput(b *testing.B, fc *FormatConfig, values []spanner.
 	benchmarkFormatCells(b, fc, values)
 }
 
+// BenchmarkFormatThroughput builds GenericColumnValues up front, then repeatedly
+// formats and discards every cell, comparing scalar FormatComplexFunc plugins vs the
+// legacy Decode + FormatNullable path on a realistic mixed-type row shape.
 func BenchmarkFormatThroughput(b *testing.B) {
 	sizes := []int{1_000, 10_000}
 	for _, rows := range sizes {

--- a/writer/README.md
+++ b/writer/README.md
@@ -1,0 +1,101 @@
+# writer
+
+Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **SQL INSERT** statements using [spanvalue](https://github.com/apstndb/spanvalue) formatters. The package sits beside the root formatter API: configure output with `spanvalue.FormatConfig` presets, then write rows through concrete writers or a shared `RowIterator` loop.
+
+| Writer | Constructor | Notes |
+|--------|-------------|--------|
+| Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row |
+| JSONL | `NewJSONLWriter` | `Flush` is a no-op |
+| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; discard writer after a write error |
+
+**Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
+
+## RowIterator
+
+Production code with `*spanner.RowIterator` should treat metadata as **lazy**: `iter.Metadata` is populated after the first `Next()`. Do not pass `iter.Metadata` to `WithMetadata` at construction—it is still `nil`.
+
+| Goal | API |
+|------|-----|
+| Built-in CSV / JSONL / SQL writer | [`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) |
+| Custom sink (legacy formatter, app-owned type) | [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator) with [`RowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks) |
+| Manual loop (every query has ≥1 row) | `iter.Do` + `WriteRow`, or `PrepareRowType` after first `Next` then `WriteRow` + `return w.Flush()` |
+| Zero-row `SELECT` (columns in metadata) | `WriteRowIterator` / `RunRowIterator`, or `PrepareRowType` after first `Next` then `Flush` |
+
+[`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) wires [`RowIteratorHooksFromWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooksFromWriter): `PrepareRowType` from metadata, `WriteRow` per data row, `Flush` in `Finish`. It always calls `iter.Stop()` and returns [`RowIteratorResult`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorResult) (metadata, query stats, [`RowsRead`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorResult.RowsRead)).
+
+[`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator) is the extension point for non-`RowIteratorWriter` sinks:
+
+- **`PrepareMetadata`** — once after the first `Next`, including when that call returns `iterator.Done` (zero data rows). Not called when the first `Next` returns another error.
+- **`WriteRow`** — each data row.
+- **`Finish`** — only after all rows succeed without error (not `defer`-style cleanup on abort).
+
+Construct hooks with [`NewRowIteratorHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#NewRowIteratorHooks), [`RowIteratorHooks.WithPrepareMetadata`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks.WithPrepareMetadata) / `WithWriteRow` / `WithFinish`, or [`RowIteratorHooksFromWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooksFromWriter). Unexported fields prevent unkeyed composite literals from other packages.
+
+**Decorators** (wrap an existing `RowIteratorHooks` value):
+
+- [`WithRowOrdinal`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithRowOrdinal) — 1-based row index for diagnostics
+- [`ObserveWriteRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#ObserveWriteRow) — callback before each row
+- [`AfterEachSuccessfulWriteRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#AfterEachSuccessfulWriteRow) — e.g. flush buffered I/O per row (not `SQLInsertWriter.Flush`)
+
+`RowsRead` counts successful `WriteRow` hook calls; it differs from [`RowIteratorStats.RowCount`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorStats.RowCount) (Spanner DML semantics). Decorators that only observe rows may call [`MarkOmitRowsRead`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks.MarkOmitRowsRead) so side-effect-only `WriteRow` wrappers do not increment `RowsRead`.
+
+```go
+iter := txn.QueryWithStats(ctx, stmt)
+
+w, err := writer.NewDelimitedWriter(out, '\t', writer.WithFormatter(cfg), writer.WithHeader(true))
+if err != nil {
+	return err
+}
+result, err := writer.WriteRowIterator(iter, w)
+if err != nil {
+	return err
+}
+_ = result.Metadata
+_ = result.Stats.QueryStats
+```
+
+```go
+result, err := writer.RunRowIterator(iter, writer.NewRowIteratorHooks().
+	WithPrepareMetadata(func(md *spannerpb.ResultSetMetadata) error {
+		return sink.Init(md)
+	}).
+	WithWriteRow(func(row *spanner.Row) error {
+		return sink.Write(row)
+	}).
+	WithFinish(func(res *writer.RowIteratorResult) error {
+		return sink.Close(res)
+	}))
+```
+
+When the app consumes `Next` but skips row bodies, register `PrepareRowType(iter.Metadata.GetRowType())` after the loop, then `Flush` for a header-only delimited export—see package godoc.
+
+**Manual loops:** propagate `Flush()` errors (`return w.Flush()`, not `defer w.Flush()`). When driving `Next` yourself, `defer iter.Stop()`.
+
+## Schema registration
+
+| Situation | Registration |
+|-----------|----------------|
+| Names only | `WithColumnNames` / `PrepareColumnNames` (≥1 name) |
+| Names + types | `WithRowType` / `PrepareRowType` / `WithMetadata` when metadata is already known |
+| Zero columns (DML without `THEN RETURN`) | `PrepareRowType(nil)` or empty row type—not `PrepareColumnNames([])` |
+| Zero-row `SELECT` | `PrepareRowType` after first `Next`, then `Flush` for header-only CSV |
+
+Without registration and with no row written, `Flush` / `WriteHeader` return `ErrMissingColumnNames`. Registered empty schema (`len(names)==0`) is valid: `Flush` writes nothing.
+
+## go-sql-spanner and GCV slices
+
+`spanvalue` does **not** wrap `database/sql` or `*sql.Rows`. Apps decode rows to `[]spanner.GenericColumnValue` and call `WriteGCVs`, registering columns with `WithColumnNames` or `WithMetadata` when available.
+
+**Adoption boundary and recipes** (scan loop, `DelimitedGCVExportOptions`, native client vs GCV path): [root README — go-sql-spanner and GenericColumnValue export](../README.md#go-sql-spanner-and-genericcolumnvalue-export).
+
+Match out-of-band headers with [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames) and the same `UnnamedFieldNamer` as `WithUnnamedFieldNamer`.
+
+## Formats and edge cases
+
+- **Quoted TSV:** `NewDelimitedWriter(out, '\t')` uses CSV escaping, not raw tab joins. Legacy raw TAB: implement `Writer` or `RowIteratorWriter` and join formatted columns with `'\t'`.
+- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. After any write error from `SQLInsertWriter`, discard the writer.
+- **Delimited vs JSONL vs SQL:** spanvalue formats each cell; encodings differ afterward. One-shot helpers: `FormatDelimitedRow`, `FormatJSONLRow`, `RowData`.
+
+## Future module split
+
+`writer` may move to a **separate Go module** in a later release while staying in this repository path during transition. For **v0.5.x**, treat exported `writer` APIs as stable within semver pre-release rules; importers should pin versions and run their own export golden tests when upgrading. Formatting behavior remains in the root `spanvalue` module—only the import path would change if split.

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -1,0 +1,54 @@
+// Package writer streams Spanner query results to delimited text, JSONL, or SQL INSERT
+// using [github.com/apstndb/spanvalue] formatters.
+//
+// Main types: [DelimitedWriter], [JSONLWriter], [SQLInsertWriter], and the [Writer] /
+// [FlushWriter] interfaces. Register column schema with [WithColumnNames], [WithRowType],
+// or [WithMetadata] (or [PrepareRowType] / [PrepareColumnNames] after construction).
+// [DelimitedWriter] buffers through encoding/csv—call [Flusher.Flush] after the final row.
+//
+// Extended documentation, RowIterator recipes, and module-split notes:
+// https://github.com/apstndb/spanvalue/blob/main/writer/README.md
+//
+// # RowIterator
+//
+// [WriteRowIterator] targets built-in [RowIteratorWriter] implementations
+// ([DelimitedWriter], [JSONLWriter], [SQLInsertWriter]) via [RowIteratorHooksFromWriter].
+// [RunRowIterator] is the extension point for other sinks: supply [RowIteratorHooks] built with
+// [NewRowIteratorHooks] and the With* setters, or decorate with [WithRowOrdinal],
+// [ObserveWriteRow], and [AfterEachSuccessfulWriteRow]. Both helpers call [cloud.google.com/go/spanner.RowIterator.Stop]
+// and return [RowIteratorResult] (metadata, stats, [RowIteratorResult.RowsRead]).
+//
+// For manual [cloud.google.com/go/spanner.RowIterator.Next] loops, register
+// [RowIteratorWriter.PrepareRowType] after the first Next when results may be empty;
+// propagate [Flusher.Flush] errors (do not defer Flush).
+//
+// # Direct writers vs hooks
+//
+// Prefer [WriteRowIterator] when the destination is a package writer. Prefer [RunRowIterator]
+// when formatting or export logic should stay outside spanvalue. Prefer [WriteRow] or
+// [WriteGCVs] without RowIterator when the app already owns iteration (for example
+// [database/sql] scans—see the root README go-sql-spanner section).
+//
+// [DelimitedGCVExportOptions] and [JSONLGCVExportOptions] group metadata, formatter,
+// and unnamed-field namer options for GCV slice export.
+//
+// # Quoted delimited text vs raw tab-separated
+//
+// [DelimitedWriter] uses encoding/csv rules (RFC 4180-style). [NewDelimitedWriter] with
+// delimiter '\t' produces quoted TSV, not a raw join of formatted strings. Legacy raw TAB
+// export can implement [Writer] or [RowIteratorWriter] and join columns with '\t'.
+//
+// # Column names and registered schema
+//
+// [WriteGCVs] and [WriteStructValues] require prior name/type registration.
+// [WriteRow] and [WriteValues] supply names per call. Writers distinguish missing schema
+// from registered zero-column schema; see [ErrMissingColumnNames]. [WithMetadata] from a
+// [cloud.google.com/go/spanner.RowIterator] before the first Next registers an empty schema—
+// use [PrepareRowType] after the first Next or [WriteRowIterator] instead.
+//
+// # SQL INSERT
+//
+// [NewSQLInsertWriter] accepts [WithSQLInsertKind], [WithSQLDialect], and [WithSQLBatchSize].
+// After any write error from [SQLInsertWriter], discard the writer. [SQLInsertWriter.Flush]
+// closes a partial batch when batching.
+package writer

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -3,8 +3,9 @@
 //
 // Main types: [DelimitedWriter], [JSONLWriter], [SQLInsertWriter], and the [Writer] /
 // [FlushWriter] interfaces. Register column schema with [WithColumnNames], [WithRowType],
-// or [WithMetadata] (or [PrepareRowType] / [PrepareColumnNames] after construction).
-// [DelimitedWriter] buffers through encoding/csv—call [Flusher.Flush] after the final row.
+// or [WithMetadata] (or [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames]
+// after construction). [DelimitedWriter] buffers through encoding/csv—call [Flusher.Flush]
+// after the final row.
 //
 // Extended documentation, RowIterator recipes, and module-split notes:
 // https://github.com/apstndb/spanvalue/blob/main/writer/README.md
@@ -15,19 +16,20 @@
 // ([DelimitedWriter], [JSONLWriter], [SQLInsertWriter]) via [RowIteratorHooksFromWriter].
 // [RunRowIterator] is the extension point for other sinks: supply [RowIteratorHooks] built with
 // [NewRowIteratorHooks] and the With* setters, or decorate with [WithRowOrdinal],
-// [ObserveWriteRow], and [AfterEachSuccessfulWriteRow]. Both helpers call [cloud.google.com/go/spanner.RowIterator.Stop]
-// and return [RowIteratorResult] (metadata, stats, [RowIteratorResult.RowsRead]).
+// [ObserveWriteRow], and [AfterEachSuccessfulWriteRow]. Both helpers call
+// [*cloud.google.com/go/spanner.RowIterator.Stop] and return [RowIteratorResult] (metadata, stats,
+// [RowIteratorResult.RowsRead]).
 //
-// For manual [cloud.google.com/go/spanner.RowIterator.Next] loops, register
+// For manual [*cloud.google.com/go/spanner.RowIterator.Next] loops, register
 // [RowIteratorWriter.PrepareRowType] after the first Next when results may be empty;
 // propagate [Flusher.Flush] errors (do not defer Flush).
 //
 // # Direct writers vs hooks
 //
 // Prefer [WriteRowIterator] when the destination is a package writer. Prefer [RunRowIterator]
-// when formatting or export logic should stay outside spanvalue. Prefer [WriteRow] or
-// [WriteGCVs] without RowIterator when the app already owns iteration (for example
-// [database/sql] scans—see the root README go-sql-spanner section).
+// when formatting or export logic should stay outside spanvalue. Prefer [Writer.WriteRow] or
+// [*DelimitedWriter.WriteGCVs] without RowIterator when the app already owns iteration (for
+// example [database/sql] scans—see the root README go-sql-spanner section).
 //
 // [DelimitedGCVExportOptions] and [JSONLGCVExportOptions] group metadata, formatter,
 // and unnamed-field namer options for GCV slice export.
@@ -40,15 +42,16 @@
 //
 // # Column names and registered schema
 //
-// [WriteGCVs] and [WriteStructValues] require prior name/type registration.
-// [WriteRow] and [WriteValues] supply names per call. Writers distinguish missing schema
-// from registered zero-column schema; see [ErrMissingColumnNames]. [WithMetadata] from a
-// [cloud.google.com/go/spanner.RowIterator] before the first Next registers an empty schema—
-// use [PrepareRowType] after the first Next or [WriteRowIterator] instead.
+// [*DelimitedWriter.WriteGCVs] and [*DelimitedWriter.WriteStructValues] require prior
+// name/type registration. [Writer.WriteRow] and [*DelimitedWriter.WriteValues] supply names
+// per call. Writers distinguish missing schema from registered zero-column schema; see
+// [ErrMissingColumnNames]. [WithMetadata] from a [cloud.google.com/go/spanner.RowIterator]
+// before the first Next registers an empty schema—use [RowIteratorWriter.PrepareRowType] after
+// the first Next or [WriteRowIterator] instead.
 //
 // # SQL INSERT
 //
 // [NewSQLInsertWriter] accepts [WithSQLInsertKind], [WithSQLDialect], and [WithSQLBatchSize].
-// After any write error from [SQLInsertWriter], discard the writer. [SQLInsertWriter.Flush]
+// After any write error from [SQLInsertWriter], discard the writer. [*SQLInsertWriter.Flush]
 // closes a partial batch when batching.
 package writer

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -180,7 +180,7 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 //
 // When an application skips row bodies but still needs a header-only delimited finish,
 // call [RowIteratorWriter.PrepareRowType] with iter.Metadata.GetRowType() after the Next
-// loop, then [Flusher.Flush]; see README "Metadata-only finish after skipping rows".
+// loop, then [Flusher.Flush]; see package README on GitHub (writer/README.md).
 func WriteRowIterator(iter *spanner.RowIterator, w RowIteratorWriter) (*RowIteratorResult, error) {
 	if iter == nil {
 		return nil, ErrNilRowIterator

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,114 +1,3 @@
-// Package writer provides small streaming helpers for exporting Spanner rows
-// using spanvalue formatters.
-//
-// For [database/sql] clients that decode rows into
-// [][cloud.google.com/go/spanner.GenericColumnValue] (for example
-// [github.com/googleapis/go-sql-spanner]), use [DelimitedWriter.WriteGCVs].
-// Register columns with [WithColumnNames] when scan metadata supplies names.
-// [database/sql] does not expose Spanner
-// [cloud.google.com/go/spanner/apiv1/spannerpb.ResultSetMetadata].
-// Use [WithMetadata] when the app already holds metadata (for example proto decode).
-// Also set [WithFormatter] and [WithUnnamedFieldNamer].
-// Match out-of-band headers with [github.com/apstndb/spanvalue.ColumnNames] on the
-// same field list and [github.com/apstndb/spanvalue.UnnamedFieldNamer] policy.
-// See the README section "go-sql-spanner and GenericColumnValue export".
-//
-// DelimitedWriter is the primary writer for CSV-style delimited text.
-// NewCSVWriter is a thin helper for the common comma-delimited CSV case, while
-// NewDelimitedWriter accepts an explicit delimiter for TSV and other delimited
-// output. DelimitedWriter and JSONLWriter preserve explicit duplicate column
-// names. Their UnnamedFieldNamer only fills empty column names, and generated
-// names avoid collisions with existing names. DelimitedWriter buffers through
-// encoding/csv, so callers must call Flush after the final write.
-//
-// # Quoted delimited text vs raw tab-separated
-//
-// [DelimitedWriter] uses encoding/csv rules: fields that contain the delimiter,
-// double quotes, or newlines are quoted and inner quotes are doubled (RFC 4180-style).
-// [NewDelimitedWriter] with delimiter '\t' produces quoted TSV, not a raw join of
-// formatted column strings with tab characters only.
-//
-// Downstream tools that must preserve legacy TAB output (for example tab-separated
-// CLI export without CSV escaping) can implement [Writer] and format each column with
-// spanvalue, then join with '\t'. For [WriteRowIterator], implement [RowIteratorWriter]
-// ([FlushWriter] plus [RowIteratorWriter.PrepareRowType]); [Flusher.Flush] may be a no-op when no header is needed.
-//
-// [Writer] streams *spanner.Row values; concrete writers also offer WriteValues,
-// WriteGCVs, and WriteStructValues. [FlushWriter] adds Flush (required for buffered
-// DelimitedWriter). Flush does not close the underlying io.Writer.
-//
-// # Constructors
-//
-// [NewDelimitedWriter], [NewCSVWriter], [NewJSONLWriter], and [NewSQLInsertWriter]
-// return an error when an option fails (for example [WithColumnNames] with an empty
-// name list). They accept [WithFormatter] and schema options below. [WithSQLInsertKind] selects the
-// INSERT prefix (see Spanner INSERT DML syntax). [WithSQLDialect] selects identifier
-// quoting for table and column names in SQL INSERT output (GoogleSQL by default).
-// [WithSQLBatchSize] groups rows into multi-row INSERT statements. When batching,
-// call [SQLInsertWriter.Flush] after the final row to close a partial batch; Flush
-// is safe to call unconditionally (including when the last batch closed on a size
-// boundary).
-//
-// After any write error from [SQLInsertWriter.WriteRow], [SQLInsertWriter.WriteGCVs],
-// [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
-// writer and do not retry writes (same convention as [encoding/csv.Writer] after Error).
-// [RowData], [FormatDelimitedRow], and [FormatJSONLRow] format a single row without a writer.
-//
-// # Column names and field types
-//
-// Each write API either supplies schema on every call or expects it in the writer:
-//
-//   - WriteRow, WriteValues: column names and GCV types per call; no registration.
-//   - WriteGCVs: register column names before the first row; types from each GCV.
-//   - WriteStructValues: register column names and field types before the first row.
-//
-// Pre-register at construction with With* or later with Prepare* on the concrete writer.
-// Names only: [WithColumnNames], PrepareColumnNames. Names and types: [WithRowType],
-// [WithMetadata], PrepareRowType. [WithMetadata] uses metadata.GetRowType(); from a
-// [cloud.google.com/go/spanner.RowIterator], Metadata is set after the first Next.
-// The first [WriteRow] or [WriteValues] call can also register column names from a row.
-// [DelimitedWriter.Prepare], [JSONLWriter.Prepare], and [SQLInsertWriter.Prepare] are deprecated.
-//
-// # Registered schema vs missing schema
-//
-// Writers distinguish schema that was never registered from a registered schema with
-// zero column names (len(names) == 0):
-//
-//   - Not registered: no Prepare*, With*, or row has supplied names yet.
-//     [DelimitedWriter.WriteHeader], [DelimitedWriter.Flush] (with [WithHeader](true)),
-//     and [DelimitedWriter.WriteGCVs] without prior registration return [ErrMissingColumnNames].
-//   - Registered empty: [PrepareRowType] or [WithRowType] with a nil row type or a row type
-//     whose fields slice is empty (for example DML without THEN RETURN: zero rows and zero
-//     columns). [DelimitedWriter.Flush] succeeds and writes no output; [DelimitedWriter.WriteHeader]
-//     is a no-op because there are no column names. A later [WriteRow] still initializes
-//     names from the row if one arrives.
-//   - [PrepareColumnNames] requires at least one column name and returns [ErrMissingColumnNames]
-//     for an empty list. Do not use it when metadata has zero columns; use [PrepareRowType] or
-//     [WithRowType] with nil or an empty fields slice instead (for example DML without THEN RETURN).
-//   - [WithColumnNames] with an empty name list returns [ErrMissingColumnNames] at
-//     construction. Prefer [PrepareRowType] or [WithRowType] for zero-column metadata.
-//
-// [WithMetadata] registers the same names and types as [WithRowType]; call one or the other, not both.
-// Use it when metadata is already available (not iter.Metadata from a
-// [cloud.google.com/go/spanner.RowIterator] before the first Next). For streaming, call
-// [PrepareRowType] with iter.Metadata.GetRowType() after the first Next when the result may be empty
-// but still has columns (including when Next returns iterator.Done); call [DelimitedWriter.Flush]
-// after the loop and propagate its error (do not defer Flush—it returns an error).
-// [RunRowIterator] and [WriteRowIterator] run that loop, call Finish (Flush for writers),
-// and return metadata and stats (including for zero-row results).
-// When every query returns at least one row, [WriteRow] registers names from the first row.
-//
-// [DelimitedWriter] defaults to a CSV/TSV header once column names are known ([WithHeader]):
-// before the first data row, or on [DelimitedWriter.Flush] when no data row was written
-// (including zero-row SELECT when names were registered). [WithHeader](false) omits the header.
-// [DelimitedWriter.WriteHeader] forces the header earlier.
-//
-// Delimited, JSONL, and SQL encodings differ after spanvalue formats each column.
-//
-// # Compatibility constructors
-//
-// [NewDelimitedWriterWithOptions], [NewJSONLWriterWithOptions], and
-// [NewSQLInsertWriterWithOptions] forward to the primary constructors above.
 package writer
 
 import (
@@ -824,6 +713,7 @@ func (w *DelimitedWriter) resolvedNames() ([]string, error) {
 }
 
 // JSONLWriter writes one JSON object per line.
+// JSONLWriter streams one JSON object per line using [github.com/apstndb/spanvalue] JSON formatting.
 type JSONLWriter struct {
 	Formatter *spanvalue.FormatConfig
 	// Set before the first write. Once names have been resolved for the current
@@ -1039,6 +929,7 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 // After any error from [SQLInsertWriter.WriteRow], [SQLInsertWriter.WriteGCVs],
 // [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
 // writer; partial batched INSERT output may be unrecoverable on retry.
+// SQLInsertWriter streams INSERT (or INSERT OR …) statements for a fixed table.
 type SQLInsertWriter struct {
 	// Table is the qualified table name used in INSERT statements.
 	//


### PR DESCRIPTION
## Summary

- Add [`writer/README.md`](writer/README.md) for GCV/row export, `RowIterator` (`WriteRowIterator`, `RunRowIterator`, hooks, decorators, `RowsRead`), schema registration, and notes if `writer` becomes its own module.
- Add [`writer/doc.go`](writer/doc.go) with package overview (qualified doc links for pkg.go.dev), RowIterator guidance, and a link to the package README; trim duplicated package comment from `writer.go`.
- Cross-link from root [`README.md`](README.md) instead of duplicating large writer sections.
- Enable **`godoclint`** in [`.golangci.yml`](.golangci.yml) (basic + `no-unused-link`; `*_test.go` excluded) and add [`.gemini/styleguide.md`](.gemini/styleguide.md) so Code Review does not duplicate CI godoc findings.
- Move throughput benchmark godoc off the test file package comment (single package doc).

## Test plan

- [x] `make check`
- [x] CI `build` and `lint` (golangci-lint v2 `linters.settings`)