### PR TITLE
docs(writer): clarify RowIterator ownership for helper APIs

### DIFF
--- a/writer/README.md
+++ b/writer/README.md
@@ -23,7 +23,21 @@ Production code with `*spanner.RowIterator` should treat metadata as **lazy**: `
 | Manual loop (every query has ≥1 row) | `iter.Do` + `WriteRow`, or `PrepareRowType` after first `Next` then `WriteRow` + `return w.Flush()` |
 | Zero-row `SELECT` (columns in metadata) | `WriteRowIterator` / `RunRowIterator`, or `PrepareRowType` after first `Next` then `Flush` |
 
-[`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) wires [`RowIteratorHooksFromWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooksFromWriter): `PrepareRowType` from metadata, `WriteRow` per data row, `Flush` in `Finish`. It always calls `iter.Stop()` and returns [`RowIteratorResult`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorResult) (metadata, query stats, [`RowsRead`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorResult.RowsRead)).
+### Iterator ownership
+
+[`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) and [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator) **own** the iterator passed in: they consume it, call `iter.Stop()`, and return [`RowIteratorResult`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorResult) for post-run metadata and stats.
+
+Prefer passing a newly created iterator directly—do not bind it and `defer iter.Stop()` at the call site:
+
+```go
+result, err := writer.WriteRowIterator(txn.Query(ctx, stmt), w)
+```
+
+After the helper returns, use `result.Metadata`, `result.Stats`, and `result.RowsRead`. Do not read `iter.Metadata`, `iter.QueryStats`, `iter.RowCount`, or `iter.QueryPlan` on the transferred iterator; reading those fields after `Stop()` does not panic in current Spanner client releases, but the helper owns lifecycle and the returned result is the supported API.
+
+**Manual loops** differ: bind `iter := txn.Query(ctx, stmt)`, `defer iter.Stop()`, consume rows yourself, and read iterator fields only after reaching `iterator.Done`.
+
+[`WriteRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WriteRowIterator) wires [`RowIteratorHooksFromWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooksFromWriter): `PrepareRowType` from metadata, `WriteRow` per data row, `Flush` in `Finish`.
 
 [`RunRowIterator`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RunRowIterator) is the extension point for non-`RowIteratorWriter` sinks:
 
@@ -42,13 +56,11 @@ Construct hooks with [`NewRowIteratorHooks`](https://pkg.go.dev/github.com/apstn
 `RowsRead` counts successful `WriteRow` hook calls; it differs from [`RowIteratorStats.RowCount`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorStats.RowCount) (Spanner DML semantics). Decorators that only observe rows may call [`MarkOmitRowsRead`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks.MarkOmitRowsRead) so side-effect-only `WriteRow` wrappers do not increment `RowsRead`.
 
 ```go
-iter := txn.QueryWithStats(ctx, stmt)
-
 w, err := writer.NewDelimitedWriter(out, '\t', writer.WithFormatter(cfg), writer.WithHeader(true))
 if err != nil {
 	return err
 }
-result, err := writer.WriteRowIterator(iter, w)
+result, err := writer.WriteRowIterator(txn.QueryWithStats(ctx, stmt), w)
 if err != nil {
 	return err
 }
@@ -57,7 +69,7 @@ _ = result.Stats.QueryStats
 ```
 
 ```go
-result, err := writer.RunRowIterator(iter, writer.NewRowIteratorHooks().
+result, err := writer.RunRowIterator(txn.Query(ctx, stmt), writer.NewRowIteratorHooks().
 	WithPrepareMetadata(func(md *spannerpb.ResultSetMetadata) error {
 		return sink.Init(md)
 	}).
@@ -71,7 +83,7 @@ result, err := writer.RunRowIterator(iter, writer.NewRowIteratorHooks().
 
 When the app consumes `Next` but skips row bodies, register `PrepareRowType(iter.Metadata.GetRowType())` after the loop, then `Flush` for a header-only delimited export—see package godoc.
 
-**Manual loops:** propagate `Flush()` errors (`return w.Flush()`, not `defer w.Flush()`). When driving `Next` yourself, `defer iter.Stop()`.
+**Manual loops:** bind the iterator, `defer iter.Stop()`, propagate `Flush()` errors (`return w.Flush()`, not `defer w.Flush()`), and read metadata or stats only after consuming to `iterator.Done`.
 
 ## Schema registration
 

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -16,13 +16,16 @@
 // ([DelimitedWriter], [JSONLWriter], [SQLInsertWriter]) via [RowIteratorHooksFromWriter].
 // [RunRowIterator] is the extension point for other sinks: supply [RowIteratorHooks] built with
 // [NewRowIteratorHooks] and the With* setters, or decorate with [WithRowOrdinal],
-// [ObserveWriteRow], and [AfterEachSuccessfulWriteRow]. Both helpers call
-// [*cloud.google.com/go/spanner.RowIterator.Stop] and return [RowIteratorResult] (metadata, stats,
-// [RowIteratorResult.RowsRead]).
+// [ObserveWriteRow], and [AfterEachSuccessfulWriteRow]. Both helpers own the iterator they
+// receive: they consume it, call [*cloud.google.com/go/spanner.RowIterator.Stop], and return
+// [RowIteratorResult] (metadata, stats, [RowIteratorResult.RowsRead]). Prefer passing a
+// newly created iterator directly (for example txn.Query(ctx, stmt)); do not defer Stop at
+// the call site. Use the returned result for post-run metadata and stats.
 //
-// For manual [*cloud.google.com/go/spanner.RowIterator.Next] loops, register
-// [RowIteratorWriter.PrepareRowType] after the first Next when results may be empty;
-// propagate [Flusher.Flush] errors (do not defer Flush).
+// For manual [*cloud.google.com/go/spanner.RowIterator.Next] loops, bind the iterator,
+// defer Stop, register [RowIteratorWriter.PrepareRowType] after the first Next when results
+// may be empty, and read metadata or stats only after consuming to [iterator.Done]; propagate
+// [Flusher.Flush] errors (do not defer Flush).
 //
 // # Direct writers vs hooks
 //

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -24,7 +24,7 @@
 //
 // For manual [*cloud.google.com/go/spanner.RowIterator.Next] loops, bind the iterator,
 // defer Stop, register [RowIteratorWriter.PrepareRowType] after the first Next when results
-// may be empty, and read metadata or stats only after consuming to [iterator.Done]; propagate
+// may be empty, and read metadata or stats only after consuming to [google.golang.org/api/iterator.Done]; propagate
 // [Flusher.Flush] errors (do not defer Flush).
 //
 // # Direct writers vs hooks

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -158,7 +158,7 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 }
 
 // RunRowIterator streams all rows from iter using hooks. The helper owns iter:
-// it consumes the iterator, always calls [spanner.RowIterator.Stop] on return,
+// it consumes the iterator, always calls [*spanner.RowIterator.Stop] on return,
 // and returns metadata and stats through [RowIteratorResult].
 //
 // Prefer passing a newly created iterator directly, without binding it at the
@@ -166,7 +166,7 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 //
 //	result, err := RunRowIterator(txn.Query(ctx, stmt), hooks)
 //
-// Do not call [spanner.RowIterator.Stop] on iter after RunRowIterator returns;
+// Do not call [*spanner.RowIterator.Stop] on iter after RunRowIterator returns;
 // the helper already stopped it. Use the returned [RowIteratorResult] for
 // metadata, query stats, and row counts—not iter.Metadata, iter.QueryStats,
 // iter.RowCount, or iter.QueryPlan after the call. Reading those fields after
@@ -192,7 +192,7 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 //
 // When an application drives [cloud.google.com/go/spanner.RowIterator.Next] directly
 // (instead of [WriteRowIterator] or [RunRowIterator]), bind the iterator, call
-// [cloud.google.com/go/spanner.RowIterator.Stop] on return (typically defer iter.Stop()),
+// [*cloud.google.com/go/spanner.RowIterator.Stop] on return (typically defer iter.Stop()),
 // and read metadata or stats fields only after consuming rows to [iterator.Done].
 //
 // When an application skips row bodies but still needs a header-only delimited finish,

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -157,8 +157,21 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 		})
 }
 
-// RunRowIterator streams all rows from iter using hooks. It always calls
-// [spanner.RowIterator.Stop] on return.
+// RunRowIterator streams all rows from iter using hooks. The helper owns iter:
+// it consumes the iterator, always calls [spanner.RowIterator.Stop] on return,
+// and returns metadata and stats through [RowIteratorResult].
+//
+// Prefer passing a newly created iterator directly, without binding it at the
+// call site:
+//
+//	result, err := RunRowIterator(txn.Query(ctx, stmt), hooks)
+//
+// Do not call [spanner.RowIterator.Stop] on iter after RunRowIterator returns;
+// the helper already stopped it. Use the returned [RowIteratorResult] for
+// metadata, query stats, and row counts—not iter.Metadata, iter.QueryStats,
+// iter.RowCount, or iter.QueryPlan after the call. Reading those fields after
+// Stop does not panic in current cloud.google.com/go/spanner releases, but the
+// iterator is transferred and the result value is the supported post-run API.
 //
 // The returned [RowIteratorResult] reflects iter.Metadata and iter stats fields
 // after Stop and the loop (including when no data rows were written). When
@@ -171,12 +184,16 @@ func RunRowIterator(iter *spanner.RowIterator, hooks RowIteratorHooks) (*RowIter
 }
 
 // WriteRowIterator streams all rows from iter into w using [RowIteratorHooksFromWriter].
-// See [RunRowIterator] for iterator metadata, stats, and zero-row behavior.
+// See [RunRowIterator] for iterator ownership, metadata, stats, and zero-row behavior.
+//
+// Prefer passing a newly created iterator directly:
+//
+//	result, err := WriteRowIterator(txn.Query(ctx, stmt), w)
 //
 // When an application drives [cloud.google.com/go/spanner.RowIterator.Next] directly
-// (instead of [WriteRowIterator] or [RunRowIterator]), call
-// [cloud.google.com/go/spanner.RowIterator.Stop] on return (typically defer iter.Stop())
-// so streams and resources are released.
+// (instead of [WriteRowIterator] or [RunRowIterator]), bind the iterator, call
+// [cloud.google.com/go/spanner.RowIterator.Stop] on return (typically defer iter.Stop()),
+// and read metadata or stats fields only after consuming rows to [iterator.Done].
 //
 // When an application skips row bodies but still needs a header-only delimited finish,
 // call [RowIteratorWriter.PrepareRowType] with iter.Metadata.GetRowType() after the Next

--- a/writer/row_iterator.go
+++ b/writer/row_iterator.go
@@ -158,7 +158,7 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 }
 
 // RunRowIterator streams all rows from iter using hooks. The helper owns iter:
-// it consumes the iterator, always calls [*spanner.RowIterator.Stop] on return,
+// it consumes the iterator, always calls [*cloud.google.com/go/spanner.RowIterator.Stop] on return,
 // and returns metadata and stats through [RowIteratorResult].
 //
 // Prefer passing a newly created iterator directly, without binding it at the
@@ -166,7 +166,7 @@ func RowIteratorHooksFromWriter(w RowIteratorWriter) RowIteratorHooks {
 //
 //	result, err := RunRowIterator(txn.Query(ctx, stmt), hooks)
 //
-// Do not call [*spanner.RowIterator.Stop] on iter after RunRowIterator returns;
+// Do not call [*cloud.google.com/go/spanner.RowIterator.Stop] on iter after RunRowIterator returns;
 // the helper already stopped it. Use the returned [RowIteratorResult] for
 // metadata, query stats, and row counts—not iter.Metadata, iter.QueryStats,
 // iter.RowCount, or iter.QueryPlan after the call. Reading those fields after


### PR DESCRIPTION
## Summary

- Document that `WriteRowIterator` and `RunRowIterator` **own** the passed `*spanner.RowIterator`: they consume it, call `Stop()`, and return `RowIteratorResult` for post-run metadata and stats.
- Prefer passing a newly created iterator directly (for example `txn.Query(ctx, stmt)`) instead of binding `iter` and `defer iter.Stop()` at the call site.
- Clarify that manual `Next` loops remain different: bind the iterator, `defer iter.Stop()`, and read metadata or stats only after consuming to `iterator.Done`.
- Update `writer/README.md` examples to use direct `txn.Query` / `txn.QueryWithStats` passing.

Fixes #144

## Test plan

- [x] `make check`


Made with [Cursor](https://cursor.com)