### PR TITLE
fix: validate PROTO/ENUM wire kind in literal cast plugins

### DIFF
--- a/common.go
+++ b/common.go
@@ -144,6 +144,9 @@ func FormatProtoAsCast(formatter Formatter, value spanner.GenericColumnValue, to
 	if IsNull(value) {
 		return formatter.GetNullString(), nil
 	}
+	if err := requireStringWire(value.Value, sppb.TypeCode_PROTO); err != nil {
+		return "", err
+	}
 
 	b, err := base64.StdEncoding.DecodeString(value.Value.GetStringValue())
 	if err != nil {
@@ -164,6 +167,9 @@ func FormatEnumAsCast(formatter Formatter, value spanner.GenericColumnValue, top
 
 	if IsNull(value) {
 		return formatter.GetNullString(), nil
+	}
+	if err := requireStringWire(value.Value, sppb.TypeCode_ENUM); err != nil {
+		return "", err
 	}
 
 	typeFQN, err := requireTypeFQN(value.Type)

--- a/common_test.go
+++ b/common_test.go
@@ -322,3 +322,56 @@ func TestFormatColumnRejectsNilStructFieldDescriptor(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatProtoEnumCastRejectsNonStringWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		protoFQN = "package.ProtoType"
+		enumFQN  = "package.EnumType"
+	)
+
+	tests := []struct {
+		name string
+		gcv  spanner.GenericColumnValue
+	}{
+		{
+			name: "proto bool wire",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: protoFQN},
+				Value: structpb.NewBoolValue(true),
+			},
+		},
+		{
+			name: "proto number wire",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: protoFQN},
+				Value: structpb.NewNumberValue(1),
+			},
+		},
+		{
+			name: "enum bool wire",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: enumFQN},
+				Value: structpb.NewBoolValue(true),
+			},
+		},
+		{
+			name: "enum number wire",
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: enumFQN},
+				Value: structpb.NewNumberValue(42),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LiteralFormatConfig().FormatToplevelColumn(tt.gcv)
+			if !errors.Is(err, ErrUnknownType) {
+				t.Fatalf("error = %v, want ErrUnknownType", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Call `requireStringWire` in `FormatProtoAsCast` and `FormatEnumAsCast` after NULL handling so malformed `structpb` kinds return `ErrUnknownType` instead of emitting invalid SQL.
- Add regression tests for non-string wire kinds (bool/number) on PROTO and ENUM via `LiteralFormatConfig`.

Fixes #156.

## Test plan
- [x] `make check`
- [x] New `TestFormatProtoEnumCastRejectsNonStringWire` covers PROTO/ENUM bool and number wire kinds


Made with [Cursor](https://cursor.com)