### PR TITLE
writer: unexport delimited/JSONL Formatter fields; adoption doc follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 
 - **Per-version truth:** [GitHub Releases](https://github.com/apstndb/spanvalue/releases) only—no in-repo `CHANGELOG.md`. Retroactive release edits OK with date footnote.
 - **v0.4.2:** scalar plugins (#97), `WriteRowIterator` (#98). **v0.4.3+:** SQL dialect/batch, TAB/tuple docs, SQL field deprecations—not Simple NUMERIC behavior.
-- Open follow-ups: [#79](https://github.com/apstndb/spanvalue/issues/79) (INSERT fragments; batching done), [#95](https://github.com/apstndb/spanvalue/issues/95) (options return errors), [#107](https://github.com/apstndb/spanvalue/issues/107) (breaking unexport).
+- Open follow-ups: [#79](https://github.com/apstndb/spanvalue/issues/79) (INSERT fragments; batching done). **v0.5.0 track (shipped in alpha):** constructor errors ([#95](https://github.com/apstndb/spanvalue/issues/95)), SQL INSERT field unexport ([#107](https://github.com/apstndb/spanvalue/issues/107) / [v0.5.0-alpha.2](https://github.com/apstndb/spanvalue/releases/tag/v0.5.0-alpha.2)). Stable release checklist: [#136](https://github.com/apstndb/spanvalue/issues/136).
 
 ## Git & review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 
 - **Per-version truth:** [GitHub Releases](https://github.com/apstndb/spanvalue/releases) only—no in-repo `CHANGELOG.md`. Retroactive release edits OK with date footnote.
 - **v0.4.2:** scalar plugins (#97), `WriteRowIterator` (#98). **v0.4.3+:** SQL dialect/batch, TAB/tuple docs, SQL field deprecations—not Simple NUMERIC behavior.
-- Open follow-ups: [#79](https://github.com/apstndb/spanvalue/issues/79) (INSERT fragments; batching done). **v0.5.0 track (shipped in alpha):** constructor errors ([#95](https://github.com/apstndb/spanvalue/issues/95)), SQL INSERT field unexport ([#107](https://github.com/apstndb/spanvalue/issues/107) / [v0.5.0-alpha.2](https://github.com/apstndb/spanvalue/releases/tag/v0.5.0-alpha.2)). Stable release checklist: [#136](https://github.com/apstndb/spanvalue/issues/136).
+- Open follow-ups: [#79](https://github.com/apstndb/spanvalue/issues/79) (INSERT fragments; batching done). **v0.5.0 track (shipped in alpha / pending stable tag):** constructor errors ([#95](https://github.com/apstndb/spanvalue/issues/95)), writer field unexport ([#107](https://github.com/apstndb/spanvalue/issues/107), [#140](https://github.com/apstndb/spanvalue/issues/140)). Stable release checklist: [#136](https://github.com/apstndb/spanvalue/issues/136).
 
 ## Git & review
 

--- a/writer/README.md
+++ b/writer/README.md
@@ -10,6 +10,8 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 
 **Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
 
+**Formatter:** set [`WithFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithFormatter) at construction; inspect the effective preset with [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.FormatConfig) on delimited, JSONL, or SQL INSERT writers (fields are not exported in v0.5.0+).
+
 ## RowIterator
 
 Production code with `*spanner.RowIterator` should treat metadata as **lazy**: `iter.Metadata` is populated after the first `Next()`. Do not pass `iter.Metadata` to `WithMetadata` at construction—it is still `nil`.

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -341,6 +341,7 @@ type formatterOption struct {
 }
 
 // WithFormatter sets the FormatConfig used by a writer.
+// For [SQLInsertWriter], a nil formatter selects [spanvalue.LiteralFormatConfig].
 func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -341,18 +341,29 @@ type formatterOption struct {
 }
 
 // WithFormatter sets the FormatConfig used by a writer.
-// For [SQLInsertWriter], a nil formatter selects [spanvalue.LiteralFormatConfig].
+// A nil formatter selects the writer-type default:
+// [DelimitedWriter] uses [spanvalue.SimpleFormatConfig],
+// [JSONLWriter] uses [spanvalue.JSONFormatConfig],
+// and [SQLInsertWriter] uses [spanvalue.LiteralFormatConfig].
 func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}
 }
 
 func (o formatterOption) applyDelimitedOption(w *DelimitedWriter) error {
-	w.Formatter = o.formatter
+	if o.formatter != nil {
+		w.formatter = o.formatter
+	} else {
+		w.formatter = spanvalue.SimpleFormatConfig()
+	}
 	return nil
 }
 
 func (o formatterOption) applyJSONLOption(w *JSONLWriter) error {
-	w.Formatter = o.formatter
+	if o.formatter != nil {
+		w.formatter = o.formatter
+	} else {
+		w.formatter = spanvalue.JSONFormatConfig()
+	}
 	return nil
 }
 
@@ -422,7 +433,7 @@ func (s *columnSchema) applyNamesOnly(names []string) {
 // DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
 // Header controls automatic header output; see [WithHeader] and [DelimitedWriter.WriteHeader].
 type DelimitedWriter struct {
-	Formatter *spanvalue.FormatConfig
+	formatter *spanvalue.FormatConfig
 	// Header enables a header line before the first data row when true (default).
 	// See [WithHeader].
 	Header bool
@@ -447,7 +458,7 @@ func NewCSVWriter(out io.Writer, opts ...DelimitedOption) (*DelimitedWriter, err
 
 func newDelimitedWriter(out io.Writer) *DelimitedWriter {
 	return &DelimitedWriter{
-		Formatter:         spanvalue.SimpleFormatConfig(),
+		formatter:         spanvalue.SimpleFormatConfig(),
 		Header:            true,
 		UnnamedFieldNamer: spanvalue.IndexedUnnamedFieldNamer,
 		out:               out,
@@ -592,7 +603,7 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 		return ErrMissingColumnNames
 	}
 
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.delimitedFormatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -647,11 +658,18 @@ func (w *DelimitedWriter) initOrValidateColumnNames(columnNames []string) error 
 	return nil
 }
 
-func (w *DelimitedWriter) formatter() *spanvalue.FormatConfig {
-	if w.Formatter != nil {
-		return w.Formatter
+// FormatConfig returns the effective formatter used for delimited value cells.
+// When no formatter is configured, this returns [spanvalue.SimpleFormatConfig].
+// Configure it only via [NewDelimitedWriter], [NewCSVWriter], or [WithFormatter].
+func (w *DelimitedWriter) FormatConfig() *spanvalue.FormatConfig {
+	return w.delimitedFormatter()
+}
+
+func (w *DelimitedWriter) delimitedFormatter() *spanvalue.FormatConfig {
+	if w.formatter == nil {
+		return spanvalue.SimpleFormatConfig()
 	}
-	return spanvalue.SimpleFormatConfig()
+	return w.formatter
 }
 
 func (w *DelimitedWriter) csvWriter() (*csv.Writer, error) {
@@ -720,7 +738,7 @@ func (w *DelimitedWriter) resolvedNames() ([]string, error) {
 // JSONLWriter writes one JSON object per line.
 // JSONLWriter streams one JSON object per line using [github.com/apstndb/spanvalue] JSON formatting.
 type JSONLWriter struct {
-	Formatter *spanvalue.FormatConfig
+	formatter *spanvalue.FormatConfig
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached object keys.
 	UnnamedFieldNamer spanvalue.UnnamedFieldNamer
@@ -752,7 +770,7 @@ func NewJSONLWriterWithOptions(out io.Writer, options ...JSONLOption) (*JSONLWri
 
 func newJSONLWriter(out io.Writer) *JSONLWriter {
 	return &JSONLWriter{
-		Formatter:         spanvalue.JSONFormatConfig(),
+		formatter:         spanvalue.JSONFormatConfig(),
 		UnnamedFieldNamer: spanvalue.IndexedUnnamedFieldNamer,
 		out:               out,
 	}
@@ -840,7 +858,7 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 		}
 		return ErrMissingColumnNames
 	}
-	formattedValues, err := spanvalue.FormatRowColumns(w.formatter(), w.schema.names, values)
+	formattedValues, err := spanvalue.FormatRowColumns(w.jsonlFormatter(), w.schema.names, values)
 	if err != nil {
 		return err
 	}
@@ -895,11 +913,18 @@ func (w *JSONLWriter) initOrValidateColumnNames(columnNames []string) error {
 	return nil
 }
 
-func (w *JSONLWriter) formatter() *spanvalue.FormatConfig {
-	if w.Formatter != nil {
-		return w.Formatter
+// FormatConfig returns the effective formatter used for JSONL value encoding.
+// When no formatter is configured, this returns [spanvalue.JSONFormatConfig].
+// Configure it only via [NewJSONLWriter] or [WithFormatter].
+func (w *JSONLWriter) FormatConfig() *spanvalue.FormatConfig {
+	return w.jsonlFormatter()
+}
+
+func (w *JSONLWriter) jsonlFormatter() *spanvalue.FormatConfig {
+	if w.formatter == nil {
+		return spanvalue.JSONFormatConfig()
 	}
-	return spanvalue.JSONFormatConfig()
+	return w.formatter
 }
 
 func (w *JSONLWriter) resolvedNames() ([]string, error) {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -166,6 +166,44 @@ func TestDelimitedWriterWithOptions(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterFormatConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := spanvalue.LiteralFormatConfig()
+	w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',', WithFormatter(cfg))
+	if w.FormatConfig() != cfg {
+		t.Fatalf("FormatConfig() = %p, want %p", w.FormatConfig(), cfg)
+	}
+
+	nilFormatterW := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',', WithFormatter(nil))
+	gotFormatter := nilFormatterW.FormatConfig()
+	if gotFormatter == nil {
+		t.Fatal("FormatConfig() with nil formatter = nil, want effective simple formatter")
+	}
+	if nilFormatterW.FormatConfig() != gotFormatter {
+		t.Fatal("FormatConfig() should return the same cached formatter on repeat calls")
+	}
+}
+
+func TestJSONLWriterFormatConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := spanvalue.LiteralFormatConfig()
+	w := mustNewJSONLWriter(t, &bytes.Buffer{}, WithFormatter(cfg))
+	if w.FormatConfig() != cfg {
+		t.Fatalf("FormatConfig() = %p, want %p", w.FormatConfig(), cfg)
+	}
+
+	nilFormatterW := mustNewJSONLWriter(t, &bytes.Buffer{}, WithFormatter(nil))
+	gotFormatter := nilFormatterW.FormatConfig()
+	if gotFormatter == nil {
+		t.Fatal("FormatConfig() with nil formatter = nil, want effective JSON formatter")
+	}
+	if nilFormatterW.FormatConfig() != gotFormatter {
+		t.Fatal("FormatConfig() should return the same cached formatter on repeat calls")
+	}
+}
+
 func TestDelimitedWriterWriteValuesZeroDelimiterInvalid(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- **#140:** Unexport `DelimitedWriter` and `JSONLWriter` formatter fields (same pattern as #107 / SQL INSERT). Use `WithFormatter` at construction and `FormatConfig()` for inspection.
- **#141:** Update `AGENTS.md` for v0.5.0 track; expand `WithFormatter` godoc for nil defaults on all writer types (Gemini review).
- Retroactive [v0.5.0-alpha.2](https://github.com/apstndb/spanvalue/releases/tag/v0.5.0-alpha.2) release notes already edited on GitHub (WithTable fix, `writer/README` link).

Closes #140.

## Breaking (v0.5.0)

- `DelimitedWriter.Formatter` and `JSONLWriter.Formatter` no longer exported.
- Migration: `writer.WithFormatter(cfg)` + `w.FormatConfig()` (same as SQL INSERT since alpha.2).

Adoption trials (execspansql, spannersh, spanner-mycli) already use constructor/options only.

## Test plan

- [x] `make check`