### PR TITLE
feat: configurable literal string quoting for SQL export

### DIFF
--- a/common.go
+++ b/common.go
@@ -206,11 +206,13 @@ type FormatConfig struct {
 	FormatComplexPlugins []FormatComplexFunc
 	FormatNullable       FormatNullableFunc
 	// Literal holds options for the literal preset only ([LiteralFormatOptions]).
-	// Consulted when FormatNullable is the preset formatNullableValueLiteral (including the
-	// formatSimpleColumn slow-path intercept). Custom FormatNullable callbacks ignore this field.
-	// Other presets leave Literal at the zero value. Quote zero value is legacy suitableQuote
-	// behavior (QuoteLegacy + PreferredDoubleQuote). Stored Quote values are normalized for
-	// invalid enum values only. Escaping uses GoogleSQL backslash rules; not PostgreSQL (#126).
+	// Quote is read when FormatNullable is the preset formatNullableValueLiteral (including the
+	// formatSimpleColumn slow-path intercept) and by literal preset complex plugins such as
+	// [FormatLiteralValue] and [FormatProtoAsCast]. Custom FormatNullable callbacks do not
+	// consult this field. Other presets leave Literal at the zero value. Quote zero value is
+	// legacy suitableQuote behavior (QuoteLegacy + PreferredDoubleQuote). Invalid enum values
+	// are normalized when literal options are applied and again when Quote is read at format
+	// time. Escaping uses GoogleSQL backslash rules; not PostgreSQL (#126).
 	Literal LiteralFormatOptions
 }
 

--- a/common.go
+++ b/common.go
@@ -116,7 +116,7 @@ func (fc *FormatConfig) formatSimpleColumn(value spanner.GenericColumnValue) (st
 		return "", err
 	}
 	if nullableFuncsEqual(fc.FormatNullable, formatNullableValueLiteral) {
-		return formatNullableValueLiteralWithQuote(fc.LiteralQuote, nv)
+		return formatNullableValueLiteralWithQuote(fc.Literal.Quote, nv)
 	}
 	return fc.FormatNullable(nv)
 }
@@ -205,13 +205,13 @@ type FormatConfig struct {
 	FormatStruct         FormatStruct
 	FormatComplexPlugins []FormatComplexFunc
 	FormatNullable       FormatNullableFunc
-	// LiteralQuote configures string and bytes literal quoting for the literal preset only.
+	// Literal holds options for the literal preset only ([LiteralFormatOptions]).
 	// Consulted when FormatNullable is the preset formatNullableValueLiteral (including the
 	// formatSimpleColumn slow-path intercept). Custom FormatNullable callbacks ignore this field.
-	// The zero value is legacy suitableQuote behavior (QuoteLegacy + PreferredDoubleQuote).
-	// Stored values are normalized for invalid enum values only.
-	// Escaping uses GoogleSQL backslash rules (outer delimiter only); not PostgreSQL (#126).
-	LiteralQuote LiteralQuoteConfig
+	// Other presets leave Literal at the zero value. Quote zero value is legacy suitableQuote
+	// behavior (QuoteLegacy + PreferredDoubleQuote). Stored Quote values are normalized for
+	// invalid enum values only. Escaping uses GoogleSQL backslash rules; not PostgreSQL (#126).
+	Literal LiteralFormatOptions
 }
 
 type FormatStruct struct {

--- a/common.go
+++ b/common.go
@@ -115,6 +115,9 @@ func (fc *FormatConfig) formatSimpleColumn(value spanner.GenericColumnValue) (st
 	if err != nil {
 		return "", err
 	}
+	if nullableFuncsEqual(fc.FormatNullable, formatNullableValueLiteral) {
+		return formatNullableValueLiteralWithQuote(fc.LiteralQuote, nv)
+	}
 	return fc.FormatNullable(nv)
 }
 
@@ -150,7 +153,8 @@ func FormatProtoAsCast(formatter Formatter, value spanner.GenericColumnValue, to
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("CAST(%v AS `%v`)", internal.ToReadableBytesLiteral(b), typeFQN), nil
+	policy := toInternalQuotePolicy(literalQuoteForFormatter(formatter))
+	return fmt.Sprintf("CAST(%v AS `%v`)", internal.ToReadableBytesLiteralPolicy(b, policy), typeFQN), nil
 }
 
 func FormatEnumAsCast(formatter Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
@@ -201,6 +205,13 @@ type FormatConfig struct {
 	FormatStruct         FormatStruct
 	FormatComplexPlugins []FormatComplexFunc
 	FormatNullable       FormatNullableFunc
+	// LiteralQuote configures string and bytes literal quoting for the literal preset only.
+	// Consulted when FormatNullable is the preset formatNullableValueLiteral (including the
+	// formatSimpleColumn slow-path intercept). Custom FormatNullable callbacks ignore this field.
+	// The zero value is legacy suitableQuote behavior (QuoteLegacy + PreferredDoubleQuote).
+	// Stored values are normalized for invalid enum values only.
+	// Escaping uses GoogleSQL backslash rules (outer delimiter only); not PostgreSQL (#126).
+	LiteralQuote LiteralQuoteConfig
 }
 
 type FormatStruct struct {

--- a/doc.go
+++ b/doc.go
@@ -6,8 +6,11 @@
 // # Primary API
 //
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
-// [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig], and [JSONFormatConfig] to pick
-// a preset. Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
+// [LiteralFormatConfigWithQuote], [LiteralFormatConfigWithSingleQuotedLiterals],
+// [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
+// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.LiteralQuote]
+// on the literal preset (string/bytes delimiter policy for SQL-style literals).
+// Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from
 // [FormatConfig.FormatComplexPlugins] to use Decode + [FormatNullable].

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
 // [LiteralFormatConfigWithQuote], [LiteralFormatConfigWithSingleQuotedLiterals],
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
-// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.Literal].Quote
+// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig].Literal.Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
 // [LiteralFormatConfigWithQuote], [LiteralFormatConfigWithSingleQuotedLiterals],
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
-// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.LiteralQuote]
+// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.Literal.Quote]
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 // Configure output with [FormatConfig]. Use the constructors [LiteralFormatConfig],
 // [LiteralFormatConfigWithQuote], [LiteralFormatConfigWithSingleQuotedLiterals],
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
-// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.Literal.Quote]
+// and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig.Literal].Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -175,7 +175,6 @@ func formatGCVScalarLiteral(q LiteralQuoteConfig, gcv spanner.GenericColumnValue
 	if err := validateScalarWire(gcv); err != nil {
 		return "", err
 	}
-	policy := toInternalQuotePolicy(q)
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
@@ -190,34 +189,34 @@ func formatGCVScalarLiteral(q LiteralQuoteConfig, gcv spanner.GenericColumnValue
 		if err != nil {
 			return "", err
 		}
-		return internal.Float32ToLiteralPolicy(f, policy), nil
+		return internal.Float32ToLiteralPolicy(f, toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_FLOAT64:
 		f, err := gcvFloat64(gcv.Value)
 		if err != nil {
 			return "", err
 		}
-		return internal.Float64ToLiteralPolicy(f, policy), nil
+		return internal.Float64ToLiteralPolicy(f, toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_STRING:
-		return internal.ToStringLiteralPolicy(gcv.Value.GetStringValue(), policy), nil
+		return internal.ToStringLiteralPolicy(gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
 		b, err := internal.DecodeBase64Wire(gcv.Value.GetStringValue())
 		if err != nil {
 			return "", err
 		}
-		return internal.ToReadableBytesLiteralPolicy(b, policy), nil
+		return internal.ToReadableBytesLiteralPolicy(b, toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_TIMESTAMP:
-		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue(), q), nil
+		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_DATE:
-		return stringBasedLiteral("DATE", gcv.Value.GetStringValue(), q), nil
+		return stringBasedLiteral("DATE", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_NUMERIC:
-		return stringBasedLiteral("NUMERIC", numericWireString(gcv), q), nil
+		return stringBasedLiteral("NUMERIC", numericWireString(gcv), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_JSON:
 		s := gcv.Value.GetStringValue()
-		return stringBasedLiteral("JSON", s, q), nil
+		return stringBasedLiteral("JSON", s, toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_INTERVAL:
-		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue(), q), nil
+		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_UUID:
-		return stringLiteralCast("UUID", gcv.Value.GetStringValue(), q), nil
+		return stringLiteralCast("UUID", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -119,7 +119,8 @@ func FormatLiteralValue(formatter Formatter, value spanner.GenericColumnValue, _
 	if IsNull(value) {
 		return formatter.GetNullString(), nil
 	}
-	return formatGCVScalarLiteral(value)
+	q := literalQuoteForFormatter(formatter)
+	return formatGCVScalarLiteral(q, value)
 }
 
 // FormatSpannerCLIValue is a [FormatComplexFunc] for [SpannerCLICompatibleFormatConfig].
@@ -170,10 +171,11 @@ func formatGCVScalarSimple(gcv spanner.GenericColumnValue) (string, error) {
 	}
 }
 
-func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
+func formatGCVScalarLiteral(q LiteralQuoteConfig, gcv spanner.GenericColumnValue) (string, error) {
 	if err := validateScalarWire(gcv); err != nil {
 		return "", err
 	}
+	policy := toInternalQuotePolicy(q)
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
@@ -188,34 +190,34 @@ func formatGCVScalarLiteral(gcv spanner.GenericColumnValue) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return internal.Float32ToLiteral(f), nil
+		return internal.Float32ToLiteralPolicy(f, policy), nil
 	case sppb.TypeCode_FLOAT64:
 		f, err := gcvFloat64(gcv.Value)
 		if err != nil {
 			return "", err
 		}
-		return internal.Float64ToLiteral(f), nil
+		return internal.Float64ToLiteralPolicy(f, policy), nil
 	case sppb.TypeCode_STRING:
-		return internal.ToStringLiteral(gcv.Value.GetStringValue()), nil
+		return internal.ToStringLiteralPolicy(gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
 		b, err := internal.DecodeBase64Wire(gcv.Value.GetStringValue())
 		if err != nil {
 			return "", err
 		}
-		return internal.ToReadableBytesLiteral(b), nil
+		return internal.ToReadableBytesLiteralPolicy(b, policy), nil
 	case sppb.TypeCode_TIMESTAMP:
-		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue()), nil
+		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue(), q), nil
 	case sppb.TypeCode_DATE:
-		return stringBasedLiteral("DATE", gcv.Value.GetStringValue()), nil
+		return stringBasedLiteral("DATE", gcv.Value.GetStringValue(), q), nil
 	case sppb.TypeCode_NUMERIC:
-		return stringBasedLiteral("NUMERIC", numericWireString(gcv)), nil
+		return stringBasedLiteral("NUMERIC", numericWireString(gcv), q), nil
 	case sppb.TypeCode_JSON:
 		s := gcv.Value.GetStringValue()
-		return stringBasedLiteral("JSON", s), nil
+		return stringBasedLiteral("JSON", s, q), nil
 	case sppb.TypeCode_INTERVAL:
-		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue()), nil
+		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue(), q), nil
 	case sppb.TypeCode_UUID:
-		return stringLiteralCast("UUID", gcv.Value.GetStringValue()), nil
+		return stringLiteralCast("UUID", gcv.Value.GetStringValue(), q), nil
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -175,6 +175,7 @@ func formatGCVScalarLiteral(q LiteralQuoteConfig, gcv spanner.GenericColumnValue
 	if err := validateScalarWire(gcv); err != nil {
 		return "", err
 	}
+	policy := toInternalQuotePolicy(q)
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_BOOL:
 		return strconv.FormatBool(gcv.Value.GetBoolValue()), nil
@@ -189,34 +190,34 @@ func formatGCVScalarLiteral(q LiteralQuoteConfig, gcv spanner.GenericColumnValue
 		if err != nil {
 			return "", err
 		}
-		return internal.Float32ToLiteralPolicy(f, toInternalQuotePolicy(q)), nil
+		return internal.Float32ToLiteralPolicy(f, policy), nil
 	case sppb.TypeCode_FLOAT64:
 		f, err := gcvFloat64(gcv.Value)
 		if err != nil {
 			return "", err
 		}
-		return internal.Float64ToLiteralPolicy(f, toInternalQuotePolicy(q)), nil
+		return internal.Float64ToLiteralPolicy(f, policy), nil
 	case sppb.TypeCode_STRING:
-		return internal.ToStringLiteralPolicy(gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
+		return internal.ToStringLiteralPolicy(gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_BYTES, sppb.TypeCode_PROTO:
 		b, err := internal.DecodeBase64Wire(gcv.Value.GetStringValue())
 		if err != nil {
 			return "", err
 		}
-		return internal.ToReadableBytesLiteralPolicy(b, toInternalQuotePolicy(q)), nil
+		return internal.ToReadableBytesLiteralPolicy(b, policy), nil
 	case sppb.TypeCode_TIMESTAMP:
-		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
+		return stringBasedLiteral("TIMESTAMP", gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_DATE:
-		return stringBasedLiteral("DATE", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
+		return stringBasedLiteral("DATE", gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_NUMERIC:
-		return stringBasedLiteral("NUMERIC", numericWireString(gcv), toInternalQuotePolicy(q)), nil
+		return stringBasedLiteral("NUMERIC", numericWireString(gcv), policy), nil
 	case sppb.TypeCode_JSON:
 		s := gcv.Value.GetStringValue()
-		return stringBasedLiteral("JSON", s, toInternalQuotePolicy(q)), nil
+		return stringBasedLiteral("JSON", s, policy), nil
 	case sppb.TypeCode_INTERVAL:
-		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
+		return stringLiteralCast("INTERVAL", gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_UUID:
-		return stringLiteralCast("UUID", gcv.Value.GetStringValue(), toInternalQuotePolicy(q)), nil
+		return stringLiteralCast("UUID", gcv.Value.GetStringValue(), policy), nil
 	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
 		fallthrough
 	default:

--- a/format_max_cell_bench_test.go
+++ b/format_max_cell_bench_test.go
@@ -1,0 +1,55 @@
+package spanvalue
+
+import (
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+)
+
+// spannerMaxCellBytes is the Spanner STRING/BYTES cell-size limit (10 MiB).
+const spannerMaxCellBytes = 10 * 1024 * 1024
+
+// BenchmarkFormatMaxCell formats a single cell at Spanner's 10 MiB STRING/BYTES limit.
+//
+// Examples:
+//
+//	go test -bench='BenchmarkFormatMaxCell/STRING/Literal/Direct' -benchmem .
+//	go test -bench='BenchmarkFormatMaxCell' -benchmem -count=5 . | benchstat
+func BenchmarkFormatMaxCell(b *testing.B) {
+	strPayload := strings.Repeat("x", spannerMaxCellBytes)
+	strGCV := gcvctor.StringValue(strPayload)
+	bytesGCV := gcvctor.BytesValue([]byte(strPayload))
+
+	for _, tc := range []struct {
+		name     string
+		gcv      spanner.GenericColumnValue
+		setBytes int64
+	}{
+		{name: "STRING", gcv: strGCV, setBytes: spannerMaxCellBytes},
+		{name: "BYTES", gcv: bytesGCV, setBytes: spannerMaxCellBytes},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for _, preset := range []struct {
+				name string
+				fc   *FormatConfig
+			}{
+				{name: "Literal/Direct", fc: LiteralFormatConfig()},
+				{name: "Literal/Nullable", fc: formatConfigNullableOnly(LiteralFormatConfig())},
+				{name: "Simple/Direct", fc: SimpleFormatConfig()},
+			} {
+				b.Run(preset.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.SetBytes(tc.setBytes)
+					b.ResetTimer()
+					for range b.N {
+						if _, err := preset.fc.FormatToplevelColumn(tc.gcv); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -247,7 +247,7 @@ func ToReadableBytesLiteral(v []byte) string {
 }
 
 func ToReadableBytesLiteralPolicy(v []byte, policy QuotePolicy) string {
-	quote := quoteForPayloadBytes(policy, v)
+	quote := quoteForPayload(policy, v)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,
@@ -268,7 +268,7 @@ func ToStringLiteral(s string) string {
 }
 
 func ToStringLiteralPolicy(s string, policy QuotePolicy) string {
-	quote := quoteForPayloadString(policy, s)
+	quote := quoteForPayload(policy, s)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -247,7 +247,7 @@ func ToReadableBytesLiteral(v []byte) string {
 }
 
 func ToReadableBytesLiteralPolicy(v []byte, policy QuotePolicy) string {
-	quote := quoteForPayload(policy, v)
+	quote := quoteForPayloadBytes(policy, v)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,
@@ -268,7 +268,7 @@ func ToStringLiteral(s string) string {
 }
 
 func ToStringLiteralPolicy(s string, policy QuotePolicy) string {
-	quote := quoteForPayload(policy, s)
+	quote := quoteForPayloadString(policy, s)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -169,11 +169,11 @@ func Float64ToLiteral(v float64) string {
 func Float64ToLiteralPolicy(v float64, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(v):
-		return castQuotedLiteral("nan", "FLOAT64", nanInfCastQuote(policy))
+		return sqlCastQuotedString("nan", "FLOAT64", nonFiniteCastDelimiter(policy))
 	case math.IsInf(v, 1):
-		return castQuotedLiteral("inf", "FLOAT64", nanInfCastQuote(policy))
+		return sqlCastQuotedString("inf", "FLOAT64", nonFiniteCastDelimiter(policy))
 	case math.IsInf(v, -1):
-		return castQuotedLiteral("-inf", "FLOAT64", nanInfCastQuote(policy))
+		return sqlCastQuotedString("-inf", "FLOAT64", nonFiniteCastDelimiter(policy))
 	default:
 		return strconv.FormatFloat(v, 'g', -1, 64)
 	}
@@ -186,19 +186,20 @@ func Float32ToLiteral(v float32) string {
 func Float32ToLiteralPolicy(v float32, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(float64(v)):
-		return castQuotedLiteral("nan", "FLOAT32", nanInfCastQuote(policy))
+		return sqlCastQuotedString("nan", "FLOAT32", nonFiniteCastDelimiter(policy))
 	case math.IsInf(float64(v), 1):
-		return castQuotedLiteral("inf", "FLOAT32", nanInfCastQuote(policy))
+		return sqlCastQuotedString("inf", "FLOAT32", nonFiniteCastDelimiter(policy))
 	case math.IsInf(float64(v), -1):
-		return castQuotedLiteral("-inf", "FLOAT32", nanInfCastQuote(policy))
+		return sqlCastQuotedString("-inf", "FLOAT32", nonFiniteCastDelimiter(policy))
 	default:
 		return fmt.Sprintf("CAST(%v AS FLOAT32)", strconv.FormatFloat(float64(v), 'g', -1, 32))
 	}
 }
 
-// nanInfCastQuote selects the outer delimiter for NaN/±Inf CAST payloads.
-// Legacy keeps historical single quotes; Always and MinEscape use PreferredQuote.
-func nanInfCastQuote(policy QuotePolicy) rune {
+// nonFiniteCastDelimiter selects the outer delimiter for NaN/±Inf CAST payloads.
+// v0.5 compat: QuoteStrategyLegacy keeps historical single quotes; Always and
+// MinEscape use PreferredQuote. Planned v0.6: align with quoteForPayload.
+func nonFiniteCastDelimiter(policy QuotePolicy) rune {
 	switch policy.Strategy {
 	case QuoteStrategyAlways, QuoteStrategyMinEscape:
 		if policy.Preferred == PreferredQuoteDouble {
@@ -210,15 +211,15 @@ func nanInfCastQuote(policy QuotePolicy) rune {
 	}
 }
 
-func castQuotedLiteral(payload, typ string, quote rune) string {
+func sqlCastQuotedString(payload, castType string, quote rune) string {
 	var b strings.Builder
-	b.Grow(len(payload) + len(typ) + 12)
+	b.Grow(len(payload) + len(castType) + 12)
 	b.WriteString("CAST(")
 	b.WriteRune(quote)
 	b.WriteString(payload)
 	b.WriteRune(quote)
 	b.WriteString(" AS ")
-	b.WriteString(typ)
+	b.WriteString(castType)
 	b.WriteByte(')')
 	return b.String()
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -169,11 +169,11 @@ func Float64ToLiteral(v float64) string {
 func Float64ToLiteralPolicy(v float64, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(v):
-		return floatSpecialCastLiteral("nan", "FLOAT64", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("nan", "FLOAT64", nanInfCastQuote(policy))
 	case math.IsInf(v, 1):
-		return floatSpecialCastLiteral("inf", "FLOAT64", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("inf", "FLOAT64", nanInfCastQuote(policy))
 	case math.IsInf(v, -1):
-		return floatSpecialCastLiteral("-inf", "FLOAT64", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("-inf", "FLOAT64", nanInfCastQuote(policy))
 	default:
 		return strconv.FormatFloat(v, 'g', -1, 64)
 	}
@@ -186,17 +186,31 @@ func Float32ToLiteral(v float32) string {
 func Float32ToLiteralPolicy(v float32, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(float64(v)):
-		return floatSpecialCastLiteral("nan", "FLOAT32", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("nan", "FLOAT32", nanInfCastQuote(policy))
 	case math.IsInf(float64(v), 1):
-		return floatSpecialCastLiteral("inf", "FLOAT32", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("inf", "FLOAT32", nanInfCastQuote(policy))
 	case math.IsInf(float64(v), -1):
-		return floatSpecialCastLiteral("-inf", "FLOAT32", policy.quoteForSpecialFloatCast())
+		return castQuotedLiteral("-inf", "FLOAT32", nanInfCastQuote(policy))
 	default:
 		return fmt.Sprintf("CAST(%v AS FLOAT32)", strconv.FormatFloat(float64(v), 'g', -1, 32))
 	}
 }
 
-func floatSpecialCastLiteral(payload, typ string, quote rune) string {
+// nanInfCastQuote selects the outer delimiter for NaN/±Inf CAST payloads.
+// Legacy keeps historical single quotes; Always and MinEscape use PreferredQuote.
+func nanInfCastQuote(policy QuotePolicy) rune {
+	switch policy.Strategy {
+	case QuoteStrategyAlways, QuoteStrategyMinEscape:
+		if policy.Preferred == PreferredQuoteDouble {
+			return '"'
+		}
+		return '\''
+	default:
+		return '\''
+	}
+}
+
+func castQuotedLiteral(payload, typ string, quote rune) string {
 	var b strings.Builder
 	b.Grow(len(payload) + len(typ) + 12)
 	b.WriteString("CAST(")

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -163,29 +163,50 @@ func EscapeRune(r rune, isString bool, quote rune) string {
 }
 
 func Float64ToLiteral(v float64) string {
+	return Float64ToLiteralPolicy(v, QuotePolicy{})
+}
+
+func Float64ToLiteralPolicy(v float64, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(v):
-		return "CAST('nan' AS FLOAT64)"
+		return floatSpecialCastLiteral("nan", "FLOAT64", policy.quoteForSpecialFloatCast())
 	case math.IsInf(v, 1):
-		return "CAST('inf' AS FLOAT64)"
+		return floatSpecialCastLiteral("inf", "FLOAT64", policy.quoteForSpecialFloatCast())
 	case math.IsInf(v, -1):
-		return "CAST('-inf' AS FLOAT64)"
+		return floatSpecialCastLiteral("-inf", "FLOAT64", policy.quoteForSpecialFloatCast())
 	default:
 		return strconv.FormatFloat(v, 'g', -1, 64)
 	}
 }
 
 func Float32ToLiteral(v float32) string {
+	return Float32ToLiteralPolicy(v, QuotePolicy{})
+}
+
+func Float32ToLiteralPolicy(v float32, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(float64(v)):
-		return "CAST('nan' AS FLOAT32)"
+		return floatSpecialCastLiteral("nan", "FLOAT32", policy.quoteForSpecialFloatCast())
 	case math.IsInf(float64(v), 1):
-		return "CAST('inf' AS FLOAT32)"
+		return floatSpecialCastLiteral("inf", "FLOAT32", policy.quoteForSpecialFloatCast())
 	case math.IsInf(float64(v), -1):
-		return "CAST('-inf' AS FLOAT32)"
+		return floatSpecialCastLiteral("-inf", "FLOAT32", policy.quoteForSpecialFloatCast())
 	default:
 		return fmt.Sprintf("CAST(%v AS FLOAT32)", strconv.FormatFloat(float64(v), 'g', -1, 32))
 	}
+}
+
+func floatSpecialCastLiteral(payload, typ string, quote rune) string {
+	var b strings.Builder
+	b.Grow(len(payload) + len(typ) + 8)
+	b.WriteString("CAST(")
+	b.WriteRune(quote)
+	b.WriteString(payload)
+	b.WriteRune(quote)
+	b.WriteString(" AS ")
+	b.WriteString(typ)
+	b.WriteByte(')')
+	return b.String()
 }
 
 func ToAny[T any](seq iter.Seq[T]) iter.Seq[any] {
@@ -203,25 +224,15 @@ func Pointers[T any, E ~[]T](e E) iter.Seq[*T] {
 }
 
 func suitableQuote(b []byte) rune {
-	var hasDouble bool
-	for _, r := range b {
-		switch r {
-		case '\'':
-			return '"'
-		case '"':
-			hasDouble = true
-		}
-	}
-
-	if hasDouble {
-		return '\''
-	}
-
-	return '"'
+	return legacyQuote(b, PreferredQuoteDouble)
 }
 
 func ToReadableBytesLiteral(v []byte) string {
-	quote := suitableQuote(v)
+	return ToReadableBytesLiteralPolicy(v, QuotePolicy{})
+}
+
+func ToReadableBytesLiteralPolicy(v []byte, policy QuotePolicy) string {
+	quote := policy.quoteForPayload(v)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,
@@ -238,7 +249,11 @@ func ToReadableBytesLiteral(v []byte) string {
 }
 
 func ToStringLiteral(s string) string {
-	quote := suitableQuote([]byte(s))
+	return ToStringLiteralPolicy(s, QuotePolicy{})
+}
+
+func ToStringLiteralPolicy(s string, policy QuotePolicy) string {
+	quote := policy.quoteForPayload([]byte(s))
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -247,7 +247,7 @@ func ToReadableBytesLiteral(v []byte) string {
 }
 
 func ToReadableBytesLiteralPolicy(v []byte, policy QuotePolicy) string {
-	quote := policy.quoteForPayload(v)
+	quote := quoteForPayload(policy, v)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,
@@ -268,7 +268,7 @@ func ToStringLiteral(s string) string {
 }
 
 func ToStringLiteralPolicy(s string, policy QuotePolicy) string {
-	quote := policy.quoteForPayload([]byte(s))
+	quote := quoteForPayload(policy, s)
 
 	var encoded strings.Builder
 	// Grow uses a cheap lower bound only. Escape expansion is content-dependent,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -198,7 +198,7 @@ func Float32ToLiteralPolicy(v float32, policy QuotePolicy) string {
 
 func floatSpecialCastLiteral(payload, typ string, quote rune) string {
 	var b strings.Builder
-	b.Grow(len(payload) + len(typ) + 8)
+	b.Grow(len(payload) + len(typ) + 12)
 	b.WriteString("CAST(")
 	b.WriteRune(quote)
 	b.WriteString(payload)

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -1,5 +1,10 @@
 package internal
 
+import (
+	"bytes"
+	"strings"
+)
+
 type bytesSeq interface {
 	~string | ~[]byte
 }
@@ -27,7 +32,7 @@ type QuotePolicy struct {
 	Preferred PreferredQuote
 }
 
-func quoteForPayload[T bytesSeq](p QuotePolicy, payload T) rune {
+func quoteForPayloadString(p QuotePolicy, payload string) rune {
 	switch p.Strategy {
 	case QuoteStrategyAlways:
 		if p.Preferred == PreferredQuoteSingle {
@@ -37,32 +42,77 @@ func quoteForPayload[T bytesSeq](p QuotePolicy, payload T) rune {
 	case QuoteStrategyMinEscape:
 		return minEscapeQuote(payload, p.Preferred)
 	default:
-		return legacyQuote(payload, p.Preferred)
+		return legacyQuoteString(payload, p.Preferred)
 	}
 }
 
-// legacyQuote generalizes historical suitableQuote: when the payload contains only the
-// preferred delimiter character, use the opposite delimiter; otherwise use preferred.
-// With PreferredQuoteDouble this matches suitableQuote byte-for-byte.
-func legacyQuote[T bytesSeq](payload T, preferred PreferredQuote) rune {
+func quoteForPayloadBytes(p QuotePolicy, payload []byte) rune {
+	switch p.Strategy {
+	case QuoteStrategyAlways:
+		if p.Preferred == PreferredQuoteSingle {
+			return '\''
+		}
+		return '"'
+	case QuoteStrategyMinEscape:
+		return minEscapeQuote(payload, p.Preferred)
+	default:
+		return legacyQuoteBytes(payload, p.Preferred)
+	}
+}
+
+// quoteForPayload dispatches to typed helpers. Used by tests; hot paths call
+// quoteForPayloadString or quoteForPayloadBytes directly to avoid interface boxing.
+func quoteForPayload[T bytesSeq](p QuotePolicy, payload T) rune {
+	switch val := any(payload).(type) {
+	case string:
+		return quoteForPayloadString(p, val)
+	case []byte:
+		return quoteForPayloadBytes(p, val)
+	default:
+		panic("unreachable")
+	}
+}
+
+// legacyQuoteString generalizes historical suitableQuote for string payloads.
+func legacyQuoteString(payload string, preferred PreferredQuote) rune {
 	pref, other := byte('"'), byte('\'')
 	if preferred == PreferredQuoteSingle {
 		pref, other = '\'', '"'
 	}
-	var hasPref bool
-	for i := 0; i < len(payload); i++ {
-		b := payload[i]
-		switch b {
-		case other:
-			return rune(pref)
-		case pref:
-			hasPref = true
-		}
+	if strings.IndexByte(payload, other) >= 0 {
+		return rune(pref)
 	}
-	if hasPref {
+	if strings.IndexByte(payload, pref) >= 0 {
 		return rune(other)
 	}
 	return rune(pref)
+}
+
+// legacyQuoteBytes generalizes historical suitableQuote for byte payloads.
+func legacyQuoteBytes(payload []byte, preferred PreferredQuote) rune {
+	pref, other := byte('"'), byte('\'')
+	if preferred == PreferredQuoteSingle {
+		pref, other = '\'', '"'
+	}
+	if bytes.IndexByte(payload, other) >= 0 {
+		return rune(pref)
+	}
+	if bytes.IndexByte(payload, pref) >= 0 {
+		return rune(other)
+	}
+	return rune(pref)
+}
+
+// legacyQuote dispatches to typed legacy quote selection. Used by tests.
+func legacyQuote[T bytesSeq](payload T, preferred PreferredQuote) rune {
+	switch val := any(payload).(type) {
+	case string:
+		return legacyQuoteString(val, preferred)
+	case []byte:
+		return legacyQuoteBytes(val, preferred)
+	default:
+		panic("unreachable")
+	}
 }
 
 // minEscapeQuote picks the delimiter that occurs less often in the payload.

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -1,10 +1,5 @@
 package internal
 
-import (
-	"bytes"
-	"strings"
-)
-
 type bytesSeq interface {
 	~string | ~[]byte
 }
@@ -32,87 +27,42 @@ type QuotePolicy struct {
 	Preferred PreferredQuote
 }
 
-func quoteForPayloadString(p QuotePolicy, payload string) rune {
-	switch p.Strategy {
-	case QuoteStrategyAlways:
-		if p.Preferred == PreferredQuoteSingle {
-			return '\''
-		}
-		return '"'
-	case QuoteStrategyMinEscape:
-		return minEscapeQuote(payload, p.Preferred)
-	default:
-		return legacyQuoteString(payload, p.Preferred)
-	}
-}
-
-func quoteForPayloadBytes(p QuotePolicy, payload []byte) rune {
-	switch p.Strategy {
-	case QuoteStrategyAlways:
-		if p.Preferred == PreferredQuoteSingle {
-			return '\''
-		}
-		return '"'
-	case QuoteStrategyMinEscape:
-		return minEscapeQuote(payload, p.Preferred)
-	default:
-		return legacyQuoteBytes(payload, p.Preferred)
-	}
-}
-
-// quoteForPayload dispatches to typed helpers. Used by tests; hot paths call
-// quoteForPayloadString or quoteForPayloadBytes directly to avoid interface boxing.
 func quoteForPayload[T bytesSeq](p QuotePolicy, payload T) rune {
-	switch val := any(payload).(type) {
-	case string:
-		return quoteForPayloadString(p, val)
-	case []byte:
-		return quoteForPayloadBytes(p, val)
+	switch p.Strategy {
+	case QuoteStrategyAlways:
+		if p.Preferred == PreferredQuoteSingle {
+			return '\''
+		}
+		return '"'
+	case QuoteStrategyMinEscape:
+		return minEscapeQuote(payload, p.Preferred)
 	default:
-		panic("unreachable")
+		return legacyQuote(payload, p.Preferred)
 	}
 }
 
-// legacyQuoteString generalizes historical suitableQuote for string payloads.
-func legacyQuoteString(payload string, preferred PreferredQuote) rune {
-	pref, other := byte('"'), byte('\'')
-	if preferred == PreferredQuoteSingle {
-		pref, other = '\'', '"'
-	}
-	if strings.IndexByte(payload, other) >= 0 {
-		return rune(pref)
-	}
-	if strings.IndexByte(payload, pref) >= 0 {
-		return rune(other)
-	}
-	return rune(pref)
-}
-
-// legacyQuoteBytes generalizes historical suitableQuote for byte payloads.
-func legacyQuoteBytes(payload []byte, preferred PreferredQuote) rune {
-	pref, other := byte('"'), byte('\'')
-	if preferred == PreferredQuoteSingle {
-		pref, other = '\'', '"'
-	}
-	if bytes.IndexByte(payload, other) >= 0 {
-		return rune(pref)
-	}
-	if bytes.IndexByte(payload, pref) >= 0 {
-		return rune(other)
-	}
-	return rune(pref)
-}
-
-// legacyQuote dispatches to typed legacy quote selection. Used by tests.
+// legacyQuote generalizes historical suitableQuote: when the payload contains only the
+// preferred delimiter character, use the opposite delimiter; otherwise use preferred.
+// With PreferredQuoteDouble this matches suitableQuote byte-for-byte.
 func legacyQuote[T bytesSeq](payload T, preferred PreferredQuote) rune {
-	switch val := any(payload).(type) {
-	case string:
-		return legacyQuoteString(val, preferred)
-	case []byte:
-		return legacyQuoteBytes(val, preferred)
-	default:
-		panic("unreachable")
+	pref, other := byte('"'), byte('\'')
+	if preferred == PreferredQuoteSingle {
+		pref, other = '\'', '"'
 	}
+	var hasPref bool
+	for i := 0; i < len(payload); i++ {
+		b := payload[i]
+		switch b {
+		case other:
+			return rune(pref)
+		case pref:
+			hasPref = true
+		}
+	}
+	if hasPref {
+		return rune(other)
+	}
+	return rune(pref)
 }
 
 // minEscapeQuote picks the delimiter that occurs less often in the payload.

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -1,0 +1,101 @@
+package internal
+
+// QuoteStrategy selects how the outer string-literal delimiter is chosen.
+type QuoteStrategy uint8
+
+const (
+	QuoteStrategyLegacy QuoteStrategy = iota
+	QuoteStrategyAlways
+	QuoteStrategyMinEscape
+)
+
+// PreferredQuote is the delimiter used by [QuoteStrategyAlways] and as tie-breaker for [QuoteStrategyMinEscape].
+type PreferredQuote uint8
+
+const (
+	PreferredQuoteDouble PreferredQuote = iota
+	PreferredQuoteSingle
+)
+
+// QuotePolicy configures literal string delimiters. The zero value is legacy adaptive quoting.
+type QuotePolicy struct {
+	Strategy  QuoteStrategy
+	Preferred PreferredQuote
+}
+
+func (p QuotePolicy) quoteForPayload(payload []byte) rune {
+	switch p.Strategy {
+	case QuoteStrategyAlways:
+		if p.Preferred == PreferredQuoteSingle {
+			return '\''
+		}
+		return '"'
+	case QuoteStrategyMinEscape:
+		return minEscapeQuote(payload, p.Preferred)
+	default:
+		return legacyQuote(payload, p.Preferred)
+	}
+}
+
+// legacyQuote generalizes historical suitableQuote: when the payload contains only the
+// preferred delimiter character, use the opposite delimiter; otherwise use preferred.
+// With PreferredQuoteDouble this matches suitableQuote byte-for-byte.
+func legacyQuote(payload []byte, preferred PreferredQuote) rune {
+	pref, other := byte('"'), byte('\'')
+	if preferred == PreferredQuoteSingle {
+		pref, other = '\'', '"'
+	}
+	var hasPref, hasOther bool
+	for _, b := range payload {
+		switch b {
+		case pref:
+			hasPref = true
+		case other:
+			hasOther = true
+		}
+	}
+	if hasPref && !hasOther {
+		return rune(other)
+	}
+	return rune(pref)
+}
+
+// minEscapeQuote picks the delimiter that occurs less often in the payload.
+// On a tie (including payloads with neither quote character), PreferredQuote wins.
+func minEscapeQuote(payload []byte, preferred PreferredQuote) rune {
+	var singleCount, doubleCount int
+	for _, r := range payload {
+		switch r {
+		case '\'':
+			singleCount++
+		case '"':
+			doubleCount++
+		}
+	}
+	switch {
+	case singleCount < doubleCount:
+		return '\''
+	case doubleCount < singleCount:
+		return '"'
+	default:
+		if preferred == PreferredQuoteSingle {
+			return '\''
+		}
+		return '"'
+	}
+}
+
+// quoteForSpecialFloatCast selects the delimiter for NaN/±Inf CAST payloads.
+// Legacy stays single-quoted. QuoteAlways and QuoteMinEscape use PreferredQuote
+// (MinEscape payloads have no quote characters, so preferred is the tie-breaker).
+func (p QuotePolicy) quoteForSpecialFloatCast() rune {
+	switch p.Strategy {
+	case QuoteStrategyAlways, QuoteStrategyMinEscape:
+		if p.Preferred == PreferredQuoteDouble {
+			return '"'
+		}
+		return '\''
+	default:
+		return '\''
+	}
+}

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -45,16 +45,16 @@ func legacyQuote(payload []byte, preferred PreferredQuote) rune {
 	if preferred == PreferredQuoteSingle {
 		pref, other = '\'', '"'
 	}
-	var hasPref, hasOther bool
+	var hasPref bool
 	for _, b := range payload {
 		switch b {
+		case other:
+			return rune(pref)
 		case pref:
 			hasPref = true
-		case other:
-			hasOther = true
 		}
 	}
-	if hasPref && !hasOther {
+	if hasPref {
 		return rune(other)
 	}
 	return rune(pref)

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -84,18 +84,3 @@ func minEscapeQuote(payload []byte, preferred PreferredQuote) rune {
 		return '"'
 	}
 }
-
-// quoteForSpecialFloatCast selects the delimiter for NaN/±Inf CAST payloads.
-// Legacy stays single-quoted. QuoteAlways and QuoteMinEscape use PreferredQuote
-// (MinEscape payloads have no quote characters, so preferred is the tie-breaker).
-func (p QuotePolicy) quoteForSpecialFloatCast() rune {
-	switch p.Strategy {
-	case QuoteStrategyAlways, QuoteStrategyMinEscape:
-		if p.Preferred == PreferredQuoteDouble {
-			return '"'
-		}
-		return '\''
-	default:
-		return '\''
-	}
-}

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -1,5 +1,9 @@
 package internal
 
+type bytesSeq interface {
+	~string | ~[]byte
+}
+
 // QuoteStrategy selects how the outer string-literal delimiter is chosen.
 type QuoteStrategy uint8
 
@@ -23,7 +27,7 @@ type QuotePolicy struct {
 	Preferred PreferredQuote
 }
 
-func (p QuotePolicy) quoteForPayload(payload []byte) rune {
+func quoteForPayload[T bytesSeq](p QuotePolicy, payload T) rune {
 	switch p.Strategy {
 	case QuoteStrategyAlways:
 		if p.Preferred == PreferredQuoteSingle {
@@ -40,13 +44,14 @@ func (p QuotePolicy) quoteForPayload(payload []byte) rune {
 // legacyQuote generalizes historical suitableQuote: when the payload contains only the
 // preferred delimiter character, use the opposite delimiter; otherwise use preferred.
 // With PreferredQuoteDouble this matches suitableQuote byte-for-byte.
-func legacyQuote(payload []byte, preferred PreferredQuote) rune {
+func legacyQuote[T bytesSeq](payload T, preferred PreferredQuote) rune {
 	pref, other := byte('"'), byte('\'')
 	if preferred == PreferredQuoteSingle {
 		pref, other = '\'', '"'
 	}
 	var hasPref bool
-	for _, b := range payload {
+	for i := 0; i < len(payload); i++ {
+		b := payload[i]
 		switch b {
 		case other:
 			return rune(pref)
@@ -62,10 +67,11 @@ func legacyQuote(payload []byte, preferred PreferredQuote) rune {
 
 // minEscapeQuote picks the delimiter that occurs less often in the payload.
 // On a tie (including payloads with neither quote character), PreferredQuote wins.
-func minEscapeQuote(payload []byte, preferred PreferredQuote) rune {
+func minEscapeQuote[T bytesSeq](payload T, preferred PreferredQuote) rune {
 	var singleCount, doubleCount int
-	for _, r := range payload {
-		switch r {
+	for i := 0; i < len(payload); i++ {
+		b := payload[i]
+		switch b {
 		case '\'':
 			singleCount++
 		case '"':

--- a/internal/quote_policy.go
+++ b/internal/quote_policy.go
@@ -1,7 +1,7 @@
 package internal
 
 type bytesSeq interface {
-	~string | ~[]byte
+	string | []byte
 }
 
 // QuoteStrategy selects how the outer string-literal delimiter is chosen.

--- a/internal/quote_policy_bench_test.go
+++ b/internal/quote_policy_bench_test.go
@@ -26,51 +26,6 @@ func BenchmarkQuoteForPayloadMaxCell(b *testing.B) {
 	b.SetBytes(int64(len(payload)))
 	b.ResetTimer()
 	for range b.N {
-		_ = quoteForPayloadString(policy, payload)
-	}
-}
-
-func BenchmarkQuoteForPayloadLegacyShapes(b *testing.B) {
-	noQuotes := strings.Repeat("x", spannerMaxCellBytes)
-	prefOnly := strings.Repeat("'", spannerMaxCellBytes)
-	oppositeEarly := `"` + strings.Repeat("x", spannerMaxCellBytes-1)
-	policy := QuotePolicy{}
-
-	for _, tc := range []struct {
-		name    string
-		payload string
-	}{
-		{name: "no_quotes", payload: noQuotes},
-		{name: "preferred_only", payload: prefOnly},
-		{name: "opposite_early", payload: oppositeEarly},
-	} {
-		b.Run(tc.name, func(b *testing.B) {
-			b.Run("string", func(b *testing.B) {
-				benchmarkQuoteForPayloadString(b, policy, tc.payload)
-			})
-			b.Run("bytes", func(b *testing.B) {
-				benchmarkQuoteForPayloadBytes(b, policy, []byte(tc.payload))
-			})
-		})
-	}
-}
-
-func benchmarkQuoteForPayloadString(b *testing.B, policy QuotePolicy, payload string) {
-	b.Helper()
-	b.ReportAllocs()
-	b.SetBytes(int64(len(payload)))
-	b.ResetTimer()
-	for range b.N {
-		_ = quoteForPayloadString(policy, payload)
-	}
-}
-
-func benchmarkQuoteForPayloadBytes(b *testing.B, policy QuotePolicy, payload []byte) {
-	b.Helper()
-	b.ReportAllocs()
-	b.SetBytes(int64(len(payload)))
-	b.ResetTimer()
-	for range b.N {
-		_ = quoteForPayloadBytes(policy, payload)
+		_ = quoteForPayload(policy, payload)
 	}
 }

--- a/internal/quote_policy_bench_test.go
+++ b/internal/quote_policy_bench_test.go
@@ -26,6 +26,51 @@ func BenchmarkQuoteForPayloadMaxCell(b *testing.B) {
 	b.SetBytes(int64(len(payload)))
 	b.ResetTimer()
 	for range b.N {
-		_ = quoteForPayload(policy, payload)
+		_ = quoteForPayloadString(policy, payload)
+	}
+}
+
+func BenchmarkQuoteForPayloadLegacyShapes(b *testing.B) {
+	noQuotes := strings.Repeat("x", spannerMaxCellBytes)
+	prefOnly := strings.Repeat("'", spannerMaxCellBytes)
+	oppositeEarly := `"` + strings.Repeat("x", spannerMaxCellBytes-1)
+	policy := QuotePolicy{}
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "no_quotes", payload: noQuotes},
+		{name: "preferred_only", payload: prefOnly},
+		{name: "opposite_early", payload: oppositeEarly},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("string", func(b *testing.B) {
+				benchmarkQuoteForPayloadString(b, policy, tc.payload)
+			})
+			b.Run("bytes", func(b *testing.B) {
+				benchmarkQuoteForPayloadBytes(b, policy, []byte(tc.payload))
+			})
+		})
+	}
+}
+
+func benchmarkQuoteForPayloadString(b *testing.B, policy QuotePolicy, payload string) {
+	b.Helper()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		_ = quoteForPayloadString(policy, payload)
+	}
+}
+
+func benchmarkQuoteForPayloadBytes(b *testing.B, policy QuotePolicy, payload []byte) {
+	b.Helper()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		_ = quoteForPayloadBytes(policy, payload)
 	}
 }

--- a/internal/quote_policy_bench_test.go
+++ b/internal/quote_policy_bench_test.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+// spannerMaxCellBytes is the Spanner STRING/BYTES cell-size limit (10 MiB).
+const spannerMaxCellBytes = 10 * 1024 * 1024
+
+func BenchmarkToStringLiteralPolicyMaxCell(b *testing.B) {
+	payload := strings.Repeat("x", spannerMaxCellBytes)
+	policy := QuotePolicy{}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		_ = ToStringLiteralPolicy(payload, policy)
+	}
+}
+
+func BenchmarkQuoteForPayloadMaxCell(b *testing.B) {
+	payload := strings.Repeat("x", spannerMaxCellBytes)
+	policy := QuotePolicy{}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		_ = quoteForPayload(policy, payload)
+	}
+}

--- a/internal/quote_policy_test.go
+++ b/internal/quote_policy_test.go
@@ -76,25 +76,10 @@ func TestQuoteForPayloadStringMatchesBytes(t *testing.T) {
 	}
 	for _, policy := range policies {
 		for _, payload := range payloads {
-			gotStr := quoteForPayloadString(policy, payload)
-			gotBytes := quoteForPayloadBytes(policy, []byte(payload))
+			gotStr := quoteForPayload(policy, payload)
+			gotBytes := quoteForPayload(policy, []byte(payload))
 			if gotStr != gotBytes {
 				t.Fatalf("policy=%+v payload=%q: string=%q bytes=%q", policy, payload, gotStr, gotBytes)
-			}
-		}
-	}
-}
-
-func TestLegacyQuoteStringMatchesBytes(t *testing.T) {
-	t.Parallel()
-
-	payloads := []string{"plain", "it's", `say "hi"`, `"it's"`}
-	for _, preferred := range []PreferredQuote{PreferredQuoteDouble, PreferredQuoteSingle} {
-		for _, payload := range payloads {
-			gotStr := legacyQuoteString(payload, preferred)
-			gotBytes := legacyQuoteBytes([]byte(payload), preferred)
-			if gotStr != gotBytes {
-				t.Fatalf("preferred=%v payload=%q: string=%q bytes=%q", preferred, payload, gotStr, gotBytes)
 			}
 		}
 	}

--- a/internal/quote_policy_test.go
+++ b/internal/quote_policy_test.go
@@ -76,10 +76,25 @@ func TestQuoteForPayloadStringMatchesBytes(t *testing.T) {
 	}
 	for _, policy := range policies {
 		for _, payload := range payloads {
-			gotStr := quoteForPayload(policy, payload)
-			gotBytes := quoteForPayload(policy, []byte(payload))
+			gotStr := quoteForPayloadString(policy, payload)
+			gotBytes := quoteForPayloadBytes(policy, []byte(payload))
 			if gotStr != gotBytes {
 				t.Fatalf("policy=%+v payload=%q: string=%q bytes=%q", policy, payload, gotStr, gotBytes)
+			}
+		}
+	}
+}
+
+func TestLegacyQuoteStringMatchesBytes(t *testing.T) {
+	t.Parallel()
+
+	payloads := []string{"plain", "it's", `say "hi"`, `"it's"`}
+	for _, preferred := range []PreferredQuote{PreferredQuoteDouble, PreferredQuoteSingle} {
+		for _, payload := range payloads {
+			gotStr := legacyQuoteString(payload, preferred)
+			gotBytes := legacyQuoteBytes([]byte(payload), preferred)
+			if gotStr != gotBytes {
+				t.Fatalf("preferred=%v payload=%q: string=%q bytes=%q", preferred, payload, gotStr, gotBytes)
 			}
 		}
 	}

--- a/internal/quote_policy_test.go
+++ b/internal/quote_policy_test.go
@@ -21,7 +21,7 @@ func TestMinEscapeQuote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := minEscapeQuote([]byte(tt.payload), tt.preferred)
+			got := minEscapeQuote(tt.payload, tt.preferred)
 			if got != tt.want {
 				t.Fatalf("minEscapeQuote(%q, %v) = %q, want %q", tt.payload, tt.preferred, got, tt.want)
 			}
@@ -42,7 +42,7 @@ func TestLegacyQuoteMatchesSuitableQuoteWithDoublePreferred(t *testing.T) {
 		`""only doubles""`,
 	}
 	for _, payload := range payloads {
-		got := legacyQuote([]byte(payload), PreferredQuoteDouble)
+		got := legacyQuote(payload, PreferredQuoteDouble)
 		want := suitableQuote([]byte(payload))
 		if got != want {
 			t.Fatalf("legacyQuote(%q, double) = %q, suitableQuote = %q", payload, got, want)
@@ -53,14 +53,34 @@ func TestLegacyQuoteMatchesSuitableQuoteWithDoublePreferred(t *testing.T) {
 func TestQuotePolicyMinEscapeDiffersFromLegacyOnBothQuotes(t *testing.T) {
 	t.Parallel()
 
-	payload := []byte(`"it's"`)
-	legacy := QuotePolicy{}.quoteForPayload(payload)
-	minEscape := QuotePolicy{Strategy: QuoteStrategyMinEscape, Preferred: PreferredQuoteDouble}.quoteForPayload(payload)
+	payload := `"it's"`
+	legacy := quoteForPayload(QuotePolicy{}, payload)
+	minEscape := quoteForPayload(QuotePolicy{Strategy: QuoteStrategyMinEscape, Preferred: PreferredQuoteDouble}, payload)
 
 	if legacy != '"' {
 		t.Fatalf("legacy = %q, want double (first single wins)", legacy)
 	}
 	if minEscape != '\'' {
 		t.Fatalf("minEscape = %q, want single (more doubles than singles)", minEscape)
+	}
+}
+
+func TestQuoteForPayloadStringMatchesBytes(t *testing.T) {
+	t.Parallel()
+
+	payloads := []string{"plain", "it's", `say "hi"`, `"it's"`}
+	policies := []QuotePolicy{
+		{},
+		{Strategy: QuoteStrategyAlways, Preferred: PreferredQuoteSingle},
+		{Strategy: QuoteStrategyMinEscape, Preferred: PreferredQuoteDouble},
+	}
+	for _, policy := range policies {
+		for _, payload := range payloads {
+			gotStr := quoteForPayload(policy, payload)
+			gotBytes := quoteForPayload(policy, []byte(payload))
+			if gotStr != gotBytes {
+				t.Fatalf("policy=%+v payload=%q: string=%q bytes=%q", policy, payload, gotStr, gotBytes)
+			}
+		}
 	}
 }

--- a/internal/quote_policy_test.go
+++ b/internal/quote_policy_test.go
@@ -1,0 +1,66 @@
+package internal
+
+import "testing"
+
+func TestMinEscapeQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		payload   string
+		preferred PreferredQuote
+		want      rune
+	}{
+		{name: "more singles prefers double", payload: "a'b", preferred: PreferredQuoteSingle, want: '"'},
+		{name: "more doubles prefers single", payload: `a"b"c`, preferred: PreferredQuoteDouble, want: '\''},
+		{name: "tie no quotes prefers double", payload: "plain", preferred: PreferredQuoteDouble, want: '"'},
+		{name: "tie no quotes prefers single", payload: "plain", preferred: PreferredQuoteSingle, want: '\''},
+		{name: "equal counts tie prefers double", payload: `'x"y`, preferred: PreferredQuoteDouble, want: '"'},
+		{name: "equal counts tie prefers single", payload: `'x"y`, preferred: PreferredQuoteSingle, want: '\''},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := minEscapeQuote([]byte(tt.payload), tt.preferred)
+			if got != tt.want {
+				t.Fatalf("minEscapeQuote(%q, %v) = %q, want %q", tt.payload, tt.preferred, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLegacyQuoteMatchesSuitableQuoteWithDoublePreferred(t *testing.T) {
+	t.Parallel()
+
+	payloads := []string{
+		"plain",
+		"it's",
+		`say "hi"`,
+		`"it's"`,
+		"no quotes here",
+		`'alone'`,
+		`""only doubles""`,
+	}
+	for _, payload := range payloads {
+		got := legacyQuote([]byte(payload), PreferredQuoteDouble)
+		want := suitableQuote([]byte(payload))
+		if got != want {
+			t.Fatalf("legacyQuote(%q, double) = %q, suitableQuote = %q", payload, got, want)
+		}
+	}
+}
+
+func TestQuotePolicyMinEscapeDiffersFromLegacyOnBothQuotes(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`"it's"`)
+	legacy := QuotePolicy{}.quoteForPayload(payload)
+	minEscape := QuotePolicy{Strategy: QuoteStrategyMinEscape, Preferred: PreferredQuoteDouble}.quoteForPayload(payload)
+
+	if legacy != '"' {
+		t.Fatalf("legacy = %q, want double (first single wins)", legacy)
+	}
+	if minEscape != '\'' {
+		t.Fatalf("minEscape = %q, want single (more doubles than singles)", minEscape)
+	}
+}

--- a/literal.go
+++ b/literal.go
@@ -53,13 +53,11 @@ var (
 	_ FormatNullableFunc = formatNullableValueLiteral
 )
 
-func stringBasedLiteral(typ, s string, q LiteralQuoteConfig) string {
-	policy := toInternalQuotePolicy(q)
+func stringBasedLiteral(typ, s string, policy internal.QuotePolicy) string {
 	return fmt.Sprintf("%s %s", typ, internal.ToStringLiteralPolicy(s, policy))
 }
 
-func stringLiteralCast(typ, s string, q LiteralQuoteConfig) string {
-	policy := toInternalQuotePolicy(q)
+func stringLiteralCast(typ, s string, policy internal.QuotePolicy) string {
 	return fmt.Sprintf("CAST(%s AS %s)", internal.ToStringLiteralPolicy(s, policy), typ)
 }
 
@@ -86,26 +84,26 @@ func formatNullableValueLiteralWithQuote(q LiteralQuoteConfig, value NullableVal
 	case spanner.NullInt64:
 		return strconv.FormatInt(v.Int64, 10), nil
 	case spanner.NullNumeric:
-		return stringBasedLiteral("NUMERIC", spanner.NumericString(&v.Numeric), q), nil
+		return stringBasedLiteral("NUMERIC", spanner.NumericString(&v.Numeric), policy), nil
 	case spanner.PGNumeric:
-		return stringBasedLiteral("NUMERIC", v.Numeric, q), nil
+		return stringBasedLiteral("NUMERIC", v.Numeric, policy), nil
 	case spanner.NullTime:
-		return stringBasedLiteral("TIMESTAMP", v.Time.Format(time.RFC3339Nano), q), nil
+		return stringBasedLiteral("TIMESTAMP", v.Time.Format(time.RFC3339Nano), policy), nil
 	case spanner.NullDate:
-		return stringBasedLiteral("DATE", v.Date.String(), q), nil
+		return stringBasedLiteral("DATE", v.Date.String(), policy), nil
 	case spanner.NullJSON:
-		return stringBasedLiteral("JSON", v.String(), q), nil
+		return stringBasedLiteral("JSON", v.String(), policy), nil
 	case spanner.PGJsonB:
 		b, err := json.Marshal(v.Value)
 		if err != nil {
 			return "", err
 		}
-		return stringBasedLiteral("JSON", string(b), q), nil
+		return stringBasedLiteral("JSON", string(b), policy), nil
 	case spanner.NullInterval:
 		// Use CAST for INTERVAL. Literal notation is unintuitive for information preservation.
-		return stringLiteralCast("INTERVAL", v.String(), q), nil
+		return stringLiteralCast("INTERVAL", v.String(), policy), nil
 	case spanner.NullUUID:
-		return stringLiteralCast("UUID", v.String(), q), nil
+		return stringLiteralCast("UUID", v.String(), policy), nil
 	default:
 		// Reject unknown type to guarantee round-trip
 		return "", fmt.Errorf("%w: %T", ErrUnknownType, v)

--- a/literal.go
+++ b/literal.go
@@ -40,6 +40,8 @@ func LiteralFormatConfig() *FormatConfig {
 	}
 }
 
+var _ func() *FormatConfig = LiteralFormatConfig
+
 var (
 	_ FormatStructParenFunc = formatTypedStructParen
 	_ FormatStructParenFunc = FormatTupleStruct
@@ -51,49 +53,59 @@ var (
 	_ FormatNullableFunc = formatNullableValueLiteral
 )
 
-func stringBasedLiteral(typ string, s string) string {
-	return fmt.Sprintf("%s %s", typ, internal.ToStringLiteral(s))
+func stringBasedLiteral(typ, s string, q LiteralQuoteConfig) string {
+	policy := toInternalQuotePolicy(q)
+	return fmt.Sprintf("%s %s", typ, internal.ToStringLiteralPolicy(s, policy))
 }
 
-func stringLiteralCast(typ string, s string) string {
-	return fmt.Sprintf("CAST(%s AS %s)", internal.ToStringLiteral(s), typ)
+func stringLiteralCast(typ, s string, q LiteralQuoteConfig) string {
+	policy := toInternalQuotePolicy(q)
+	return fmt.Sprintf("CAST(%s AS %s)", internal.ToStringLiteralPolicy(s, policy), typ)
 }
 
+// formatNullableValueLiteral is the identity sentinel for scalarFastPathActive and
+// formatSimpleColumn dispatch. It must stay equivalent to
+// formatNullableValueLiteralWithQuote(LiteralQuoteConfig{}, nv).
 func formatNullableValueLiteral(value NullableValue) (string, error) {
+	return formatNullableValueLiteralWithQuote(LiteralQuoteConfig{}, value)
+}
+
+func formatNullableValueLiteralWithQuote(q LiteralQuoteConfig, value NullableValue) (string, error) {
+	policy := toInternalQuotePolicy(q)
 	switch v := value.(type) {
 	case spanner.NullString:
-		return internal.ToStringLiteral(v.StringVal), nil
+		return internal.ToStringLiteralPolicy(v.StringVal, policy), nil
 	case spanner.NullBool:
 		return strconv.FormatBool(v.Bool), nil
 	case NullBytes:
-		return internal.ToReadableBytesLiteral(v), nil
+		return internal.ToReadableBytesLiteralPolicy(v, policy), nil
 	case spanner.NullFloat32:
-		return internal.Float32ToLiteral(v.Float32), nil
+		return internal.Float32ToLiteralPolicy(v.Float32, policy), nil
 	case spanner.NullFloat64:
-		return internal.Float64ToLiteral(v.Float64), nil
+		return internal.Float64ToLiteralPolicy(v.Float64, policy), nil
 	case spanner.NullInt64:
 		return strconv.FormatInt(v.Int64, 10), nil
 	case spanner.NullNumeric:
-		return stringBasedLiteral("NUMERIC", spanner.NumericString(&v.Numeric)), nil
+		return stringBasedLiteral("NUMERIC", spanner.NumericString(&v.Numeric), q), nil
 	case spanner.PGNumeric:
-		return stringBasedLiteral("NUMERIC", v.Numeric), nil
+		return stringBasedLiteral("NUMERIC", v.Numeric, q), nil
 	case spanner.NullTime:
-		return stringBasedLiteral("TIMESTAMP", v.Time.Format(time.RFC3339Nano)), nil
+		return stringBasedLiteral("TIMESTAMP", v.Time.Format(time.RFC3339Nano), q), nil
 	case spanner.NullDate:
-		return stringBasedLiteral("DATE", v.Date.String()), nil
+		return stringBasedLiteral("DATE", v.Date.String(), q), nil
 	case spanner.NullJSON:
-		return stringBasedLiteral("JSON", v.String()), nil
+		return stringBasedLiteral("JSON", v.String(), q), nil
 	case spanner.PGJsonB:
 		b, err := json.Marshal(v.Value)
 		if err != nil {
 			return "", err
 		}
-		return stringBasedLiteral("JSON", string(b)), nil
+		return stringBasedLiteral("JSON", string(b), q), nil
 	case spanner.NullInterval:
 		// Use CAST for INTERVAL. Literal notation is unintuitive for information preservation.
-		return stringLiteralCast("INTERVAL", v.String()), nil
+		return stringLiteralCast("INTERVAL", v.String(), q), nil
 	case spanner.NullUUID:
-		return stringLiteralCast("UUID", v.String()), nil
+		return stringLiteralCast("UUID", v.String(), q), nil
 	default:
 		// Reject unknown type to guarantee round-trip
 		return "", fmt.Errorf("%w: %T", ErrUnknownType, v)

--- a/literal_quote.go
+++ b/literal_quote.go
@@ -1,6 +1,10 @@
 package spanvalue
 
-import "github.com/apstndb/spanvalue/internal"
+import (
+	"strconv"
+
+	"github.com/apstndb/spanvalue/internal"
+)
 
 // QuoteStrategy selects how the outer string-literal delimiter is chosen for the literal preset.
 type QuoteStrategy uint8
@@ -97,7 +101,7 @@ func (s QuoteStrategy) String() string {
 	case QuoteMinEscape:
 		return "QuoteMinEscape"
 	default:
-		return "QuoteStrategy(" + itoaUint8(uint8(s)) + ")"
+		return "QuoteStrategy(" + strconv.Itoa(int(s)) + ")"
 	}
 }
 
@@ -108,16 +112,8 @@ func (p PreferredQuote) String() string {
 	case PreferredSingleQuote:
 		return "PreferredSingleQuote"
 	default:
-		return "PreferredQuote(" + itoaUint8(uint8(p)) + ")"
+		return "PreferredQuote(" + strconv.Itoa(int(p)) + ")"
 	}
-}
-
-func itoaUint8(v uint8) string {
-	const digits = "0123456789"
-	if v < 10 {
-		return string(digits[v])
-	}
-	return string([]byte{digits[v/10], digits[v%10]})
 }
 
 func normalizeLiteralQuote(cfg LiteralQuoteConfig) LiteralQuoteConfig {

--- a/literal_quote.go
+++ b/literal_quote.go
@@ -1,0 +1,142 @@
+package spanvalue
+
+import "github.com/apstndb/spanvalue/internal"
+
+// QuoteStrategy selects how the outer string-literal delimiter is chosen for the literal preset.
+type QuoteStrategy uint8
+
+const (
+	// QuoteLegacy uses PreferredQuote when the payload needs no opposite-delimiter escape.
+	// When the payload contains only the preferred quote character, the opposite delimiter is used.
+	// PreferredDoubleQuote (the zero value) matches historical suitableQuote byte-for-byte.
+	QuoteLegacy QuoteStrategy = iota
+	// QuoteAlways uses PreferredQuote for every string and bytes literal.
+	QuoteAlways
+	// QuoteMinEscape picks the delimiter whose quote character occurs less often in the payload.
+	// On a tie, PreferredQuote wins. Only quote-character counts matter; other escapes are delimiter-independent.
+	QuoteMinEscape
+)
+
+// PreferredQuote is the default delimiter for [QuoteLegacy] (with opposite-delimiter escape
+// when the payload contains only that quote character), the fixed delimiter for [QuoteAlways],
+// and the tie-breaker for [QuoteMinEscape].
+type PreferredQuote uint8
+
+const (
+	// PreferredDoubleQuote uses double quotes as the outer delimiter.
+	PreferredDoubleQuote PreferredQuote = iota
+	// PreferredSingleQuote uses single quotes as the outer delimiter.
+	PreferredSingleQuote
+)
+
+// LiteralQuoteConfig configures string and bytes literal quoting for the literal preset.
+// The zero value is legacy adaptive quoting. Invalid enum values are normalized per axis.
+type LiteralQuoteConfig struct {
+	Strategy       QuoteStrategy
+	PreferredQuote PreferredQuote
+}
+
+// LiteralOption configures a literal preset returned by [LiteralFormatConfigWithOptions].
+type LiteralOption interface {
+	applyLiteralOption(*FormatConfig)
+}
+
+type literalQuoteOption struct {
+	cfg LiteralQuoteConfig
+}
+
+// WithLiteralQuote sets quote policy on a literal preset built with [LiteralFormatConfigWithOptions].
+func WithLiteralQuote(cfg LiteralQuoteConfig) LiteralOption {
+	return literalQuoteOption{cfg: cfg}
+}
+
+func (o literalQuoteOption) applyLiteralOption(fc *FormatConfig) {
+	fc.LiteralQuote = normalizeLiteralQuote(o.cfg)
+}
+
+// LiteralFormatConfigWithOptions returns a copy of [LiteralFormatConfig] with the given options applied.
+func LiteralFormatConfigWithOptions(opts ...LiteralOption) *FormatConfig {
+	fc := LiteralFormatConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyLiteralOption(fc)
+		}
+	}
+	return fc
+}
+
+// LiteralFormatConfigWithQuote returns a copy of [LiteralFormatConfig] with the given quote settings.
+func LiteralFormatConfigWithQuote(cfg LiteralQuoteConfig) *FormatConfig {
+	return LiteralFormatConfigWithOptions(WithLiteralQuote(cfg))
+}
+
+// LiteralFormatConfigWithSingleQuotedLiterals returns a literal preset that always single-quotes
+// string and bytes literals (SQL INSERT style).
+func LiteralFormatConfigWithSingleQuotedLiterals() *FormatConfig {
+	return LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteAlways,
+		PreferredQuote: PreferredSingleQuote,
+	})
+}
+
+func (s QuoteStrategy) String() string {
+	switch s {
+	case QuoteLegacy:
+		return "QuoteLegacy"
+	case QuoteAlways:
+		return "QuoteAlways"
+	case QuoteMinEscape:
+		return "QuoteMinEscape"
+	default:
+		return "QuoteStrategy(" + itoaUint8(uint8(s)) + ")"
+	}
+}
+
+func (p PreferredQuote) String() string {
+	switch p {
+	case PreferredDoubleQuote:
+		return "PreferredDoubleQuote"
+	case PreferredSingleQuote:
+		return "PreferredSingleQuote"
+	default:
+		return "PreferredQuote(" + itoaUint8(uint8(p)) + ")"
+	}
+}
+
+func itoaUint8(v uint8) string {
+	const digits = "0123456789"
+	if v < 10 {
+		return string(digits[v])
+	}
+	return string([]byte{digits[v/10], digits[v%10]})
+}
+
+func normalizeLiteralQuote(cfg LiteralQuoteConfig) LiteralQuoteConfig {
+	switch cfg.Strategy {
+	case QuoteLegacy, QuoteAlways, QuoteMinEscape:
+	default:
+		cfg.Strategy = QuoteLegacy
+	}
+	switch cfg.PreferredQuote {
+	case PreferredDoubleQuote, PreferredSingleQuote:
+	default:
+		cfg.PreferredQuote = PreferredDoubleQuote
+	}
+	return cfg
+}
+
+func toInternalQuotePolicy(cfg LiteralQuoteConfig) internal.QuotePolicy {
+	cfg = normalizeLiteralQuote(cfg)
+	return internal.QuotePolicy{
+		Strategy:  internal.QuoteStrategy(cfg.Strategy),
+		Preferred: internal.PreferredQuote(cfg.PreferredQuote),
+	}
+}
+
+func literalQuoteForFormatter(formatter any) LiteralQuoteConfig {
+	fc, ok := formatter.(*FormatConfig)
+	if !ok {
+		return LiteralQuoteConfig{}
+	}
+	return fc.LiteralQuote
+}

--- a/literal_quote.go
+++ b/literal_quote.go
@@ -140,7 +140,7 @@ func toInternalQuotePolicy(cfg LiteralQuoteConfig) internal.QuotePolicy {
 
 func literalQuoteForFormatter(formatter any) LiteralQuoteConfig {
 	fc, ok := formatter.(*FormatConfig)
-	if !ok {
+	if !ok || fc == nil {
 		return LiteralQuoteConfig{}
 	}
 	return fc.Literal.Quote

--- a/literal_quote.go
+++ b/literal_quote.go
@@ -13,11 +13,16 @@ const (
 	// QuoteLegacy uses PreferredQuote when the payload needs no opposite-delimiter escape.
 	// When the payload contains only the preferred quote character, the opposite delimiter is used.
 	// PreferredDoubleQuote (the zero value) matches historical suitableQuote byte-for-byte.
+	// When both quote characters appear, Legacy uses presence rules (any opposite quote keeps
+	// the preferred delimiter); [QuoteMinEscape] instead compares quote-character counts.
 	QuoteLegacy QuoteStrategy = iota
 	// QuoteAlways uses PreferredQuote for every string and bytes literal.
 	QuoteAlways
 	// QuoteMinEscape picks the delimiter whose quote character occurs less often in the payload.
 	// On a tie, PreferredQuote wins. Only quote-character counts matter; other escapes are delimiter-independent.
+	// With PreferredSingleQuote it often matches [QuoteLegacy], but when both delimiters appear
+	// MinEscape compares counts (e.g. a''b"c stays single-quoted under Legacy+Single but uses
+	// double under MinEscape+Single because one double escape beats two single escapes).
 	QuoteMinEscape
 )
 
@@ -132,10 +137,22 @@ func normalizeLiteralQuote(cfg LiteralQuoteConfig) LiteralQuoteConfig {
 
 func toInternalQuotePolicy(cfg LiteralQuoteConfig) internal.QuotePolicy {
 	cfg = normalizeLiteralQuote(cfg)
-	return internal.QuotePolicy{
-		Strategy:  internal.QuoteStrategy(cfg.Strategy),
-		Preferred: internal.PreferredQuote(cfg.PreferredQuote),
+	var p internal.QuotePolicy
+	switch cfg.Strategy {
+	case QuoteAlways:
+		p.Strategy = internal.QuoteStrategyAlways
+	case QuoteMinEscape:
+		p.Strategy = internal.QuoteStrategyMinEscape
+	default:
+		p.Strategy = internal.QuoteStrategyLegacy
 	}
+	switch cfg.PreferredQuote {
+	case PreferredSingleQuote:
+		p.Preferred = internal.PreferredQuoteSingle
+	default:
+		p.Preferred = internal.PreferredQuoteDouble
+	}
+	return p
 }
 
 func literalQuoteForFormatter(formatter any) LiteralQuoteConfig {

--- a/literal_quote.go
+++ b/literal_quote.go
@@ -36,6 +36,15 @@ type LiteralQuoteConfig struct {
 	PreferredQuote PreferredQuote
 }
 
+// LiteralFormatOptions holds settings that apply only to the literal preset ([LiteralFormatConfig]
+// and clones). Other presets ignore this field. A future major release may move literal-specific
+// configuration off [FormatConfig] entirely; callers should set options via literal constructors
+// or [WithLiteralQuote] rather than assuming a stable nested layout.
+type LiteralFormatOptions struct {
+	// Quote selects the outer delimiter policy for string and bytes SQL-style literals.
+	Quote LiteralQuoteConfig
+}
+
 // LiteralOption configures a literal preset returned by [LiteralFormatConfigWithOptions].
 type LiteralOption interface {
 	applyLiteralOption(*FormatConfig)
@@ -51,7 +60,7 @@ func WithLiteralQuote(cfg LiteralQuoteConfig) LiteralOption {
 }
 
 func (o literalQuoteOption) applyLiteralOption(fc *FormatConfig) {
-	fc.LiteralQuote = normalizeLiteralQuote(o.cfg)
+	fc.Literal.Quote = normalizeLiteralQuote(o.cfg)
 }
 
 // LiteralFormatConfigWithOptions returns a copy of [LiteralFormatConfig] with the given options applied.
@@ -138,5 +147,5 @@ func literalQuoteForFormatter(formatter any) LiteralQuoteConfig {
 	if !ok {
 		return LiteralQuoteConfig{}
 	}
-	return fc.LiteralQuote
+	return fc.Literal.Quote
 }

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -94,6 +94,9 @@ func TestQuoteStrategyString(t *testing.T) {
 	if got, want := QuoteMinEscape.String(), "QuoteMinEscape"; got != want {
 		t.Fatalf("QuoteMinEscape.String() = %q, want %q", got, want)
 	}
+	if got, want := QuoteStrategy(200).String(), "QuoteStrategy(200)"; got != want {
+		t.Fatalf("QuoteStrategy(200).String() = %q, want %q", got, want)
+	}
 	if got, want := PreferredSingleQuote.String(), "PreferredSingleQuote"; got != want {
 		t.Fatalf("PreferredSingleQuote.String() = %q, want %q", got, want)
 	}

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -479,6 +479,11 @@ func TestLiteralQuoteForFormatterNonFormatConfig(t *testing.T) {
 	if got := literalQuoteForFormatter(struct{}{}); got != (LiteralQuoteConfig{}) {
 		t.Fatalf("non-FormatConfig formatter: got %+v, want zero", got)
 	}
+
+	var nilFC *FormatConfig
+	if got := literalQuoteForFormatter(nilFC); got != (LiteralQuoteConfig{}) {
+		t.Fatalf("typed nil *FormatConfig: got %+v, want zero", got)
+	}
 }
 
 func ExampleLiteralFormatConfigWithSingleQuotedLiterals() {

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -8,7 +8,6 @@ import (
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	"github.com/apstndb/spanvalue/gcvctor"
-	"github.com/apstndb/spanvalue/internal"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -186,9 +185,7 @@ func TestLiteralQuoteLegacyPreferredSingle(t *testing.T) {
 		{name: "no quotes uses preferred single", gcv: gcvctor.StringValue("plain"), want: `'plain'`},
 		{name: "only singles uses opposite double", gcv: gcvctor.StringValue("it's"), want: `"it's"`},
 		{name: "only doubles uses opposite single", gcv: gcvctor.StringValue(`say "hi"`), want: `'say "hi"'`},
-		{name: "both uses preferred single", gcv: gcvctor.StringValue(`"it's"`), want: internal.ToStringLiteralPolicy(`"it's"`, internal.QuotePolicy{
-			Strategy: internal.QuoteStrategyLegacy, Preferred: internal.PreferredQuoteSingle,
-		})},
+		{name: "both uses preferred single", gcv: gcvctor.StringValue(`"it's"`), want: `'"it\'s"'`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -407,6 +404,45 @@ func TestLiteralQuoteNormalizeAtFormatTime(t *testing.T) {
 func TestLiteralQuoteEscapeCorners(t *testing.T) {
 	t.Parallel()
 
+	escapeCornerWants := map[string]map[string]string{
+		"legacy_double": {
+			"plain":       `"plain"`,
+			"only_single": `"it's"`,
+			"only_double": `'say "hi"'`,
+			"both_quotes": `"\"it's\""`,
+		},
+		"legacy_single": {
+			"plain":       `'plain'`,
+			"only_single": `"it's"`,
+			"only_double": `'say "hi"'`,
+			"both_quotes": `'"it\'s"'`,
+		},
+		"always_single": {
+			"plain":       `'plain'`,
+			"only_single": `'it\'s'`,
+			"only_double": `'say "hi"'`,
+			"both_quotes": `'"it\'s"'`,
+		},
+		"always_double": {
+			"plain":       `"plain"`,
+			"only_single": `"it's"`,
+			"only_double": `"say \"hi\""`,
+			"both_quotes": `"\"it's\""`,
+		},
+		"minescape_single": {
+			"plain":       `'plain'`,
+			"only_single": `"it's"`,
+			"only_double": `'say "hi"'`,
+			"both_quotes": `'"it\'s"'`,
+		},
+		"minescape_double": {
+			"plain":       `"plain"`,
+			"only_single": `"it's"`,
+			"only_double": `'say "hi"'`,
+			"both_quotes": `'"it\'s"'`,
+		},
+	}
+
 	configs := []struct {
 		name string
 		cfg  LiteralQuoteConfig
@@ -421,19 +457,18 @@ func TestLiteralQuoteEscapeCorners(t *testing.T) {
 	payloads := []struct {
 		name string
 		gcv  spanner.GenericColumnValue
-		s    string
 	}{
-		{name: "plain", gcv: gcvctor.StringValue("plain"), s: "plain"},
-		{name: "only_single", gcv: gcvctor.StringValue("it's"), s: "it's"},
-		{name: "only_double", gcv: gcvctor.StringValue(`say "hi"`), s: `say "hi"`},
-		{name: "both_quotes", gcv: gcvctor.StringValue(`"it's"`), s: `"it's"`},
+		{name: "plain", gcv: gcvctor.StringValue("plain")},
+		{name: "only_single", gcv: gcvctor.StringValue("it's")},
+		{name: "only_double", gcv: gcvctor.StringValue(`say "hi"`)},
+		{name: "both_quotes", gcv: gcvctor.StringValue(`"it's"`)},
 	}
 
 	for _, config := range configs {
 		t.Run(config.name, func(t *testing.T) {
 			t.Parallel()
 			fc := LiteralFormatConfigWithQuote(config.cfg)
-			policy := toInternalQuotePolicy(config.cfg)
+			wants := escapeCornerWants[config.name]
 			for _, payload := range payloads {
 				t.Run(payload.name, func(t *testing.T) {
 					t.Parallel()
@@ -441,7 +476,7 @@ func TestLiteralQuoteEscapeCorners(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					want := internal.ToStringLiteralPolicy(payload.s, policy)
+					want := wants[payload.name]
 					if got != want {
 						t.Fatalf("got %q, want %q", got, want)
 					}

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -72,8 +72,8 @@ func TestLiteralFormatConfigWithOptions(t *testing.T) {
 		}),
 	)
 	want := LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote}
-	if fc.LiteralQuote != want {
-		t.Fatalf("LiteralQuote = %+v, want %+v", fc.LiteralQuote, want)
+	if fc.Literal.Quote != want {
+		t.Fatalf("Literal.Quote = %+v, want %+v", fc.Literal.Quote, want)
 	}
 
 	got, err := fc.FormatToplevelColumn(gcvctor.StringValue("plain"))
@@ -146,8 +146,8 @@ func TestLiteralFormatConfigWithSingleQuotedLiterals(t *testing.T) {
 
 	fc := LiteralFormatConfigWithSingleQuotedLiterals()
 	want := LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredSingleQuote}
-	if fc.LiteralQuote != want {
-		t.Fatalf("LiteralQuote = %+v, want %+v", fc.LiteralQuote, want)
+	if fc.Literal.Quote != want {
+		t.Fatalf("Literal.Quote = %+v, want %+v", fc.Literal.Quote, want)
 	}
 
 	got, err := fc.FormatToplevelColumn(gcvctor.DateValue(civil.Date{Year: 2014, Month: 9, Day: 27}))
@@ -387,7 +387,7 @@ func TestLiteralQuoteNormalizeAtFormatTime(t *testing.T) {
 	t.Parallel()
 
 	fc := LiteralFormatConfig()
-	fc.LiteralQuote = LiteralQuoteConfig{
+	fc.Literal.Quote = LiteralQuoteConfig{
 		Strategy:       QuoteStrategy(99),
 		PreferredQuote: PreferredSingleQuote,
 	}

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -1,0 +1,490 @@
+package spanvalue
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/apstndb/spanvalue/internal"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNormalizeLiteralQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   LiteralQuoteConfig
+		want LiteralQuoteConfig
+	}{
+		{
+			name: "zero value legacy",
+			in:   LiteralQuoteConfig{},
+			want: LiteralQuoteConfig{Strategy: QuoteLegacy, PreferredQuote: PreferredDoubleQuote},
+		},
+		{
+			name: "legacy keeps preferred single",
+			in:   LiteralQuoteConfig{Strategy: QuoteLegacy, PreferredQuote: PreferredSingleQuote},
+			want: LiteralQuoteConfig{Strategy: QuoteLegacy, PreferredQuote: PreferredSingleQuote},
+		},
+		{
+			name: "always single",
+			in:   LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredSingleQuote},
+			want: LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredSingleQuote},
+		},
+		{
+			name: "min escape keeps preferred single",
+			in:   LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote},
+			want: LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote},
+		},
+		{
+			name: "invalid strategy keeps valid preferred",
+			in:   LiteralQuoteConfig{Strategy: QuoteStrategy(99), PreferredQuote: PreferredSingleQuote},
+			want: LiteralQuoteConfig{Strategy: QuoteLegacy, PreferredQuote: PreferredSingleQuote},
+		},
+		{
+			name: "invalid preferred",
+			in:   LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredQuote(99)},
+			want: LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredDoubleQuote},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeLiteralQuote(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeLiteralQuote() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLiteralFormatConfigWithOptions(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfigWithOptions(
+		WithLiteralQuote(LiteralQuoteConfig{
+			Strategy:       QuoteMinEscape,
+			PreferredQuote: PreferredSingleQuote,
+		}),
+	)
+	want := LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote}
+	if fc.LiteralQuote != want {
+		t.Fatalf("LiteralQuote = %+v, want %+v", fc.LiteralQuote, want)
+	}
+
+	got, err := fc.FormatToplevelColumn(gcvctor.StringValue("plain"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `'plain'` {
+		t.Fatalf("STRING literal = %q, want 'plain'", got)
+	}
+}
+
+func TestQuoteStrategyString(t *testing.T) {
+	t.Parallel()
+
+	if got, want := QuoteLegacy.String(), "QuoteLegacy"; got != want {
+		t.Fatalf("QuoteLegacy.String() = %q, want %q", got, want)
+	}
+	if got, want := QuoteMinEscape.String(), "QuoteMinEscape"; got != want {
+		t.Fatalf("QuoteMinEscape.String() = %q, want %q", got, want)
+	}
+	if got, want := PreferredSingleQuote.String(), "PreferredSingleQuote"; got != want {
+		t.Fatalf("PreferredSingleQuote.String() = %q, want %q", got, want)
+	}
+}
+
+func TestLiteralQuoteMinEscape(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteMinEscape,
+		PreferredQuote: PreferredDoubleQuote,
+	})
+
+	got, err := fc.FormatToplevelColumn(gcvctor.StringValue("it's ok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `"it's ok"` {
+		t.Fatalf("more singles -> double: got %q, want %q", got, `"it's ok"`)
+	}
+
+	got, err = fc.FormatToplevelColumn(gcvctor.StringValue(`say "hi"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `'say "hi"'` {
+		t.Fatalf("more doubles -> single: got %q, want %q", got, `'say "hi"'`)
+	}
+
+	// Legacy + PreferredDoubleQuote uses preferred when both quote types appear;
+	// MinEscape picks the delimiter with fewer characters to escape.
+	legacyGot, err := LiteralFormatConfig().FormatToplevelColumn(gcvctor.StringValue(`"it's"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = fc.FormatToplevelColumn(gcvctor.StringValue(`"it's"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == legacyGot {
+		t.Fatalf("min escape should differ from legacy; legacy=%q got=%q", legacyGot, got)
+	}
+	if got[0] != '\'' || got[len(got)-1] != '\'' {
+		t.Fatalf("expected single-quoted outer delimiter, got %q", got)
+	}
+}
+
+func TestLiteralFormatConfigWithSingleQuotedLiterals(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfigWithSingleQuotedLiterals()
+	want := LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredSingleQuote}
+	if fc.LiteralQuote != want {
+		t.Fatalf("LiteralQuote = %+v, want %+v", fc.LiteralQuote, want)
+	}
+
+	got, err := fc.FormatToplevelColumn(gcvctor.DateValue(civil.Date{Year: 2014, Month: 9, Day: 27}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "DATE '2014-09-27'" {
+		t.Fatalf("DATE literal = %q, want DATE '2014-09-27'", got)
+	}
+
+	got, err = fc.FormatToplevelColumn(gcvctor.StringValue("it's fine"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `'it\'s fine'` {
+		t.Fatalf("STRING literal = %q, want 'it\\'s fine'", got)
+	}
+}
+
+func TestLiteralQuoteLegacyPreferredSingle(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteLegacy,
+		PreferredQuote: PreferredSingleQuote,
+	})
+
+	tests := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		want string
+	}{
+		{name: "no quotes uses preferred single", gcv: gcvctor.StringValue("plain"), want: `'plain'`},
+		{name: "only singles uses opposite double", gcv: gcvctor.StringValue("it's"), want: `"it's"`},
+		{name: "only doubles uses opposite single", gcv: gcvctor.StringValue(`say "hi"`), want: `'say "hi"'`},
+		{name: "both uses preferred single", gcv: gcvctor.StringValue(`"it's"`), want: internal.ToStringLiteralPolicy(`"it's"`, internal.QuotePolicy{
+			Strategy: internal.QuoteStrategyLegacy, Preferred: internal.PreferredQuoteSingle,
+		})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := fc.FormatToplevelColumn(tt.gcv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLiteralQuoteLegacyAdaptive(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfig()
+	tests := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		want string
+	}{
+		{
+			name: "only double quote in payload",
+			gcv:  gcvctor.StringValue(`say "hi"`),
+			want: `'say "hi"'`,
+		},
+		{
+			name: "only single quote in payload",
+			gcv:  gcvctor.StringValue("it's"),
+			want: `"it's"`,
+		},
+		{
+			name: "both quote characters",
+			gcv:  gcvctor.StringValue(`"it's"`),
+			want: `"\"it's\""`,
+		},
+		{
+			name: "no quotes default double",
+			gcv:  gcvctor.StringValue("plain"),
+			want: `"plain"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := fc.FormatToplevelColumn(tt.gcv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLiteralQuoteNaNInf(t *testing.T) {
+	t.Parallel()
+
+	legacy := LiteralFormatConfig()
+	doubleAlways := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteAlways,
+		PreferredQuote: PreferredDoubleQuote,
+	})
+
+	cases := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		want string
+	}{
+		{"float64 nan legacy", gcvctor.Float64Value(math.NaN()), "CAST('nan' AS FLOAT64)"},
+		{"float64 inf legacy", gcvctor.Float64Value(math.Inf(1)), "CAST('inf' AS FLOAT64)"},
+		{"float64 neg inf legacy", gcvctor.Float64Value(math.Inf(-1)), "CAST('-inf' AS FLOAT64)"},
+		{"float32 nan legacy", gcvctor.Float32Value(float32(math.NaN())), "CAST('nan' AS FLOAT32)"},
+		{"float32 inf legacy", gcvctor.Float32Value(float32(math.Inf(1))), "CAST('inf' AS FLOAT32)"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := legacy.FormatToplevelColumn(tt.gcv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("legacy got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	doubleCases := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		want string
+	}{
+		{"float64 nan double", gcvctor.Float64Value(math.NaN()), `CAST("nan" AS FLOAT64)`},
+		{"float64 inf double", gcvctor.Float64Value(math.Inf(1)), `CAST("inf" AS FLOAT64)`},
+		{"float32 nan double", gcvctor.Float32Value(float32(math.NaN())), `CAST("nan" AS FLOAT32)`},
+	}
+	for _, tt := range doubleCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := doubleAlways.FormatToplevelColumn(tt.gcv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("double always got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	minEscapeDouble := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteMinEscape,
+		PreferredQuote: PreferredDoubleQuote,
+	})
+	got, err := minEscapeDouble.FormatToplevelColumn(gcvctor.Float64Value(math.NaN()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `CAST("nan" AS FLOAT64)` {
+		t.Fatalf("min escape double NaN = %q, want CAST(\"nan\" AS FLOAT64)", got)
+	}
+}
+
+func TestFormatNullableValueLiteralMatchesWithQuoteZero(t *testing.T) {
+	t.Parallel()
+
+	nv := spanner.NullString{StringVal: "hello", Valid: true}
+	got, err := formatNullableValueLiteral(nv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := formatNullableValueLiteralWithQuote(LiteralQuoteConfig{}, nv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestLiteralQuoteFastPathMatchesSlowPath(t *testing.T) {
+	t.Parallel()
+
+	presets := []struct {
+		name string
+		fc   *FormatConfig
+	}{
+		{name: "legacy default", fc: LiteralFormatConfig()},
+		{name: "single always", fc: LiteralFormatConfigWithSingleQuotedLiterals()},
+		{name: "legacy preferred single", fc: LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+			Strategy: QuoteLegacy, PreferredQuote: PreferredSingleQuote,
+		})},
+		{name: "min escape single tie", fc: LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+			Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote,
+		})},
+		{name: "min escape double tie", fc: LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+			Strategy: QuoteMinEscape, PreferredQuote: PreferredDoubleQuote,
+		})},
+		{name: "always double", fc: LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+			Strategy: QuoteAlways, PreferredQuote: PreferredDoubleQuote,
+		})},
+	}
+
+	scalars := []spanner.GenericColumnValue{
+		gcvctor.StringValue("hello"),
+		gcvctor.StringValue("it's"),
+		gcvctor.BytesValue([]byte{0, 1}),
+		gcvctor.DateValue(civil.Date{Year: 2020, Month: 1, Day: 2}),
+		gcvctor.Float64Value(math.NaN()),
+		gcvctor.Float32Value(float32(math.Inf(-1))),
+	}
+
+	for _, preset := range presets {
+		t.Run(preset.name, func(t *testing.T) {
+			t.Parallel()
+			legacy := formatConfigNullableOnly(preset.fc)
+			for i, gcv := range scalars {
+				got, err := preset.fc.FormatToplevelColumn(gcv)
+				if err != nil {
+					t.Fatalf("scalar[%d] direct: %v", i, err)
+				}
+				want, err := legacy.FormatToplevelColumn(gcv)
+				if err != nil {
+					t.Fatalf("scalar[%d] nullable path: %v", i, err)
+				}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Fatalf("scalar[%d] mismatch (-nullable +direct):\n%s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestLiteralQuoteNormalizeAtFormatTime(t *testing.T) {
+	t.Parallel()
+
+	fc := LiteralFormatConfig()
+	fc.LiteralQuote = LiteralQuoteConfig{
+		Strategy:       QuoteStrategy(99),
+		PreferredQuote: PreferredSingleQuote,
+	}
+	got, err := fc.FormatToplevelColumn(gcvctor.StringValue("plain"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `'plain'`
+	if got != want {
+		t.Fatalf("got %q, want %q (invalid strategy -> legacy + preserved single)", got, want)
+	}
+}
+
+func TestLiteralQuoteEscapeCorners(t *testing.T) {
+	t.Parallel()
+
+	configs := []struct {
+		name string
+		cfg  LiteralQuoteConfig
+	}{
+		{name: "legacy_double", cfg: LiteralQuoteConfig{}},
+		{name: "legacy_single", cfg: LiteralQuoteConfig{Strategy: QuoteLegacy, PreferredQuote: PreferredSingleQuote}},
+		{name: "always_single", cfg: LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredSingleQuote}},
+		{name: "always_double", cfg: LiteralQuoteConfig{Strategy: QuoteAlways, PreferredQuote: PreferredDoubleQuote}},
+		{name: "minescape_single", cfg: LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredSingleQuote}},
+		{name: "minescape_double", cfg: LiteralQuoteConfig{Strategy: QuoteMinEscape, PreferredQuote: PreferredDoubleQuote}},
+	}
+	payloads := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		s    string
+	}{
+		{name: "plain", gcv: gcvctor.StringValue("plain"), s: "plain"},
+		{name: "only_single", gcv: gcvctor.StringValue("it's"), s: "it's"},
+		{name: "only_double", gcv: gcvctor.StringValue(`say "hi"`), s: `say "hi"`},
+		{name: "both_quotes", gcv: gcvctor.StringValue(`"it's"`), s: `"it's"`},
+	}
+
+	for _, config := range configs {
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+			fc := LiteralFormatConfigWithQuote(config.cfg)
+			policy := toInternalQuotePolicy(config.cfg)
+			for _, payload := range payloads {
+				t.Run(payload.name, func(t *testing.T) {
+					t.Parallel()
+					got, err := fc.FormatToplevelColumn(payload.gcv)
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := internal.ToStringLiteralPolicy(payload.s, policy)
+					if got != want {
+						t.Fatalf("got %q, want %q", got, want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestFormatProtoAsCastLiteralQuote(t *testing.T) {
+	t.Parallel()
+
+	gcv := gcvctor.ProtoValue("package.ProtoType", []byte("deadbeef"))
+
+	legacy, err := LiteralFormatConfig().FormatToplevelColumn(gcv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy != "CAST(b\"deadbeef\" AS `package.ProtoType`)" {
+		t.Fatalf("legacy proto = %q", legacy)
+	}
+
+	single, err := LiteralFormatConfigWithSingleQuotedLiterals().FormatToplevelColumn(gcv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if single != "CAST(b'deadbeef' AS `package.ProtoType`)" {
+		t.Fatalf("single-quoted proto = %q", single)
+	}
+}
+
+func TestLiteralQuoteForFormatterNonFormatConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := literalQuoteForFormatter(struct{}{}); got != (LiteralQuoteConfig{}) {
+		t.Fatalf("non-FormatConfig formatter: got %+v, want zero", got)
+	}
+}
+
+func ExampleLiteralFormatConfigWithSingleQuotedLiterals() {
+	fc := LiteralFormatConfigWithSingleQuotedLiterals()
+	date, _ := fc.FormatToplevelColumn(gcvctor.DateValue(civil.Date{Year: 2014, Month: 9, Day: 27}))
+	str, _ := fc.FormatToplevelColumn(gcvctor.StringValue("it's fine"))
+	fmt.Println(date)
+	fmt.Println(str)
+	// Output:
+	// DATE '2014-09-27'
+	// 'it\'s fine'
+}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -1116,6 +1117,30 @@ func TestSQLInsertWriterInsertKind(t *testing.T) {
 				t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestSQLInsertWriterWithSingleQuotedLiterals(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	cfg := spanvalue.LiteralFormatConfigWithSingleQuotedLiterals()
+	w := mustNewSQLInsertWriter(t,
+		&out,
+		"users",
+		WithMetadata(metadataWithColumnNames("event_date", "note")),
+		WithFormatter(cfg),
+	)
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{
+		gcvctor.DateValue(civil.Date{Year: 2014, Month: 9, Day: 27}),
+		gcvctor.StringValue("it's fine"),
+	}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+
+	want := "INSERT INTO `users` (`event_date`, `note`) VALUES (DATE '2014-09-27', 'it\\'s fine');\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `FormatConfig.Literal.Quote` (`LiteralQuoteConfig`) and quote strategies (`QuoteLegacy`, `QuoteAlways`, `QuoteMinEscape`) for the literal preset.
- Default (`LiteralFormatConfig()` / zero `Literal.Quote`) stays **byte-identical** to today's `suitableQuote` output for STRING/BYTES/DATE/TIMESTAMP/NUMERIC and related literals.
- New constructors: `LiteralFormatConfigWithQuote`, `LiteralFormatConfigWithSingleQuotedLiterals`, `LiteralFormatConfigWithOptions`, and `WithLiteralQuote`.
- `QuoteLegacy` generalizes historical adaptive quoting while respecting `PreferredQuote` (zero value + `PreferredDoubleQuote` = current behavior). `PreferredQuote` has no separate "unspecified" variant: omitting the field is the same as `PreferredDoubleQuote`.
- Fast and slow literal paths both honor quote policy. NaN/±Inf CAST literals use a temporary v0.5 compat rule (Legacy → single quotes; Always/MinEscape → `PreferredQuote`).

Closes #143.

## Upgrading

### 1. `FormatConfig` gains an exported field

Downstream **unkeyed** composite literals may fail to compile:

```go
// Before
fc := &spanvalue.FormatConfig{NullString: "NULL", FormatNullable: fn}

// After — use keyed fields or a preset constructor
fc := &spanvalue.FormatConfig{
    NullString:     "NULL",
    FormatNullable: fn,
    Literal: spanvalue.LiteralFormatOptions{}, // zero Quote = legacy
}
```

`LiteralFormatConfig()` signature is **unchanged** (`func() *FormatConfig`). Existing call sites that use the constructor or clone presets need no change.

### 2. Default behavior unchanged (v0.5)

`LiteralFormatConfig()`, `FormatRowLiteral`, `FormatColumnLiteral`, and `SQLInsertWriter` defaults produce the same strings as before unless you opt into a new constructor.

### 3. Single-quoted SQL INSERT (opt-in)

```go
w, err := writer.NewSQLInsertWriter(out, "users",
    writer.WithFormatter(spanvalue.LiteralFormatConfigWithSingleQuotedLiterals()),
)
// DATE '2014-09-27', 'it\'s fine' instead of DATE "2014-09-27", "it's fine"
```

Other options: `LiteralFormatConfigWithQuote`, `LiteralFormatConfigWithOptions(WithLiteralQuote(...))`, or assign `Literal.Quote` on a cloned config.

### 4. NaN/±Inf CAST literals (v0.5 compat; planned v0.6 change)

In **v0.5**, non-finite float CAST output is intentionally special-cased:

| Policy | NaN/±Inf CAST delimiter (v0.5) |
|--------|--------------------------------|
| `QuoteLegacy` (default) | single quotes — `CAST('nan' AS FLOAT64)` |
| `QuoteAlways` / `QuoteMinEscape` + `PreferredDoubleQuote` | double quotes — `CAST("nan" AS FLOAT64)` |
| `QuoteAlways` / `QuoteMinEscape` + `PreferredSingleQuote` | single quotes |

This differs from ordinary STRING/BYTES quoting under the same policy when the payload contains no quote characters.

**Planned for v0.6:** align NaN/±Inf CAST delimiters with the same `Literal.Quote` rules used for other quoted literals (via `quoteForPayload`), in one release. Strict preservation of the v0.5 NaN/±Inf exception is **not** a long-term compatibility goal. No `PreferredQuote` "unspecified" variant will be added; zero / omitted preferred remains `PreferredDoubleQuote`.

Document the v0.6 output change in the GitHub Release at tag time when NaN/±Inf formatting is updated.

### 5. Performance

`BenchmarkFormatPerType/(STRING|BYTES|DATE)/Literal/Direct` vs `main` @ 3831066: geomean +0.19% sec/op, **allocs/op identical** (benchstat, n=5).

## Test plan

- [x] `make check`
- [x] Golden / escape-corner tests per strategy (`literal_quote_test.go`)
- [x] Fast ≡ slow equivalence for all strategies
- [x] NaN/±Inf FLOAT32/FLOAT64 (legacy single; opt-in double)
- [x] PROTO `FormatProtoAsCast` + `SQLInsertWriter` single-quoted e2e
- [x] `ExampleLiteralFormatConfigWithSingleQuotedLiterals`