### PR TITLE
Return error when FormatNullable is nil on scalar slow path

### DIFF
--- a/common.go
+++ b/common.go
@@ -201,7 +201,7 @@ type Formatter interface {
 //     append a trailing scalar plugin ([FormatSimpleValue], [FormatLiteralValue],
 //     [FormatSpannerCLIValue], or [FormatJSONSimpleValue]) that formats scalars directly
 //     from GenericColumnValue without Decode; use [FormatConfigWithoutScalarPlugins] or remove
-//     them on a clone to use the legacy path. Plugins fall through when [FormatNullable] is set.
+//     them on a clone to use the legacy path. Plugins fall through when the FormatNullable field is set.
 //   - FormatNullable: optional extension hook. When set, formats non-NULL scalars after Decode
 //     when no scalar plugin handles the value. When nil, the scalar slow path returns
 //     [ErrFormatNullableRequired] without Decode. NULL scalars use [*FormatConfig.GetNullString]

--- a/common.go
+++ b/common.go
@@ -21,6 +21,9 @@ var (
 	ErrMismatchedFields           = errors.New("mismatched struct value/field count")
 	ErrUnexpectedComplexValueKind = errors.New("unexpected complex value kind")
 	ErrEmptyTypeFQN               = errors.New("empty type FQN")
+	// ErrFormatNullableRequired is returned from the scalar slow path when
+	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting).
+	ErrFormatNullableRequired = errors.New("format nullable required")
 )
 
 const (
@@ -111,6 +114,9 @@ func (fc *FormatConfig) formatSimpleColumn(value spanner.GenericColumnValue) (st
 	if IsNull(value) {
 		return fc.GetNullString(), nil
 	}
+	if fc.FormatNullable == nil {
+		return "", ErrFormatNullableRequired
+	}
 	nv, err := simpleGCVToNullable(value)
 	if err != nil {
 		return "", err
@@ -181,8 +187,8 @@ type Formatter interface {
 // FormatConfig controls how Spanner values are formatted. Preset constructors
 // such as [LiteralFormatConfig] return a fresh instance with non-nil callbacks
 // for the value kinds they support. [FormatConfig.FormatColumn] calls FormatArray,
-// FormatStruct, and FormatNullable directly; a nil callback panics when that
-// branch runs unless a [FormatComplexFunc] plugin handles the value first.
+// FormatStruct, and FormatNullable directly; a nil callback returns an error when
+// that branch runs unless a [FormatComplexFunc] plugin handles the value first.
 //
 // Nil field behavior:
 //   - FormatArray: required for non-NULL ARRAY values. NULL ARRAY values use
@@ -194,9 +200,11 @@ type Formatter interface {
 //     append a trailing scalar plugin ([FormatSimpleValue], [FormatLiteralValue],
 //     [FormatSpannerCLIValue], or [FormatJSONSimpleValue]) that formats scalars directly
 //     from GenericColumnValue without Decode; use [FormatConfigWithoutScalarPlugins] or remove
-//     them on a clone to use the legacy path. Plugins fall through when [FormatNullable] is replaced.
-//   - FormatNullable: formats non-NULL scalars after Decode when no scalar plugin handles
-//     the value. NULL scalars use [FormatConfig.GetNullString] before FormatNullable runs.
+//     them on a clone to use the legacy path. Plugins fall through when [FormatNullable] is set.
+//   - FormatNullable: optional extension hook. When set, formats non-NULL scalars after Decode
+//     when no scalar plugin handles the value. When nil, the scalar slow path returns
+//     [ErrFormatNullableRequired] without Decode. NULL scalars use [FormatConfig.GetNullString]
+//     before the slow path runs (FormatNullable is not called for NULL).
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
 type FormatConfig struct {

--- a/common.go
+++ b/common.go
@@ -186,15 +186,16 @@ type Formatter interface {
 
 // FormatConfig controls how Spanner values are formatted. Preset constructors
 // such as [LiteralFormatConfig] return a fresh instance with non-nil callbacks
-// for the value kinds they support. [FormatConfig.FormatColumn] calls FormatArray,
-// FormatStruct, and FormatNullable directly; a nil callback returns an error when
-// that branch runs unless a [FormatComplexFunc] plugin handles the value first.
+// for the value kinds they support. [*FormatConfig.FormatColumn] calls FormatArray,
+// FormatStruct, and FormatNullable directly; a nil FormatNullable returns
+// [ErrFormatNullableRequired] on the scalar slow path unless a [FormatComplexFunc]
+// plugin handles the value first. Nil FormatArray or FormatStruct still panic when invoked.
 //
 // Nil field behavior:
 //   - FormatArray: required for non-NULL ARRAY values. NULL ARRAY values use
-//     [FormatConfig.GetNullString] before FormatArray is called.
+//     [*FormatConfig.GetNullString] before FormatArray is called.
 //   - FormatStruct.FormatStructField and FormatStruct.FormatStructParen: required
-//     for non-NULL STRUCT values. NULL STRUCT values use [FormatConfig.GetNullString]
+//     for non-NULL STRUCT values. NULL STRUCT values use [*FormatConfig.GetNullString]
 //     before struct callbacks run.
 //   - FormatComplexPlugins: nil or empty means no plugins run. Preset constructors
 //     append a trailing scalar plugin ([FormatSimpleValue], [FormatLiteralValue],
@@ -203,7 +204,7 @@ type Formatter interface {
 //     them on a clone to use the legacy path. Plugins fall through when [FormatNullable] is set.
 //   - FormatNullable: optional extension hook. When set, formats non-NULL scalars after Decode
 //     when no scalar plugin handles the value. When nil, the scalar slow path returns
-//     [ErrFormatNullableRequired] without Decode. NULL scalars use [FormatConfig.GetNullString]
+//     [ErrFormatNullableRequired] without Decode. NULL scalars use [*FormatConfig.GetNullString]
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.

--- a/doc.go
+++ b/doc.go
@@ -13,8 +13,9 @@
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from
-// [FormatConfig.FormatComplexPlugins] to use Decode + [FormatNullable].
-// Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is replaced.
+// [FormatConfig.FormatComplexPlugins] to use Decode + [FormatConfig.FormatNullable]
+// (set FormatNullable on the clone; nil returns [ErrFormatNullableRequired]).
+// Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is set.
 // Constructors return a new [FormatConfig]; call [FormatConfig.Clone] before mutating
 // a config you may reuse ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
 // For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -49,7 +49,8 @@ func nullableFuncsEqual(a, b FormatNullableFunc) bool {
 }
 
 // FormatConfigWithoutScalarPlugins returns a clone of fc with preset scalar fast-path plugins
-// removed so scalars use Decode and [FormatNullable].
+// removed so scalars use Decode and [FormatConfig.FormatNullable]. Set FormatNullable on the
+// clone before formatting non-NULL scalars; nil FormatNullable returns [ErrFormatNullableRequired].
 func FormatConfigWithoutScalarPlugins(fc *FormatConfig) *FormatConfig {
 	if fc == nil {
 		return nil
@@ -70,6 +71,9 @@ func scalarTypeCode(value spanner.GenericColumnValue) (sppb.TypeCode, bool) {
 func scalarFastPathActive(formatter Formatter, presetNullable FormatNullableFunc) bool {
 	fc, ok := formatter.(*FormatConfig)
 	if !ok {
+		return true
+	}
+	if fc.FormatNullable == nil {
 		return true
 	}
 	return nullableFuncsEqual(fc.FormatNullable, presetNullable)

--- a/format_gcv_scalar_test.go
+++ b/format_gcv_scalar_test.go
@@ -1,6 +1,7 @@
 package spanvalue
 
 import (
+	"errors"
 	"math"
 	"math/big"
 	"reflect"
@@ -17,6 +18,12 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+func formatConfigDecodePath(fc *FormatConfig, nv FormatNullableFunc) *FormatConfig {
+	stripped := FormatConfigWithoutScalarPlugins(fc)
+	stripped.FormatNullable = nv
+	return stripped
+}
 
 func formatConfigNullableOnly(fc *FormatConfig) *FormatConfig {
 	return FormatConfigWithoutScalarPlugins(fc)
@@ -89,6 +96,43 @@ func TestFormatGCVScalarPluginsMatchNullablePath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFormatConfig_nilFormatNullableFailFast(t *testing.T) {
+	t.Parallel()
+
+	fc := formatConfigDecodePath(SimpleFormatConfig(), nil)
+	_, err := fc.FormatToplevelColumn(gcvctor.BoolValue(true))
+	if !errors.Is(err, ErrFormatNullableRequired) {
+		t.Fatalf("got err %v want %v", err, ErrFormatNullableRequired)
+	}
+}
+
+func TestFormatConfig_nullScalarSkipsFormatNullable(t *testing.T) {
+	t.Parallel()
+
+	fc := formatConfigDecodePath(SimpleFormatConfig(), nil)
+	got, err := fc.FormatToplevelColumn(gcvctor.NullOf(typector.CodeToSimpleType(sppb.TypeCode_BOOL)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != fc.GetNullString() {
+		t.Fatalf("got %q want %q", got, fc.GetNullString())
+	}
+}
+
+func TestFormatConfig_nilFormatNullableKeepsScalarPlugins(t *testing.T) {
+	t.Parallel()
+
+	fc := SimpleFormatConfig()
+	fc.FormatNullable = nil
+	got, err := fc.FormatToplevelColumn(gcvctor.BoolValue(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "true" {
+		t.Fatalf("got %q want true", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `ErrFormatNullableRequired` and return it from `formatSimpleColumn` when the scalar slow path runs with nil `FormatNullable`, without calling `simpleGCVToNullable`.
- Keep scalar fast-path plugins active when `FormatNullable` is nil so preset behavior is unchanged when plugins are present.
- NULL scalars still use `GetNullString()` before slow-path dispatch.

Fixes #152.

## Test plan

- [x] `make check`
- [x] `TestFormatConfig_nilFormatNullableFailFast` — stripped plugins + nil `FormatNullable` returns sentinel
- [x] `TestFormatConfig_nullScalarSkipsFormatNullable` — NULL scalar formats without error
- [x] `TestFormatConfig_nilFormatNullableKeepsScalarPlugins` — plugins still handle scalars when `FormatNullable` is nil
- [x] Existing `TestFormatGCVScalarPluginsMatchNullablePath` and custom-hook test unchanged


Made with [Cursor](https://cursor.com)