### PR TITLE
docs: add protofmt and hook adapter recipes

### DIFF
--- a/protofmt/doc.go
+++ b/protofmt/doc.go
@@ -11,4 +11,8 @@
 // [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes] when their
 // generated packages are imported and linked into the binary, including by
 // blank import.
+//
+// To enable descriptor-aware display, clone an existing spanvalue format preset
+// and prepend [FormatProtoTextValue] and [FormatEnumNameValue] before the
+// preset's existing plugins. See the package examples for the minimal pattern.
 package protofmt

--- a/protofmt/example_test.go
+++ b/protofmt/example_test.go
@@ -1,0 +1,47 @@
+package protofmt_test
+
+import (
+	"fmt"
+
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/apstndb/spanvalue/protofmt"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func Example_spannerCLICompatibleFormatConfigWithProto() {
+	var fds *descriptorpb.FileDescriptorSet
+	// Load fds in the application, for example from a descriptor set produced
+	// with imports included. A nil fds is valid: it creates an empty resolver,
+	// so the plugins fall through to the preset's descriptor-free formatting.
+	dynamicResolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(fds)
+	if err != nil {
+		panic(err)
+	}
+
+	resolver := protofmt.ComposeProtoEnumResolvers(
+		dynamicResolver,
+		protoregistry.GlobalTypes, // for generated protobuf packages linked into the binary
+	)
+
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
+		},
+		fc.FormatComplexPlugins...,
+	)
+
+	out, err := fc.FormatToplevelColumn(gcvctor.EnumValue(
+		"google.protobuf.FieldDescriptorProto.Type",
+		int64(descriptorpb.FieldDescriptorProto_TYPE_STRING.Number()),
+	))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output:
+	// TYPE_STRING
+}

--- a/writer/README.md
+++ b/writer/README.md
@@ -81,6 +81,38 @@ result, err := writer.RunRowIterator(txn.Query(ctx, stmt), writer.NewRowIterator
 	}))
 ```
 
+For complex adapters with several app-owned sinks, keep the state in a small
+local helper and expose that helper through hooks:
+
+```go
+type exportSink struct {
+	formatter appFormatter
+	metrics   appMetrics
+}
+
+var sink exportSink
+hooks := writer.NewRowIteratorHooks().
+	WithPrepareMetadata(func(md *spannerpb.ResultSetMetadata) error {
+		return sink.formatter.Prepare(md)
+	}).
+	WithWriteRow(func(row *spanner.Row) error {
+		if err := sink.metrics.ObserveRow(); err != nil {
+			return err
+		}
+		return sink.formatter.Write(row)
+	}).
+	WithFinish(func(result *writer.RowIteratorResult) error {
+		return sink.formatter.Finish(result)
+	})
+
+result, err := writer.RunRowIterator(txn.Query(ctx, stmt), hooks)
+```
+
+This keeps transformation, metrics, and finalization policy in the application
+while still using `RunRowIterator` for iterator ownership, metadata timing, and
+result collection. Prefer this pattern until a shared composition helper removes
+enough real downstream boilerplate to justify another writer API.
+
 When the app consumes `Next` but skips row bodies, register `PrepareRowType(iter.Metadata.GetRowType())` after the loop, then `Flush` for a header-only delimited export—see package godoc.
 
 **Manual loops:** bind the iterator, `defer iter.Stop()`, propagate `Flush()` errors (`return w.Flush()`, not `defer w.Flush()`), and read metadata or stats only after consuming to `iterator.Done`.

--- a/writer/README.md
+++ b/writer/README.md
@@ -90,7 +90,10 @@ type exportSink struct {
 	metrics   appMetrics
 }
 
-var sink exportSink
+sink := exportSink{
+	formatter: appFormatterImpl{},
+	metrics:   appMetricsImpl{},
+}
 hooks := writer.NewRowIteratorHooks().
 	WithPrepareMetadata(func(md *spannerpb.ResultSetMetadata) error {
 		return sink.formatter.Prepare(md)


### PR DESCRIPTION
## Summary

- add a pkg.go.dev-visible `protofmt` example for cloning a preset and prepending descriptor-aware PROTO/ENUM plugins
- document nil descriptor-set fallthrough and generated-type lookup through `protoregistry.GlobalTypes` in the recipe
- document the `RunRowIterator` stateful local-helper pattern for multi-sink adapters, choosing the docs-only direction for hook composition for now

## Validation

- `go test -run Example -v ./protofmt`
- `go test ./protofmt`
- `go test ./...`
- `git diff --check`
- `make check`

Closes #145.
Closes #154.