### PR TITLE
Enable errorlint, misspell, and modernize in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,14 @@
 version: "2"
 
 linters:
+  # Matches golangci-lint v2 implicit default before this file existed.
   default: standard
   enable:
     - godoclint
+    - errorlint
+    - misspell
+    # Includes forvar (loop-variable copy) and rangeint; subsumes copyloopvar for our tree.
+    - modernize
   exclusions:
     rules:
       - path: _test\.go$

--- a/common_test.go
+++ b/common_test.go
@@ -209,7 +209,6 @@ func TestFormatRowNilRow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := tt.call(); !errors.Is(err, ErrNilRow) {
@@ -246,7 +245,6 @@ func TestFormatColumnRejectsNonListComplexKinds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := SimpleFormatConfig().FormatToplevelColumn(tt.gcv)
@@ -281,7 +279,6 @@ func TestFormatColumnRejectsEmptyTypeFQN(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := LiteralFormatConfig().FormatToplevelColumn(tt.gcv)
@@ -316,7 +313,6 @@ func TestFormatColumnRejectsNilStructFieldDescriptor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := tt.fc.FormatToplevelColumn(gcv)

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -23,7 +23,6 @@ func TestQuoteIdentifier(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteIdentifier(tt.dialect, tt.input); got != tt.want {
@@ -48,7 +47,6 @@ func TestQuoteQualifiedIdentifier(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := QuoteQualifiedIdentifier(tt.dialect, tt.input); got != tt.want {

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -72,7 +72,6 @@ func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {
 	}
 
 	for _, preset := range presets {
-		preset := preset
 		t.Run(preset.name, func(t *testing.T) {
 			t.Parallel()
 			legacy := formatConfigNullableOnly(preset.fc)

--- a/format_per_type_bench_test.go
+++ b/format_per_type_bench_test.go
@@ -133,7 +133,6 @@ func BenchmarkFormatPerType(b *testing.B) {
 		values := benchCellsForCase(tc, benchCellsPerType)
 		b.Run(tc.name, func(b *testing.B) {
 			for _, preset := range benchPerTypePresets {
-				preset := preset
 				b.Run(preset.name, func(b *testing.B) {
 					benchmarkFormatCells(b, preset.fc(), values)
 				})

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -57,7 +57,6 @@ func TestNumericValueCheckedNil(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -93,7 +92,6 @@ func TestNumericValueAndPGNumericValueNilReturnTypedNull(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if diff := cmp.Diff(tt.want, tt.got, protocmp.Transform()); diff != "" {
@@ -472,7 +470,6 @@ func TestValidatedStringValueHelpers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -728,7 +725,6 @@ func TestNormalizeArrayElements(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -944,7 +940,6 @@ func TestStructValueOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -987,7 +982,6 @@ func TestStructValueOfNilFieldTypeReturnsStructFieldError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/json_test.go
+++ b/json_test.go
@@ -141,7 +141,6 @@ func TestJSONFormatConfig_InvalidRawPayload(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -159,7 +158,7 @@ func TestJSONFormatConfig_InvalidRawPayload(t *testing.T) {
 func TestFormatRowJSONObject(t *testing.T) {
 	t.Parallel()
 
-	row := lo.Must(spanner.NewRow([]string{"id", "name", "active"}, []interface{}{int64(42), "Alice", true}))
+	row := lo.Must(spanner.NewRow([]string{"id", "name", "active"}, []any{int64(42), "Alice", true}))
 	got := lo.Must(FormatRowJSONObject(JSONFormatConfig(), row, IndexedUnnamedFieldNamer))
 
 	want := `{"id":42,"name":"Alice","active":true}`
@@ -171,7 +170,7 @@ func TestFormatRowJSONObject(t *testing.T) {
 func TestFormatRowJSONObject_UnnamedColumns(t *testing.T) {
 	t.Parallel()
 
-	row := lo.Must(spanner.NewRow([]string{"", ""}, []interface{}{int64(2), "hello"}))
+	row := lo.Must(spanner.NewRow([]string{"", ""}, []any{int64(2), "hello"}))
 	got := lo.Must(FormatRowJSONObject(JSONFormatConfig(), row, IndexedUnnamedFieldNamer))
 
 	want := `{"_0":2,"_1":"hello"}`
@@ -335,7 +334,7 @@ func TestFormatRowJSONObject_Error(t *testing.T) {
 
 	t.Run("empty name", func(t *testing.T) {
 		t.Parallel()
-		row := lo.Must(spanner.NewRow([]string{""}, []interface{}{1}))
+		row := lo.Must(spanner.NewRow([]string{""}, []any{1}))
 		_, err := FormatRowJSONObject(JSONFormatConfig(), row, func(i int) string {
 			return ""
 		})
@@ -353,7 +352,7 @@ func TestFormatRowJSONObject_Error(t *testing.T) {
 		// First column is named "dup", second is unnamed.
 		// Namer returns "dup" for index 0, but it's taken by first column.
 		// Namer returns "dup" again for index 1, which should trigger an error.
-		row := lo.Must(spanner.NewRow([]string{"dup", ""}, []interface{}{1, 2}))
+		row := lo.Must(spanner.NewRow([]string{"dup", ""}, []any{1, 2}))
 		_, err := FormatRowJSONObject(JSONFormatConfig(), row, func(i int) string {
 			return "dup"
 		})

--- a/literal_test.go
+++ b/literal_test.go
@@ -48,7 +48,7 @@ func mustParseTimeString(t *testing.T, timeStr string) time.Time {
 func TestDecodeColumnLiteral(t *testing.T) {
 	for _, tt := range []struct {
 		desc  string
-		value interface{}
+		value any
 		want  string
 	}{
 		// non-nullable
@@ -500,17 +500,17 @@ func TestDecodeColumn_roundtripFloat64(t *testing.T) {
 func TestDecodeRowLiteral(t *testing.T) {
 	for _, tt := range []struct {
 		desc   string
-		values []interface{}
+		values []any
 		want   []string
 	}{
 		{
 			desc:   "non-null columns",
-			values: []interface{}{"foo", 123},
+			values: []any{"foo", 123},
 			want:   []string{`"foo"`, "123"},
 		},
 		{
 			desc:   "non-null column and null column",
-			values: []interface{}{"foo", spanner.NullString{StringVal: "", Valid: false}},
+			values: []any{"foo", spanner.NullString{StringVal: "", Valid: false}},
 			want:   []string{`"foo"`, "NULL"},
 		},
 	} {

--- a/spanner_cli_compatible_test.go
+++ b/spanner_cli_compatible_test.go
@@ -37,12 +37,12 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 )
 
-func createRow(t *testing.T, values []interface{}) *spanner.Row {
+func createRow(t *testing.T, values []any) *spanner.Row {
 	t.Helper()
 
 	// column names are not important in this test, so use dummy name
 	names := make([]string, len(values))
-	for i := 0; i < len(names); i++ {
+	for i := range names {
 		names[i] = "dummy"
 	}
 
@@ -53,10 +53,10 @@ func createRow(t *testing.T, values []interface{}) *spanner.Row {
 	return row
 }
 
-func createColumnValue(t *testing.T, value interface{}) spanner.GenericColumnValue {
+func createColumnValue(t *testing.T, value any) spanner.GenericColumnValue {
 	t.Helper()
 
-	row := createRow(t, []interface{}{value})
+	row := createRow(t, []any{value})
 	var cv spanner.GenericColumnValue
 	if err := row.Column(0, &cv); err != nil {
 		t.Fatalf("Creating spanner column value failed unexpectedly: %v", err)
@@ -72,7 +72,7 @@ func equalStringSlice(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i] != b[i] {
 			return false
 		}
@@ -87,7 +87,7 @@ type jsonMessage struct {
 func TestDecodeColumn(t *testing.T) {
 	tests := []struct {
 		desc  string
-		value interface{}
+		value any
 		want  string
 	}{
 		// non-nullable
@@ -499,17 +499,17 @@ func TestDecodeColumn(t *testing.T) {
 func TestDecodeRow(t *testing.T) {
 	tests := []struct {
 		desc   string
-		values []interface{}
+		values []any
 		want   []string
 	}{
 		{
 			desc:   "non-null columns",
-			values: []interface{}{"foo", 123},
+			values: []any{"foo", 123},
 			want:   []string{"foo", "123"},
 		},
 		{
 			desc:   "non-null column and null column",
-			values: []interface{}{"foo", spanner.NullString{StringVal: "", Valid: false}},
+			values: []any{"foo", spanner.NullString{StringVal: "", Valid: false}},
 			want:   []string{"foo", "NULL"},
 		},
 	}

--- a/writer/row_iterator_decorators_test.go
+++ b/writer/row_iterator_decorators_test.go
@@ -11,11 +11,11 @@ func TestRunRowIterator_rowsRead(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	row2, err := spanner.NewRow([]string{"id"}, []interface{}{int64(2)})
+	row2, err := spanner.NewRow([]string{"id"}, []any{int64(2)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestWithRowOrdinal(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestObserveWriteRow(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,11 +194,11 @@ func TestAfterEachSuccessfulWriteRow(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	row2, err := spanner.NewRow([]string{"id"}, []interface{}{int64(2)})
+	row2, err := spanner.NewRow([]string{"id"}, []any{int64(2)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestDecoratorResetOnQueryErrorBeforeMetadata(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestResetEachRunRunsOncePerRun(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestRowIteratorHooksExtensibility(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -121,7 +121,7 @@ func TestWriteRowIterator_withRows(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id", "name")
-	row, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(1), "a"})
+	row, err := spanner.NewRow([]string{"id", "name"}, []any{int64(1), "a"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestWriteRowIterator_writeErrorStillReturnsOutcome(t *testing.T) {
 	t.Parallel()
 
 	md := metadataWithColumnNames("id")
-	row, err := spanner.NewRow([]string{"id"}, []interface{}{int64(1)})
+	row, err := spanner.NewRow([]string{"id"}, []any{int64(1)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -361,7 +361,7 @@ func TestDelimitedWriterWriteRow(t *testing.T) {
 	var out bytes.Buffer
 	w := mustNewDelimitedWriter(t, &out, Comma)
 
-	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
+	row, err := spanner.NewRow([]string{"id", ""}, []any{int64(42), "hello"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -601,7 +601,7 @@ func TestJSONLWriterWriteRow(t *testing.T) {
 
 	var out bytes.Buffer
 	w := mustNewJSONLWriter(t, &out)
-	row, err := spanner.NewRow([]string{"id", ""}, []interface{}{int64(42), "hello"})
+	row, err := spanner.NewRow([]string{"id", ""}, []any{int64(42), "hello"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -645,7 +645,7 @@ func TestJSONLWriterWriteGCVsAfterWriteRow(t *testing.T) {
 	var out bytes.Buffer
 	w := mustNewJSONLWriter(t, &out)
 
-	row, err := spanner.NewRow([]string{"id", "name"}, []interface{}{int64(42), "hello"})
+	row, err := spanner.NewRow([]string{"id", "name"}, []any{int64(42), "hello"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -673,7 +673,7 @@ func TestJSONLWriterWriteGCVsKeepsResolvedNamesAfterNamerChange(t *testing.T) {
 	var out bytes.Buffer
 	w := mustNewJSONLWriter(t, &out)
 
-	row, err := spanner.NewRow([]string{"", ""}, []interface{}{int64(42), "hello"})
+	row, err := spanner.NewRow([]string{"", ""}, []any{int64(42), "hello"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -1133,7 +1133,7 @@ func TestSQLInsertWriterWriteRow(t *testing.T) {
 	var out bytes.Buffer
 	w := mustNewSQLInsertWriter(t, &out, "db.user`table")
 
-	row, err := spanner.NewRow([]string{"na`me", "payload"}, []interface{}{"Alice", "semi;\nline"})
+	row, err := spanner.NewRow([]string{"na`me", "payload"}, []any{"Alice", "semi;\nline"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -1285,7 +1285,7 @@ func TestSQLInsertWriterWriteGCVsEmptyTableName(t *testing.T) {
 func TestRowDataAndOneRowFormatHelpers(t *testing.T) {
 	t.Parallel()
 
-	row, err := spanner.NewRow([]string{"id", "note"}, []interface{}{int64(42), "comma, ok"})
+	row, err := spanner.NewRow([]string{"id", "note"}, []any{int64(42), "comma, ok"})
 	if err != nil {
 		t.Fatalf("spanner.NewRow() error = %v", err)
 	}
@@ -1354,7 +1354,7 @@ func TestFormatDelimitedValuesInvalidDelimiter(t *testing.T) {
 			name:      "zero in FormatDelimitedRow",
 			delimiter: 0,
 			format: func(delim rune) error {
-				row, err := spanner.NewRow(columnNames, []interface{}{"Alice"})
+				row, err := spanner.NewRow(columnNames, []any{"Alice"})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary

- Keep `default: standard` unchanged; add `errorlint`, `misspell`, and `modernize` alongside existing `godoclint`.
- Apply `modernize` fixes: drop redundant `tt := tt` / `preset := preset` copies (Go 1.22+ loop semantics), `range` over integers, and `interface{}` → `any` in tests.
- Do **not** enable `copyloopvar` separately: `modernize`’s `forvar` covers the loop-copy cases we had; benchmark `preset := preset` was only reported by `copyloopvar` before, and is removed as part of this cleanup.

## copyloopvar vs modernize

They overlap on `for _, tt := range … { tt := tt }` (`forvar` vs copyloopvar). `copyloopvar` can still flag patterns `forvar` misses (e.g. some benchmark reassignments). For this repo, enabling both would be mostly duplicate signal after the test cleanups.

## Test plan

- [x] `make check`

Made with [Cursor](https://cursor.com)