### PR TITLE
Add descriptor-aware PROTO/ENUM formatting plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,10 @@ For display paths where protobuf descriptors are available, prepend opt-in
 [`protofmt`](https://pkg.go.dev/github.com/apstndb/spanvalue/protofmt) plugins to a cloned
 formatter. These plugins render PROTO values as protobuf text and ENUM values
 as names; they are display-oriented and do not replace descriptor-free SQL
-literal output such as `FormatProtoAsCast` / `FormatEnumAsCast`.
+literal output such as `FormatProtoAsCast` / `FormatEnumAsCast`. Descriptor
+loading and compilation stay in the application. If you enable multiline
+prototext, nested ARRAY/STRUCT cells and delimited-output fields can contain
+embedded newlines.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see [writer/README.md](writer/README.md). For
 non-streaming paths, use

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Helpers for working with Cloud Spanner’s [`spanner.GenericColumnValue`](https:
 |--------|------|
 | [`github.com/apstndb/spanvalue`](https://pkg.go.dev/github.com/apstndb/spanvalue) | Format `spanner.GenericColumnValue` and `*spanner.Row` using [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig) and presets such as [`LiteralFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#LiteralFormatConfig), [`JSONFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#JSONFormatConfig), [`SpannerCLICompatibleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SpannerCLICompatibleFormatConfig). |
 | [`github.com/apstndb/spanvalue/gcvctor`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor) | Build `spanner.GenericColumnValue` (scalars, `ARRAY`, `STRUCT`, typed nulls). Types are often composed with [`github.com/apstndb/spantype/typector`](https://pkg.go.dev/github.com/apstndb/spantype/typector). |
+| [`github.com/apstndb/spanvalue/protofmt`](https://pkg.go.dev/github.com/apstndb/spanvalue/protofmt) | Opt-in descriptor-aware PROTO and ENUM display plugins for [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig). |
 | [`github.com/apstndb/spanvalue/writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer) | Stream Spanner rows to CSV, TSV, JSONL, or SQL INSERT ([writer/README.md](writer/README.md)). |
 
 ## Identifier quoting helpers
@@ -203,6 +204,11 @@ Delimited output uses [`SimpleFormatConfig`](https://pkg.go.dev/github.com/apstn
 by default. Build cells with [`gcvctor.EnumValue`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#EnumValue)
 and [`gcvctor.ProtoValue`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#ProtoValue),
 then `WriteGCVs` (see `TestDelimitedWriterWriteGCVsEnumProto` in the `writer` package).
+For display paths where protobuf descriptors are available, prepend opt-in
+[`protofmt`](https://pkg.go.dev/github.com/apstndb/spanvalue/protofmt) plugins to a cloned
+formatter. These plugins render PROTO values as protobuf text and ENUM values
+as names; they are display-oriented and do not replace descriptor-free SQL
+literal output such as `FormatProtoAsCast` / `FormatEnumAsCast`.
 Delimited, JSONL, and SQL encodings differ after
 spanvalue formats each column; see [writer/README.md](writer/README.md). For
 non-streaming paths, use

--- a/doc.go
+++ b/doc.go
@@ -36,5 +36,6 @@
 //
 // To build [cloud.google.com/go/spanner.GenericColumnValue] values from Go types, see
 // [github.com/apstndb/spanvalue/gcvctor]. For streaming row export, see
-// [github.com/apstndb/spanvalue/writer].
+// [github.com/apstndb/spanvalue/writer]. For opt-in descriptor-aware PROTO and ENUM
+// display plugins, see [github.com/apstndb/spanvalue/protofmt].
 package spanvalue

--- a/protofmt/doc.go
+++ b/protofmt/doc.go
@@ -1,0 +1,9 @@
+// Package protofmt provides descriptor-aware PROTO and ENUM formatting plugins
+// for spanvalue format configs.
+//
+// The plugins in this package are opt-in. They are intended for display paths
+// where protobuf descriptors are available, such as CLI table output. They do
+// not change spanvalue preset defaults and do not replace descriptor-free SQL
+// literal fallbacks such as spanvalue.FormatProtoAsCast and
+// spanvalue.FormatEnumAsCast.
+package protofmt

--- a/protofmt/doc.go
+++ b/protofmt/doc.go
@@ -4,6 +4,11 @@
 // The plugins in this package are opt-in. They are intended for display paths
 // where protobuf descriptors are available, such as CLI table output. They do
 // not change spanvalue preset defaults and do not replace descriptor-free SQL
-// literal fallbacks such as spanvalue.FormatProtoAsCast and
-// spanvalue.FormatEnumAsCast.
+// literal fallbacks such as [github.com/apstndb/spanvalue.FormatProtoAsCast] and
+// [github.com/apstndb/spanvalue.FormatEnumAsCast].
+//
+// Generated protobuf types can be resolved through
+// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes] when their
+// generated packages are imported and linked into the binary, including by
+// blank import.
 package protofmt

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -1,0 +1,278 @@
+package protofmt
+
+import (
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanvalue"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	minEnumNumber = int64(-1 << 31)
+	maxEnumNumber = int64(1<<31 - 1)
+)
+
+// ProtoEnumResolver resolves protobuf message, extension, and enum types for
+// descriptor-aware Spanner PROTO and ENUM display.
+type ProtoEnumResolver interface {
+	protoregistry.MessageTypeResolver
+	protoregistry.ExtensionTypeResolver
+	FindEnumByName(protoreflect.FullName) (protoreflect.EnumType, error)
+}
+
+var (
+	_ ProtoEnumResolver = (*dynamicpb.Types)(nil)
+	_ ProtoEnumResolver = (*protoregistry.Types)(nil)
+
+	_ spanvalue.FormatComplexFunc = FormatProtoTextValue(ProtoTextValueOptions{})
+	_ spanvalue.FormatComplexFunc = FormatEnumNameValue(EnumNameValueOptions{})
+)
+
+// ProtoTextValueOptions configures [FormatProtoTextValue].
+//
+// Resolver is authoritative: [FormatProtoTextValue] copies Unmarshal and
+// Marshal, then overwrites both local Resolver fields from Resolver without
+// mutating caller-owned options.
+type ProtoTextValueOptions struct {
+	Resolver  ProtoEnumResolver
+	Unmarshal proto.UnmarshalOptions
+	Marshal   prototext.MarshalOptions
+}
+
+// EnumNameValueOptions configures [FormatEnumNameValue].
+type EnumNameValueOptions struct {
+	Resolver ProtoEnumResolver
+}
+
+// FormatProtoTextValue returns a spanvalue plugin that formats Spanner PROTO
+// values as protobuf text format when opts.Resolver can resolve the message
+// type.
+//
+// The plugin returns [spanvalue.ErrFallthrough] for non-PROTO values, nil or
+// missing resolvers, empty type names, and missing message types. Typed NULL
+// PROTO values return formatter.GetNullString without consulting the resolver.
+// Malformed non-NULL wire payloads, base64 decode failures, unmarshal failures,
+// and marshal failures are returned as real errors.
+//
+// Protobuf text output is display-oriented and intentionally not stable. Tests
+// and callers must not depend on byte-for-byte stable output.
+func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFunc {
+	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+		if value.Type.GetCode() != sppb.TypeCode_PROTO {
+			return "", spanvalue.ErrFallthrough
+		}
+		if spanvalue.IsNull(value) {
+			return formatter.GetNullString(), nil
+		}
+		if isNilResolver(opts.Resolver) {
+			return "", spanvalue.ErrFallthrough
+		}
+
+		typeName := protoreflect.FullName(value.Type.GetProtoTypeFqn())
+		if typeName == "" {
+			return "", spanvalue.ErrFallthrough
+		}
+		messageType, err := opts.Resolver.FindMessageByName(typeName)
+		if isExactNotFound(err) {
+			return "", spanvalue.ErrFallthrough
+		}
+		if err != nil {
+			return "", err
+		}
+
+		wire, err := stringWire(value, sppb.TypeCode_PROTO)
+		if err != nil {
+			return "", err
+		}
+		payload, err := base64.StdEncoding.DecodeString(wire)
+		if err != nil {
+			return "", err
+		}
+
+		message := messageType.New()
+		unmarshal := opts.Unmarshal
+		unmarshal.Resolver = opts.Resolver
+		if err := unmarshal.Unmarshal(payload, message.Interface()); err != nil {
+			return "", err
+		}
+
+		marshal := opts.Marshal
+		marshal.Resolver = opts.Resolver
+		out, err := marshal.Marshal(message.Interface())
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSuffix(string(out), "\n"), nil
+	}
+}
+
+// FormatEnumNameValue returns a spanvalue plugin that formats Spanner ENUM
+// values as enum value names when opts.Resolver can resolve the enum type and
+// value number.
+//
+// The plugin returns [spanvalue.ErrFallthrough] for non-ENUM values, nil or
+// missing resolvers, empty type names, and missing enum types. Typed NULL ENUM
+// values return formatter.GetNullString without consulting the resolver. Known
+// enum types with unknown or out-of-range numeric values return the original
+// numeric string.
+func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc {
+	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+		if value.Type.GetCode() != sppb.TypeCode_ENUM {
+			return "", spanvalue.ErrFallthrough
+		}
+		if spanvalue.IsNull(value) {
+			return formatter.GetNullString(), nil
+		}
+		if isNilResolver(opts.Resolver) {
+			return "", spanvalue.ErrFallthrough
+		}
+
+		typeName := protoreflect.FullName(value.Type.GetProtoTypeFqn())
+		if typeName == "" {
+			return "", spanvalue.ErrFallthrough
+		}
+		enumType, err := opts.Resolver.FindEnumByName(typeName)
+		if isExactNotFound(err) {
+			return "", spanvalue.ErrFallthrough
+		}
+		if err != nil {
+			return "", err
+		}
+
+		wire, err := stringWire(value, sppb.TypeCode_ENUM)
+		if err != nil {
+			return "", err
+		}
+		n, err := strconv.ParseInt(wire, 10, 64)
+		if err != nil {
+			return "", err
+		}
+		if n < minEnumNumber || n > maxEnumNumber {
+			return wire, nil
+		}
+
+		valueDesc := enumType.Descriptor().Values().ByNumber(protoreflect.EnumNumber(n))
+		if valueDesc == nil {
+			return wire, nil
+		}
+		return string(valueDesc.Name()), nil
+	}
+}
+
+// ProtoEnumResolverFromFileDescriptorSet builds a dynamic protobuf resolver
+// from fds.
+//
+// A nil fds returns an empty resolver with nil error. Non-nil descriptor sets
+// must be self-contained enough for [protodesc.NewFiles] to resolve imports.
+// Reading .proto files, fetching remote descriptors, invoking compilers, and
+// merging descriptor sets are application responsibilities.
+func ProtoEnumResolverFromFileDescriptorSet(fds *descriptorpb.FileDescriptorSet) (ProtoEnumResolver, error) {
+	if fds == nil {
+		return dynamicpb.NewTypes(nil), nil
+	}
+	files, err := protodesc.NewFiles(fds)
+	if err != nil {
+		return nil, err
+	}
+	return dynamicpb.NewTypes(files), nil
+}
+
+// ComposeProtoEnumResolvers returns a resolver that tries resolvers in order.
+//
+// Nil resolvers are skipped. Lookup continues only when a resolver returns the
+// exact [protoregistry.NotFound] sentinel; wrapped NotFound errors are returned
+// as ordinary errors. If no resolver finds a type, the composed resolver returns
+// exact [protoregistry.NotFound].
+func ComposeProtoEnumResolvers(resolvers ...ProtoEnumResolver) ProtoEnumResolver {
+	return compositeResolver{resolvers: append([]ProtoEnumResolver(nil), resolvers...)}
+}
+
+type compositeResolver struct {
+	resolvers []ProtoEnumResolver
+}
+
+func (r compositeResolver) FindMessageByName(name protoreflect.FullName) (protoreflect.MessageType, error) {
+	return find(r.resolvers, func(resolver ProtoEnumResolver) (protoreflect.MessageType, error) {
+		return resolver.FindMessageByName(name)
+	})
+}
+
+func (r compositeResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	return find(r.resolvers, func(resolver ProtoEnumResolver) (protoreflect.MessageType, error) {
+		return resolver.FindMessageByURL(url)
+	})
+}
+
+func (r compositeResolver) FindExtensionByName(name protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	return find(r.resolvers, func(resolver ProtoEnumResolver) (protoreflect.ExtensionType, error) {
+		return resolver.FindExtensionByName(name)
+	})
+}
+
+func (r compositeResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	return find(r.resolvers, func(resolver ProtoEnumResolver) (protoreflect.ExtensionType, error) {
+		return resolver.FindExtensionByNumber(message, field)
+	})
+}
+
+func (r compositeResolver) FindEnumByName(name protoreflect.FullName) (protoreflect.EnumType, error) {
+	return find(r.resolvers, func(resolver ProtoEnumResolver) (protoreflect.EnumType, error) {
+		return resolver.FindEnumByName(name)
+	})
+}
+
+func find[T any](resolvers []ProtoEnumResolver, lookup func(ProtoEnumResolver) (T, error)) (T, error) {
+	var zero T
+	for _, resolver := range resolvers {
+		if isNilResolver(resolver) {
+			continue
+		}
+		v, err := lookup(resolver)
+		if err == nil {
+			return v, nil
+		}
+		if !isExactNotFound(err) {
+			return zero, err
+		}
+	}
+	return zero, protoregistry.NotFound
+}
+
+func stringWire(value spanner.GenericColumnValue, code sppb.TypeCode) (string, error) {
+	if _, ok := value.Value.GetKind().(*structpb.Value_StringValue); !ok {
+		return "", fmt.Errorf("%w: %v value kind %T", spanvalue.ErrUnknownType, code, value.Value.GetKind())
+	}
+	return value.Value.GetStringValue(), nil
+}
+
+func isExactNotFound(err error) bool {
+	// Resolver contracts require the exact sentinel so wrapped NotFound errors
+	// remain real errors instead of accidental fallback.
+	return err == protoregistry.NotFound //nolint:errorlint
+}
+
+func isNilResolver(resolver ProtoEnumResolver) bool {
+	if resolver == nil {
+		return true
+	}
+	v := reflect.ValueOf(resolver)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -76,6 +76,24 @@ type EnumNameValueOptions struct {
 // Protobuf text output is display-oriented and intentionally not stable. Tests
 // and callers must not depend on byte-for-byte stable output.
 func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFunc {
+	resolver := opts.Resolver
+	if isNilResolver(resolver) {
+		return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+			if value.Type.GetCode() != sppb.TypeCode_PROTO {
+				return "", spanvalue.ErrFallthrough
+			}
+			if spanvalue.IsNull(value) {
+				return formatter.GetNullString(), nil
+			}
+			return "", spanvalue.ErrFallthrough
+		}
+	}
+
+	unmarshal := opts.Unmarshal
+	unmarshal.Resolver = resolver
+	marshal := opts.Marshal
+	marshal.Resolver = resolver
+
 	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 		if value.Type.GetCode() != sppb.TypeCode_PROTO {
 			return "", spanvalue.ErrFallthrough
@@ -83,15 +101,12 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 		if spanvalue.IsNull(value) {
 			return formatter.GetNullString(), nil
 		}
-		if isNilResolver(opts.Resolver) {
-			return "", spanvalue.ErrFallthrough
-		}
 
 		typeName := protoreflect.FullName(value.Type.GetProtoTypeFqn())
 		if typeName == "" {
 			return "", spanvalue.ErrFallthrough
 		}
-		messageType, err := opts.Resolver.FindMessageByName(typeName)
+		messageType, err := resolver.FindMessageByName(typeName)
 		if isExactNotFound(err) {
 			return "", spanvalue.ErrFallthrough
 		}
@@ -109,14 +124,10 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 		}
 
 		message := messageType.New()
-		unmarshal := opts.Unmarshal
-		unmarshal.Resolver = opts.Resolver
 		if err := unmarshal.Unmarshal(payload, message.Interface()); err != nil {
 			return "", err
 		}
 
-		marshal := opts.Marshal
-		marshal.Resolver = opts.Resolver
 		out, err := marshal.Marshal(message.Interface())
 		if err != nil {
 			return "", err
@@ -135,6 +146,19 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 // enum types with unknown or out-of-range numeric values return the original
 // numeric string.
 func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc {
+	resolver := opts.Resolver
+	if isNilResolver(resolver) {
+		return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+			if value.Type.GetCode() != sppb.TypeCode_ENUM {
+				return "", spanvalue.ErrFallthrough
+			}
+			if spanvalue.IsNull(value) {
+				return formatter.GetNullString(), nil
+			}
+			return "", spanvalue.ErrFallthrough
+		}
+	}
+
 	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 		if value.Type.GetCode() != sppb.TypeCode_ENUM {
 			return "", spanvalue.ErrFallthrough
@@ -142,15 +166,12 @@ func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc 
 		if spanvalue.IsNull(value) {
 			return formatter.GetNullString(), nil
 		}
-		if isNilResolver(opts.Resolver) {
-			return "", spanvalue.ErrFallthrough
-		}
 
 		typeName := protoreflect.FullName(value.Type.GetProtoTypeFqn())
 		if typeName == "" {
 			return "", spanvalue.ErrFallthrough
 		}
-		enumType, err := opts.Resolver.FindEnumByName(typeName)
+		enumType, err := resolver.FindEnumByName(typeName)
 		if isExactNotFound(err) {
 			return "", spanvalue.ErrFallthrough
 		}
@@ -208,6 +229,9 @@ func ComposeProtoEnumResolvers(resolvers ...ProtoEnumResolver) ProtoEnumResolver
 		if !isNilResolver(resolver) {
 			active = append(active, resolver)
 		}
+	}
+	if len(active) == 1 {
+		return active[0]
 	}
 	return compositeResolver{resolvers: active}
 }

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -113,6 +113,9 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 		if err != nil {
 			return "", err
 		}
+		if messageType == nil {
+			return "", spanvalue.ErrFallthrough
+		}
 
 		wire, err := stringWire(value, sppb.TypeCode_PROTO)
 		if err != nil {
@@ -178,6 +181,9 @@ func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc 
 		if err != nil {
 			return "", err
 		}
+		if enumType == nil {
+			return "", spanvalue.ErrFallthrough
+		}
 
 		wire, err := stringWire(value, sppb.TypeCode_ENUM)
 		if err != nil {
@@ -229,6 +235,11 @@ func ComposeProtoEnumResolvers(resolvers ...ProtoEnumResolver) ProtoEnumResolver
 		if !isNilResolver(resolver) {
 			active = append(active, resolver)
 		}
+	}
+	if len(active) == 0 {
+		// Keep ComposeProtoEnumResolvers usable as a resolver even when it is
+		// empty: direct Find* calls return exact NotFound instead of panicking.
+		return compositeResolver{resolvers: nil}
 	}
 	if len(active) == 1 {
 		return active[0]

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -30,6 +30,12 @@ const (
 type ProtoEnumResolver interface {
 	protoregistry.MessageTypeResolver
 	protoregistry.ExtensionTypeResolver
+	EnumResolver
+}
+
+// EnumResolver resolves protobuf enum types for descriptor-aware Spanner ENUM
+// display.
+type EnumResolver interface {
 	FindEnumByName(protoreflect.FullName) (protoreflect.EnumType, error)
 }
 
@@ -54,7 +60,7 @@ type ProtoTextValueOptions struct {
 
 // EnumNameValueOptions configures [FormatEnumNameValue].
 type EnumNameValueOptions struct {
-	Resolver ProtoEnumResolver
+	Resolver EnumResolver
 }
 
 // FormatProtoTextValue returns a spanvalue plugin that formats Spanner PROTO
@@ -63,7 +69,7 @@ type EnumNameValueOptions struct {
 //
 // The plugin returns [spanvalue.ErrFallthrough] for non-PROTO values, nil or
 // missing resolvers, empty type names, and missing message types. Typed NULL
-// PROTO values return formatter.GetNullString without consulting the resolver.
+// PROTO values return [spanvalue.Formatter.GetNullString] without consulting the resolver.
 // Malformed non-NULL wire payloads, base64 decode failures, unmarshal failures,
 // and marshal failures are returned as real errors.
 //
@@ -125,7 +131,7 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 //
 // The plugin returns [spanvalue.ErrFallthrough] for non-ENUM values, nil or
 // missing resolvers, empty type names, and missing enum types. Typed NULL ENUM
-// values return formatter.GetNullString without consulting the resolver. Known
+// values return [spanvalue.Formatter.GetNullString] without consulting the resolver. Known
 // enum types with unknown or out-of-range numeric values return the original
 // numeric string.
 func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc {
@@ -197,7 +203,13 @@ func ProtoEnumResolverFromFileDescriptorSet(fds *descriptorpb.FileDescriptorSet)
 // as ordinary errors. If no resolver finds a type, the composed resolver returns
 // exact [protoregistry.NotFound].
 func ComposeProtoEnumResolvers(resolvers ...ProtoEnumResolver) ProtoEnumResolver {
-	return compositeResolver{resolvers: append([]ProtoEnumResolver(nil), resolvers...)}
+	active := make([]ProtoEnumResolver, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		if !isNilResolver(resolver) {
+			active = append(active, resolver)
+		}
+	}
+	return compositeResolver{resolvers: active}
 }
 
 type compositeResolver struct {
@@ -237,9 +249,6 @@ func (r compositeResolver) FindEnumByName(name protoreflect.FullName) (protorefl
 func find[T any](resolvers []ProtoEnumResolver, lookup func(ProtoEnumResolver) (T, error)) (T, error) {
 	var zero T
 	for _, resolver := range resolvers {
-		if isNilResolver(resolver) {
-			continue
-		}
 		v, err := lookup(resolver)
 		if err == nil {
 			return v, nil
@@ -264,7 +273,7 @@ func isExactNotFound(err error) bool {
 	return err == protoregistry.NotFound //nolint:errorlint
 }
 
-func isNilResolver(resolver ProtoEnumResolver) bool {
+func isNilResolver(resolver any) bool {
 	if resolver == nil {
 		return true
 	}

--- a/protofmt/protofmt_test.go
+++ b/protofmt/protofmt_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/apstndb/spanvalue/protofmt"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -25,6 +27,7 @@ import (
 const (
 	testProtoPackage = "example.music"
 	singerInfoFQN    = testProtoPackage + ".SingerInfo"
+	envelopeFQN      = testProtoPackage + ".Envelope"
 	genreFQN         = testProtoPackage + ".Genre"
 )
 
@@ -71,6 +74,27 @@ func TestFormatProtoTextValue_generatedMessageFromGlobalTypes(t *testing.T) {
 	}
 	if !proto.Equal(want, &gotMessage) {
 		t.Fatalf("round-trip mismatch\nwant: %v\ngot:  %v", want, &gotMessage)
+	}
+}
+
+func TestFormatProtoTextValue_usesMarshalResolverForAnyExpansion(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	singer := newSingerInfo(t, resolver, 1, "Alice", 1)
+	envelope := newEnvelopeWithAny(t, resolver, singer)
+	payload := marshalProto(t, envelope)
+
+	fc := descriptorAwareConfig(resolver)
+	got, err := fc.FormatToplevelColumn(gcvctor.ProtoValue(envelopeFQN, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "type.googleapis.com/"+singerInfoFQN) {
+		t.Fatalf("formatted Any was not expanded with the custom resolver:\n%s", got)
+	}
+	if !strings.Contains(got, "singer_id") || !strings.Contains(got, "Alice") {
+		t.Fatalf("expanded Any did not include SingerInfo fields:\n%s", got)
 	}
 }
 
@@ -148,6 +172,11 @@ func TestFormatPlugins_fallthroughCases(t *testing.T) {
 			gcv:    gcvctor.ProtoValue("example.music.Missing", nil),
 		},
 		{
+			name:   "proto missing type from GlobalTypes",
+			plugin: protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: protoregistry.GlobalTypes}),
+			gcv:    gcvctor.ProtoValue("example.music.Missing", nil),
+		},
+		{
 			name:   "enum nil resolver",
 			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{}),
 			gcv:    gcvctor.EnumValue(genreFQN, 1),
@@ -163,6 +192,11 @@ func TestFormatPlugins_fallthroughCases(t *testing.T) {
 		{
 			name:   "enum missing type",
 			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
+			gcv:    gcvctor.EnumValue("example.music.Missing", 1),
+		},
+		{
+			name:   "enum missing type from GlobalTypes",
+			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: protoregistry.GlobalTypes}),
 			gcv:    gcvctor.EnumValue("example.music.Missing", 1),
 		},
 	}
@@ -459,6 +493,29 @@ func newEmptySingerInfo(t *testing.T, resolver protofmt.ProtoEnumResolver) proto
 	return messageType.New().Interface()
 }
 
+func newEnvelopeWithAny(t *testing.T, resolver protofmt.ProtoEnumResolver, message proto.Message) proto.Message {
+	t.Helper()
+
+	envelopeType, err := resolver.FindMessageByName(envelopeFQN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anyType, err := resolver.FindMessageByName("google.protobuf.Any")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	anyMessage := anyType.New()
+	anyFields := anyMessage.Descriptor().Fields()
+	anyMessage.Set(anyFields.ByName("type_url"), protoreflect.ValueOfString("type.googleapis.com/"+string(message.ProtoReflect().Descriptor().FullName())))
+	anyMessage.Set(anyFields.ByName("value"), protoreflect.ValueOfBytes(marshalProto(t, message)))
+
+	envelope := envelopeType.New()
+	envelopeFields := envelope.Descriptor().Fields()
+	envelope.Set(envelopeFields.ByName("info"), protoreflect.ValueOfMessage(anyMessage))
+	return envelope.Interface()
+}
+
 func marshalProto(t *testing.T, m proto.Message) []byte {
 	t.Helper()
 
@@ -476,10 +533,14 @@ func isExactNotFound(err error) bool {
 func testFileDescriptorSet() *descriptorpb.FileDescriptorSet {
 	return &descriptorpb.FileDescriptorSet{
 		File: []*descriptorpb.FileDescriptorProto{
+			protodesc.ToFileDescriptorProto(anypb.File_google_protobuf_any_proto),
 			{
 				Name:    proto.String("music.proto"),
 				Package: proto.String(testProtoPackage),
 				Syntax:  proto.String("proto3"),
+				Dependency: []string{
+					"google/protobuf/any.proto",
+				},
 				EnumType: []*descriptorpb.EnumDescriptorProto{
 					{
 						Name: proto.String("Genre"),
@@ -515,6 +576,19 @@ func testFileDescriptorSet() *descriptorpb.FileDescriptorSet {
 								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
 								Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
 								TypeName: proto.String("." + genreFQN),
+							},
+						},
+					},
+					{
+						Name: proto.String("Envelope"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{
+								Name:     proto.String("info"),
+								JsonName: proto.String("info"),
+								Number:   proto.Int32(1),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+								TypeName: proto.String(".google.protobuf.Any"),
 							},
 						},
 					},

--- a/protofmt/protofmt_test.go
+++ b/protofmt/protofmt_test.go
@@ -1,0 +1,602 @@
+package protofmt_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/apstndb/spanvalue/protofmt"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	testProtoPackage = "example.music"
+	singerInfoFQN    = testProtoPackage + ".SingerInfo"
+	genreFQN         = testProtoPackage + ".Genre"
+)
+
+func TestFormatProtoTextValue_dynamicMessageRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	want := newSingerInfo(t, resolver, 1, "Alice", 1)
+	payload := marshalProto(t, want)
+
+	fc := descriptorAwareConfig(resolver)
+	got, err := fc.FormatToplevelColumn(gcvctor.ProtoValue(singerInfoFQN, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Fatalf("formatted prototext has trailing newline: %q", got)
+	}
+
+	gotMessage := newEmptySingerInfo(t, resolver)
+	if err := (prototext.UnmarshalOptions{Resolver: resolver}).Unmarshal([]byte(got), gotMessage); err != nil {
+		t.Fatalf("unmarshal formatted prototext: %v\ntext:\n%s", err, got)
+	}
+	if !proto.Equal(want, gotMessage) {
+		t.Fatalf("round-trip mismatch\nwant: %v\ngot:  %v", want, gotMessage)
+	}
+}
+
+func TestFormatProtoTextValue_generatedMessageFromGlobalTypes(t *testing.T) {
+	t.Parallel()
+
+	want := durationpb.New(1500 * time.Millisecond)
+	payload := marshalProto(t, want)
+
+	fc := descriptorAwareConfig(protoregistry.GlobalTypes)
+	got, err := fc.FormatToplevelColumn(gcvctor.ProtoValue("google.protobuf.Duration", payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotMessage durationpb.Duration
+	if err := prototext.Unmarshal([]byte(got), &gotMessage); err != nil {
+		t.Fatalf("unmarshal formatted prototext: %v\ntext:\n%s", err, got)
+	}
+	if !proto.Equal(want, &gotMessage) {
+		t.Fatalf("round-trip mismatch\nwant: %v\ngot:  %v", want, &gotMessage)
+	}
+}
+
+func TestFormatEnumNameValue_dynamicEnum(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	fc := descriptorAwareConfig(resolver)
+
+	tests := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+		want string
+	}{
+		{
+			name: "known value",
+			gcv:  gcvctor.EnumValue(genreFQN, 1),
+			want: "POP",
+		},
+		{
+			name: "unknown value",
+			gcv:  gcvctor.EnumValue(genreFQN, 99),
+			want: "99",
+		},
+		{
+			name: "out of int32 range",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: genreFQN},
+				Value: structpb.NewStringValue("2147483648"),
+			},
+			want: "2147483648",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fc.FormatToplevelColumn(tt.gcv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPlugins_fallthroughCases(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	tests := []struct {
+		name   string
+		plugin spanvalue.FormatComplexFunc
+		gcv    spanner.GenericColumnValue
+	}{
+		{
+			name:   "proto nil resolver",
+			plugin: protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{}),
+			gcv:    gcvctor.ProtoValue(singerInfoFQN, nil),
+		},
+		{
+			name:   "proto empty fqn",
+			plugin: protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver}),
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO},
+				Value: structpb.NewStringValue(""),
+			},
+		},
+		{
+			name:   "proto missing type",
+			plugin: protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver}),
+			gcv:    gcvctor.ProtoValue("example.music.Missing", nil),
+		},
+		{
+			name:   "enum nil resolver",
+			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{}),
+			gcv:    gcvctor.EnumValue(genreFQN, 1),
+		},
+		{
+			name:   "enum empty fqn",
+			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM},
+				Value: structpb.NewStringValue("1"),
+			},
+		},
+		{
+			name:   "enum missing type",
+			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
+			gcv:    gcvctor.EnumValue("example.music.Missing", 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tt.plugin(spanvalue.SpannerCLICompatibleFormatConfig(), tt.gcv, true)
+			if !errors.Is(err, spanvalue.ErrFallthrough) {
+				t.Fatalf("error = %v, want ErrFallthrough", err)
+			}
+		})
+	}
+}
+
+func TestFormatPlugins_typedNullUsesFormatter(t *testing.T) {
+	t.Parallel()
+
+	fc := descriptorAwareConfig(nil)
+	fc.NullString = "<NULL>"
+
+	tests := []spanner.GenericColumnValue{
+		gcvctor.NullOf(&sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: singerInfoFQN}),
+		gcvctor.NullOf(&sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: genreFQN}),
+	}
+	for _, gcv := range tests {
+		got, err := fc.FormatToplevelColumn(gcv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "<NULL>" {
+			t.Fatalf("got %q, want <NULL>", got)
+		}
+	}
+}
+
+func TestFormatPlugins_returnRealErrors(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	tests := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+	}{
+		{
+			name: "proto malformed wire kind",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: singerInfoFQN},
+				Value: structpb.NewNumberValue(1),
+			},
+		},
+		{
+			name: "proto base64 decode",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: singerInfoFQN},
+				Value: structpb.NewStringValue("not-base64!"),
+			},
+		},
+		{
+			name: "proto unmarshal",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: singerInfoFQN},
+				Value: structpb.NewStringValue(base64.StdEncoding.EncodeToString([]byte{0xff})),
+			},
+		},
+		{
+			name: "enum malformed wire kind",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: genreFQN},
+				Value: structpb.NewNumberValue(1),
+			},
+		},
+		{
+			name: "enum non-numeric",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: genreFQN},
+				Value: structpb.NewStringValue("POP"),
+			},
+		},
+	}
+
+	fc := descriptorAwareConfig(resolver)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := fc.FormatToplevelColumn(tt.gcv)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if errors.Is(err, spanvalue.ErrFallthrough) {
+				t.Fatalf("error = %v, want real error", err)
+			}
+		})
+	}
+}
+
+func TestFormatPlugins_nestedDispatch(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	payload := marshalProto(t, newSingerInfo(t, resolver, 1, "Alice", 1))
+	protoGCV := gcvctor.ProtoValue(singerInfoFQN, payload)
+	enumGCV := gcvctor.EnumValue(genreFQN, 1)
+
+	fc := descriptorAwareConfig(resolver)
+
+	arrayGCV, err := gcvctor.ArrayValue(protoGCV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotArray, err := fc.FormatToplevelColumn(arrayGCV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotArray, "singer_id") || !strings.Contains(gotArray, "Alice") {
+		t.Fatalf("array output did not use proto formatter: %q", gotArray)
+	}
+
+	structGCV, err := gcvctor.StructValueOf([]string{"genre", "info"}, []spanner.GenericColumnValue{enumGCV, protoGCV})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotStruct, err := fc.FormatToplevelColumn(structGCV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotStruct, "POP") || !strings.Contains(gotStruct, "singer_id") {
+		t.Fatalf("struct output did not use proto/enum formatters: %q", gotStruct)
+	}
+}
+
+func TestProtoEnumResolverFromFileDescriptorSet_nilIsEmptyResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.FindMessageByName("example.Missing")
+	if !isExactNotFound(err) {
+		t.Fatalf("error = %v, want exact protoregistry.NotFound", err)
+	}
+}
+
+func TestComposeProtoEnumResolvers_orderedLookup(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	want, err := resolver.FindMessageByName(singerInfoFQN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	first := fakeResolver{
+		findMessageByName: func(protoreflect.FullName) (protoreflect.MessageType, error) {
+			calls = append(calls, "first")
+			return nil, protoregistry.NotFound
+		},
+	}
+	second := fakeResolver{
+		findMessageByName: func(protoreflect.FullName) (protoreflect.MessageType, error) {
+			calls = append(calls, "second")
+			return want, nil
+		},
+	}
+
+	got, err := protofmt.ComposeProtoEnumResolvers(first, nil, second).FindMessageByName(singerInfoFQN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Descriptor().FullName() != want.Descriptor().FullName() {
+		t.Fatalf("got %v, want %v", got.Descriptor().FullName(), want.Descriptor().FullName())
+	}
+	if strings.Join(calls, ",") != "first,second" {
+		t.Fatalf("calls = %v, want [first second]", calls)
+	}
+}
+
+func TestComposeProtoEnumResolvers_errorSemantics(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+	wrappedNotFound := fmt.Errorf("wrapped: %w", protoregistry.NotFound)
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "first non-notfound error", err: boom, want: boom},
+		{name: "wrapped notfound is not skipped", err: wrappedNotFound, want: wrappedNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolver := protofmt.ComposeProtoEnumResolvers(
+				fakeResolver{
+					findMessageByName: func(protoreflect.FullName) (protoreflect.MessageType, error) {
+						return nil, tt.err
+					},
+				},
+				testResolver(t),
+			)
+			_, err := resolver.FindMessageByName(singerInfoFQN)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestComposeProtoEnumResolvers_allMethodsUseNotFoundFallback(t *testing.T) {
+	t.Parallel()
+
+	firstCalls := 0
+	secondCalls := 0
+	first := countingResolver{err: protoregistry.NotFound, calls: &firstCalls}
+	second := countingResolver{err: nil, calls: &secondCalls}
+	resolver := protofmt.ComposeProtoEnumResolvers(first, second)
+
+	if _, err := resolver.FindMessageByName("example.Message"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.FindMessageByURL("type.googleapis.com/example.Message"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.FindExtensionByName("example.ext"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.FindExtensionByNumber("example.Message", 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.FindEnumByName("example.Enum"); err != nil {
+		t.Fatal(err)
+	}
+	if firstCalls != 5 || secondCalls != 5 {
+		t.Fatalf("calls = first:%d second:%d, want 5 and 5", firstCalls, secondCalls)
+	}
+
+	_, err := protofmt.ComposeProtoEnumResolvers(first).FindEnumByName("example.Missing")
+	if !isExactNotFound(err) {
+		t.Fatalf("error = %v, want exact protoregistry.NotFound", err)
+	}
+}
+
+func descriptorAwareConfig(resolver protofmt.ProtoEnumResolver) *spanvalue.FormatConfig {
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{
+				Resolver: resolver,
+				Marshal:  prototext.MarshalOptions{Multiline: true},
+			}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
+		},
+		fc.FormatComplexPlugins...,
+	)
+	return fc
+}
+
+func testResolver(t *testing.T) protofmt.ProtoEnumResolver {
+	t.Helper()
+
+	resolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(testFileDescriptorSet())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolver
+}
+
+func newSingerInfo(t *testing.T, resolver protofmt.ProtoEnumResolver, id int64, name string, genre protoreflect.EnumNumber) proto.Message {
+	t.Helper()
+
+	message := newEmptySingerInfo(t, resolver).ProtoReflect()
+	fields := message.Descriptor().Fields()
+	message.Set(fields.ByName("singer_id"), protoreflect.ValueOfInt64(id))
+	message.Set(fields.ByName("name"), protoreflect.ValueOfString(name))
+	message.Set(fields.ByName("genre"), protoreflect.ValueOfEnum(genre))
+	return message.Interface()
+}
+
+func newEmptySingerInfo(t *testing.T, resolver protofmt.ProtoEnumResolver) proto.Message {
+	t.Helper()
+
+	messageType, err := resolver.FindMessageByName(singerInfoFQN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return messageType.New().Interface()
+}
+
+func marshalProto(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func isExactNotFound(err error) bool {
+	return err == protoregistry.NotFound //nolint:errorlint
+}
+
+func testFileDescriptorSet() *descriptorpb.FileDescriptorSet {
+	return &descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{
+			{
+				Name:    proto.String("music.proto"),
+				Package: proto.String(testProtoPackage),
+				Syntax:  proto.String("proto3"),
+				EnumType: []*descriptorpb.EnumDescriptorProto{
+					{
+						Name: proto.String("Genre"),
+						Value: []*descriptorpb.EnumValueDescriptorProto{
+							{Name: proto.String("GENRE_UNSPECIFIED"), Number: proto.Int32(0)},
+							{Name: proto.String("POP"), Number: proto.Int32(1)},
+							{Name: proto.String("ROCK"), Number: proto.Int32(2)},
+						},
+					},
+				},
+				MessageType: []*descriptorpb.DescriptorProto{
+					{
+						Name: proto.String("SingerInfo"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{
+								Name:     proto.String("singer_id"),
+								JsonName: proto.String("singerId"),
+								Number:   proto.Int32(1),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+							},
+							{
+								Name:     proto.String("name"),
+								JsonName: proto.String("name"),
+								Number:   proto.Int32(2),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							},
+							{
+								Name:     proto.String("genre"),
+								JsonName: proto.String("genre"),
+								Number:   proto.Int32(3),
+								Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+								Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
+								TypeName: proto.String("." + genreFQN),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type fakeResolver struct {
+	findMessageByName     func(protoreflect.FullName) (protoreflect.MessageType, error)
+	findMessageByURL      func(string) (protoreflect.MessageType, error)
+	findExtensionByName   func(protoreflect.FullName) (protoreflect.ExtensionType, error)
+	findExtensionByNumber func(protoreflect.FullName, protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
+	findEnumByName        func(protoreflect.FullName) (protoreflect.EnumType, error)
+}
+
+func (r fakeResolver) FindMessageByName(name protoreflect.FullName) (protoreflect.MessageType, error) {
+	if r.findMessageByName != nil {
+		return r.findMessageByName(name)
+	}
+	return nil, protoregistry.NotFound
+}
+
+func (r fakeResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	if r.findMessageByURL != nil {
+		return r.findMessageByURL(url)
+	}
+	return nil, protoregistry.NotFound
+}
+
+func (r fakeResolver) FindExtensionByName(name protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	if r.findExtensionByName != nil {
+		return r.findExtensionByName(name)
+	}
+	return nil, protoregistry.NotFound
+}
+
+func (r fakeResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	if r.findExtensionByNumber != nil {
+		return r.findExtensionByNumber(message, field)
+	}
+	return nil, protoregistry.NotFound
+}
+
+func (r fakeResolver) FindEnumByName(name protoreflect.FullName) (protoreflect.EnumType, error) {
+	if r.findEnumByName != nil {
+		return r.findEnumByName(name)
+	}
+	return nil, protoregistry.NotFound
+}
+
+type countingResolver struct {
+	err   error
+	calls *int
+}
+
+func (r countingResolver) inc() {
+	*r.calls = *r.calls + 1
+}
+
+func (r countingResolver) FindMessageByName(protoreflect.FullName) (protoreflect.MessageType, error) {
+	r.inc()
+	return nil, r.err
+}
+
+func (r countingResolver) FindMessageByURL(string) (protoreflect.MessageType, error) {
+	r.inc()
+	return nil, r.err
+}
+
+func (r countingResolver) FindExtensionByName(protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	r.inc()
+	return nil, r.err
+}
+
+func (r countingResolver) FindExtensionByNumber(protoreflect.FullName, protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	r.inc()
+	return nil, r.err
+}
+
+func (r countingResolver) FindEnumByName(protoreflect.FullName) (protoreflect.EnumType, error) {
+	r.inc()
+	return nil, r.err
+}

--- a/protofmt/protofmt_test.go
+++ b/protofmt/protofmt_test.go
@@ -378,6 +378,16 @@ func TestComposeProtoEnumResolvers_orderedLookup(t *testing.T) {
 	}
 }
 
+func TestComposeProtoEnumResolvers_singleActiveResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	got := protofmt.ComposeProtoEnumResolvers(nil, resolver, nil)
+	if got != resolver {
+		t.Fatalf("got %T, want original resolver %T", got, resolver)
+	}
+}
+
 func TestComposeProtoEnumResolvers_errorSemantics(t *testing.T) {
 	t.Parallel()
 

--- a/protofmt/protofmt_test.go
+++ b/protofmt/protofmt_test.go
@@ -177,6 +177,17 @@ func TestFormatPlugins_fallthroughCases(t *testing.T) {
 			gcv:    gcvctor.ProtoValue("example.music.Missing", nil),
 		},
 		{
+			name: "proto nil message type from resolver",
+			plugin: protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{
+				Resolver: fakeResolver{
+					findMessageByName: func(protoreflect.FullName) (protoreflect.MessageType, error) {
+						return nil, nil
+					},
+				},
+			}),
+			gcv: gcvctor.ProtoValue(singerInfoFQN, nil),
+		},
+		{
 			name:   "enum nil resolver",
 			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{}),
 			gcv:    gcvctor.EnumValue(genreFQN, 1),
@@ -198,6 +209,17 @@ func TestFormatPlugins_fallthroughCases(t *testing.T) {
 			name:   "enum missing type from GlobalTypes",
 			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: protoregistry.GlobalTypes}),
 			gcv:    gcvctor.EnumValue("example.music.Missing", 1),
+		},
+		{
+			name: "enum nil enum type from resolver",
+			plugin: protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{
+				Resolver: fakeResolver{
+					findEnumByName: func(protoreflect.FullName) (protoreflect.EnumType, error) {
+						return nil, nil
+					},
+				},
+			}),
+			gcv: gcvctor.EnumValue(genreFQN, 1),
 		},
 	}
 
@@ -385,6 +407,16 @@ func TestComposeProtoEnumResolvers_singleActiveResolver(t *testing.T) {
 	got := protofmt.ComposeProtoEnumResolvers(nil, resolver, nil)
 	if got != resolver {
 		t.Fatalf("got %T, want original resolver %T", got, resolver)
+	}
+}
+
+func TestComposeProtoEnumResolvers_emptyResolverReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	resolver := protofmt.ComposeProtoEnumResolvers(nil)
+	_, err := resolver.FindMessageByName("example.Missing")
+	if !isExactNotFound(err) {
+		t.Fatalf("error = %v, want exact protoregistry.NotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a new `protofmt` package with opt-in descriptor-aware PROTO and ENUM formatting plugins.
- Support dynamic descriptor sets, generated/registered protobuf types, resolver composition, native protobuf marshal/unmarshal options, typed NULL handling, and descriptor-free fallthrough.
- Keep descriptor loading/compilation in applications, keep the root package and preset defaults descriptor-free, and document display caveats such as multiline prototext in nested or delimited cells.
- Use a smaller enum-only resolver interface for ENUM formatting while full `ProtoEnumResolver` support remains available for PROTO, extension lookup, `Any` expansion, and resolver composition.
- Add coverage for dynamic messages, `protoregistry.GlobalTypes`, resolver semantics, malformed wire payloads, enum fallback, protobuf option resolver wiring, and nested ARRAY/STRUCT dispatch.

Fixes #149.

## Testing

- `go test ./protofmt`
- `go test ./...`
- `make check`
