### PR TITLE
gcvctor: add Must helpers for nested test fixtures

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -54,4 +54,19 @@
 //
 // Formatting these values as strings is provided by the sibling package
 // [github.com/apstndb/spanvalue].
+//
+// # Test fixtures
+//
+// For nested ARRAY and STRUCT trees in tests, prefer [MustArrayValueOf], [MustStructValueOf],
+// and [MustNormalizeArrayElements] over local panic-on-error helpers. They wrap the
+// error-returning constructors and are intended for schema-known fixture data, not production paths.
+//
+// String payloads: [StringBasedValueFromCode] stores the wire string as-is with no validation
+// (no extra imports beyond typector). When the test cares about canonical wire form, use validated
+// helpers such as [DateStringValue] or the corresponding [MustDateStringValue], [MustTimestampStringValue],
+// [MustIntervalStringValue], and [MustJSONValue] for inline nesting. Typed Go inputs ([DateValue] with
+// [cloud.google.com/go/civil.Date], [TimestampValue] with [time.Time], and so on) avoid parse errors
+// when you already hold the native value.
+//
+// See [ExampleStringBasedValueFromCode_validatedDate] and [ExampleNormalizeArrayElements].
 package gcvctor

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -68,5 +68,5 @@
 // [cloud.google.com/go/civil.Date], [TimestampValue] with [time.Time], and so on) avoid parse errors
 // when you already hold the native value.
 //
-// See [ExampleStringBasedValueFromCode_validatedDate] and [ExampleNormalizeArrayElements].
+// See ExampleStringBasedValueFromCode_validatedDate and ExampleNormalizeArrayElements.
 package gcvctor

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -26,13 +26,13 @@ func ExampleNullOf() {
 func ExampleNormalizeArrayElements() {
 	elemType := typector.CodeToSimpleType(sppb.TypeCode_DATE)
 	elems := []spanner.GenericColumnValue{
-		must(gcvctor.DateStringValue("2026-04-01")),
+		gcvctor.MustDateStringValue("2026-04-01"),
 		gcvctor.NullOf(nil),
-		must(gcvctor.DateStringValue("2026-04-03")),
+		gcvctor.MustDateStringValue("2026-04-03"),
 	}
 
-	normalized := must(gcvctor.NormalizeArrayElements(elemType, elems...))
-	array := must(gcvctor.ArrayValueOf(elemType, normalized...))
+	normalized := gcvctor.MustNormalizeArrayElements(elemType, elems...)
+	array := gcvctor.MustArrayValueOf(elemType, normalized...)
 	values := array.Value.GetListValue().Values
 
 	fmt.Println(array.Type.Code.String(), array.Type.ArrayElementType.Code.String(), len(values))
@@ -66,7 +66,7 @@ func ExampleUUIDValue() {
 }
 
 func ExampleIntervalStringValue() {
-	gcv := must(gcvctor.IntervalStringValue("P1Y2M3DT4H5M6S"))
+	gcv := gcvctor.MustIntervalStringValue("P1Y2M3DT4H5M6S")
 
 	fmt.Println(gcv.Type.Code.String(), gcv.Value.GetStringValue())
 	// Output:

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -1,0 +1,76 @@
+package gcvctor
+
+import (
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+// MustArrayValueOf is like [ArrayValueOf] but panics on error.
+// Use only in tests and table-driven fixtures where schema and inputs are known good.
+func MustArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) spanner.GenericColumnValue {
+	gcv, err := ArrayValueOf(elemType, elems...)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustStructValueOf is like [StructValueOf] but panics on error.
+// Use only in tests and table-driven fixtures where schema and inputs are known good.
+func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanner.GenericColumnValue {
+	gcv, err := StructValueOf(names, gcvs)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustNormalizeArrayElements is like [NormalizeArrayElements] but panics on error.
+// Use only in tests and table-driven fixtures where schema and inputs are known good.
+func MustNormalizeArrayElements(elemType *sppb.Type, elems ...spanner.GenericColumnValue) []spanner.GenericColumnValue {
+	normalized, err := NormalizeArrayElements(elemType, elems...)
+	if err != nil {
+		panic(err)
+	}
+	return normalized
+}
+
+// MustDateStringValue is like [DateStringValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustDateStringValue(v string) spanner.GenericColumnValue {
+	gcv, err := DateStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustTimestampStringValue is like [TimestampStringValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustTimestampStringValue(v string) spanner.GenericColumnValue {
+	gcv, err := TimestampStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustIntervalStringValue is like [IntervalStringValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustIntervalStringValue(v string) spanner.GenericColumnValue {
+	gcv, err := IntervalStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustJSONValue is like [JSONValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustJSONValue(v any) spanner.GenericColumnValue {
+	gcv, err := JSONValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -74,3 +74,13 @@ func MustJSONValue(v any) spanner.GenericColumnValue {
 	}
 	return gcv
 }
+
+// MustPGJSONBValue is like [PGJSONBValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustPGJSONBValue(v any) spanner.GenericColumnValue {
+	gcv, err := PGJSONBValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -69,6 +69,14 @@ func TestMustJSONValue_panicsOnMarshalError(t *testing.T) {
 	})
 }
 
+func TestMustPGJSONBValue_panicsOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustPGJSONBValue(make(chan int))
+	})
+}
+
 func TestMustStructValueOf_matchesStructValueOf(t *testing.T) {
 	t.Parallel()
 

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -156,7 +156,7 @@ func TestMustDateStringValue_wrapsParseError(t *testing.T) {
 	}
 }
 
-func TestMustArrayValueOf_panicsPreserveErrMismatchedCounts(t *testing.T) {
+func TestMustStructValueOf_panicsPreserveErrMismatchedCounts(t *testing.T) {
 	t.Parallel()
 
 	var panicked any

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -1,0 +1,173 @@
+package gcvctor_test
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+)
+
+func expectPanic(t *testing.T, fn func()) {
+	t.Helper()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	fn()
+}
+
+func TestMustStructValueOf_panicsOnMismatchedCounts(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustStructValueOf(
+			[]string{"a"},
+			[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.Int64Value(2)},
+		)
+	})
+}
+
+func TestMustArrayValueOf_panicsOnTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	elemType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	expectPanic(t, func() {
+		gcvctor.MustArrayValueOf(elemType, gcvctor.StringValue("x"))
+	})
+}
+
+func TestMustNormalizeArrayElements_panicsOnNilElementType(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustNormalizeArrayElements(nil, gcvctor.Int64Value(1))
+	})
+}
+
+func TestMustDateStringValue_panicsOnInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustDateStringValue("not-a-date")
+	})
+}
+
+func TestMustJSONValue_panicsOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustJSONValue(make(chan int))
+	})
+}
+
+func TestMustStructValueOf_matchesStructValueOf(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"id", "name"}
+	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
+	want, err := gcvctor.StructValueOf(names, gcvs)
+	if err != nil {
+		t.Fatalf("StructValueOf: %v", err)
+	}
+	got := gcvctor.MustStructValueOf(names, gcvs)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustStructValueOf mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustArrayValueOf_nestedStruct(t *testing.T) {
+	t.Parallel()
+
+	structType, err := typector.NameCodeSlicesToStructType(
+		[]string{"Code", "DisplayOrder"},
+		[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
+	)
+	if err != nil {
+		t.Fatalf("NameCodeSlicesToStructType: %v", err)
+	}
+
+	arrayParam := gcvctor.MustArrayValueOf(structType,
+		gcvctor.MustStructValueOf(
+			[]string{"Code", "DisplayOrder"},
+			[]spanner.GenericColumnValue{gcvctor.StringValue("10"), gcvctor.Int64Value(1)},
+		),
+		gcvctor.NullOf(structType),
+	)
+
+	if arrayParam.Type.Code != sppb.TypeCode_ARRAY {
+		t.Fatalf("Type.Code = %v, want ARRAY", arrayParam.Type.Code)
+	}
+	values := arrayParam.Value.GetListValue().Values
+	if len(values) != 2 {
+		t.Fatalf("len(values) = %d, want 2", len(values))
+	}
+	if values[0].GetListValue() == nil {
+		t.Fatal("first element: expected non-null struct list value")
+	}
+	nullElem := spanner.GenericColumnValue{Type: structType, Value: values[1]}
+	if !spanvalue.IsNull(nullElem) {
+		t.Fatal("second element: expected SQL NULL")
+	}
+}
+
+func TestMustNormalizeArrayElements_matchesNormalizeArrayElements(t *testing.T) {
+	t.Parallel()
+
+	elemType := typector.CodeToSimpleType(sppb.TypeCode_DATE)
+	elems := []spanner.GenericColumnValue{
+		gcvctor.MustDateStringValue("2026-04-01"),
+		gcvctor.NullOf(nil),
+	}
+	want, err := gcvctor.NormalizeArrayElements(elemType, elems...)
+	if err != nil {
+		t.Fatalf("NormalizeArrayElements: %v", err)
+	}
+	got := gcvctor.MustNormalizeArrayElements(elemType, elems...)
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustNormalizeArrayElements mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustDateStringValue_wrapsParseError(t *testing.T) {
+	t.Parallel()
+
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		gcvctor.MustDateStringValue("bad")
+	}()
+	if panicked == nil {
+		t.Fatal("expected panic")
+	}
+	if _, ok := panicked.(error); !ok {
+		t.Fatalf("panic value type = %T, want error", panicked)
+	}
+}
+
+func TestMustArrayValueOf_panicsPreserveErrMismatchedCounts(t *testing.T) {
+	t.Parallel()
+
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		gcvctor.MustStructValueOf([]string{"a"}, nil)
+	}()
+	if panicked == nil {
+		t.Fatal("expected panic")
+	}
+	if !errors.Is(panicked.(error), gcvctor.ErrMismatchedCounts) {
+		t.Fatalf("panic = %v, want ErrMismatchedCounts", panicked)
+	}
+}

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -167,7 +167,11 @@ func TestMustStructValueOf_panicsPreserveErrMismatchedCounts(t *testing.T) {
 	if panicked == nil {
 		t.Fatal("expected panic")
 	}
-	if !errors.Is(panicked.(error), gcvctor.ErrMismatchedCounts) {
+	err, ok := panicked.(error)
+	if !ok {
+		t.Fatalf("panic value type = %T, want error", panicked)
+	}
+	if !errors.Is(err, gcvctor.ErrMismatchedCounts) {
 		t.Fatalf("panic = %v, want ErrMismatchedCounts", panicked)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `MustArrayValueOf`, `MustStructValueOf`, `MustNormalizeArrayElements` (panic on error; documented for test-only use)
- Add optional Must variants for validated string helpers: `MustDateStringValue`, `MustTimestampStringValue`, `MustIntervalStringValue`, `MustJSONValue`
- Document test-fixture guidance in `gcvctor/doc.go` (StringBasedValueFromCode vs validated helpers)
- Unit tests for panic behavior and nested fixture construction; dogfood in `ExampleNormalizeArrayElements` and `ExampleIntervalStringValue`

Closes #161

## Test plan

- [x] `go test ./gcvctor/...`
- [x] `golangci-lint run ./gcvctor/...`
- [x] `make check` (vet, build, test pass; full-repo lint may pick up stale sibling worktree paths locally)


Made with [Cursor](https://cursor.com)