### PR TITLE
fix: reject non-empty column names after zero-column schema registration

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -646,7 +646,7 @@ func (w *DelimitedWriter) setColumnNames(names []string) {
 
 func (w *DelimitedWriter) initOrValidateColumnNames(columnNames []string) error {
 	initialized := len(w.schema.names) == 0
-	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
+	if err := initOrValidateColumnNames(&w.schema, columnNames); err != nil {
 		return err
 	}
 	if len(w.schema.names) > 0 {
@@ -900,7 +900,7 @@ func (w *JSONLWriter) setColumnNames(names []string) {
 
 func (w *JSONLWriter) initOrValidateColumnNames(columnNames []string) error {
 	initialized := len(w.schema.names) == 0
-	if err := initOrValidateColumnNames(&w.schema.names, columnNames); err != nil {
+	if err := initOrValidateColumnNames(&w.schema, columnNames); err != nil {
 		return err
 	}
 	if len(w.schema.names) > 0 {
@@ -1266,7 +1266,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if len(columnNames) == 0 && w.quotedColumnNames != "" {
 		return w.quotedColumnNames, nil
 	}
-	names, err := validatedColumnNames(w.schema.names, columnNames)
+	names, err := validatedColumnNames(w.schema.names, w.schema.registered, columnNames)
 	if err != nil {
 		return "", err
 	}
@@ -1274,7 +1274,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if err != nil {
 		return "", err
 	}
-	if len(w.schema.names) == 0 {
+	if len(w.schema.names) == 0 && len(names) > 0 {
 		w.schema.names = names
 	}
 	w.schema.registered = true
@@ -1450,24 +1450,27 @@ func gcvsFromStructValues(types []*sppb.Type, values []*structpb.Value) ([]spann
 	return gcvs, nil
 }
 
-// initOrValidateColumnNames initializes dst from the first non-empty
+// initOrValidateColumnNames initializes schema.names from the first non-empty
 // columnNames slice it sees. Once initialized, subsequent non-empty inputs must
 // match exactly; empty inputs are accepted only after initialization.
-func initOrValidateColumnNames(dst *[]string, columnNames []string) error {
-	validated, err := validatedColumnNames(*dst, columnNames)
+func initOrValidateColumnNames(schema *columnSchema, columnNames []string) error {
+	validated, err := validatedColumnNames(schema.names, schema.registered, columnNames)
 	if err != nil {
 		return err
 	}
-	if len(*dst) == 0 {
-		*dst = validated
+	if len(schema.names) == 0 {
+		schema.names = validated
 	}
 	return nil
 }
 
-func validatedColumnNames(existing []string, columnNames []string) ([]string, error) {
+func validatedColumnNames(existing []string, registered bool, columnNames []string) ([]string, error) {
 	if len(existing) == 0 {
 		if len(columnNames) == 0 {
 			return nil, ErrMissingColumnNames
+		}
+		if registered {
+			return nil, fmt.Errorf("%w: got %v want %v", ErrColumnNamesMismatch, columnNames, existing)
 		}
 		return slices.Clone(columnNames), nil
 	}
@@ -1489,7 +1492,7 @@ func validatePrepareRowTypeTransition(schema *columnSchema, columnNames []string
 		}
 		return nil
 	}
-	_, err := validatedColumnNames(schema.names, columnNames)
+	_, err := validatedColumnNames(schema.names, schema.registered, columnNames)
 	return err
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1274,7 +1274,7 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 	if err != nil {
 		return "", err
 	}
-	if len(w.schema.names) == 0 && len(names) > 0 {
+	if len(w.schema.names) == 0 {
 		w.schema.names = names
 	}
 	w.schema.registered = true
@@ -1467,10 +1467,13 @@ func initOrValidateColumnNames(schema *columnSchema, columnNames []string) error
 func validatedColumnNames(existing []string, registered bool, columnNames []string) ([]string, error) {
 	if len(existing) == 0 {
 		if len(columnNames) == 0 {
+			if registered {
+				return nil, nil
+			}
 			return nil, ErrMissingColumnNames
 		}
 		if registered {
-			return nil, fmt.Errorf("%w: got %v want %v", ErrColumnNamesMismatch, columnNames, existing)
+			return nil, fmt.Errorf("%w: got %v, want zero-column schema (registered empty row type)", ErrColumnNamesMismatch, columnNames)
 		}
 		return slices.Clone(columnNames), nil
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1685,6 +1685,36 @@ func TestWriterRejectsNonEmptyColumnNamesAfterRegisteredZeroColumnSchema(t *test
 			},
 		},
 		{
+			name: "delimited PrepareRowType",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',')
+				if err := w.PrepareRowType(nil); err != nil {
+					t.Fatalf("PrepareRowType(nil) error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*DelimitedWriter).PrepareRowType(rowTypeWithColumnNames("id"))
+			},
+		},
+		{
+			name: "jsonl PrepareRowType",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewJSONLWriter(t, &bytes.Buffer{})
+				if err := w.PrepareRowType(nil); err != nil {
+					t.Fatalf("PrepareRowType(nil) error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*JSONLWriter).PrepareRowType(rowTypeWithColumnNames("id"))
+			},
+		},
+		{
 			name: "sql insert WriteValues",
 			setup: func(t *testing.T) Writer {
 				t.Helper()
@@ -1713,6 +1743,24 @@ func TestWriterRejectsNonEmptyColumnNamesAfterRegisteredZeroColumnSchema(t *test
 	}
 }
 
+func TestWriterAcceptsEmptyColumnNamesAfterRegisteredZeroColumnSchema(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewDelimitedWriter(t, &out, ',')
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.WriteValues(nil, nil); err != nil {
+		t.Fatalf("WriteValues(nil, nil) error = %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
 func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1598,6 +1598,121 @@ func TestSQLInsertWriterPrepareEmptyRowTypeFlushNoOp(t *testing.T) {
 	}
 }
 
+func TestWriterRejectsNonEmptyColumnNamesAfterRegisteredZeroColumnSchema(t *testing.T) {
+	t.Parallel()
+
+	columnNames := []string{"id"}
+	values := []spanner.GenericColumnValue{gcvctor.Int64Value(1)}
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T) Writer
+		invoke func(t *testing.T, w Writer) error
+	}{
+		{
+			name: "delimited PrepareColumnNames",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',')
+				if err := w.PrepareRowType(nil); err != nil {
+					t.Fatalf("PrepareRowType(nil) error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*DelimitedWriter).PrepareColumnNames(columnNames)
+			},
+		},
+		{
+			name: "delimited WriteValues",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewDelimitedWriter(t, &bytes.Buffer{}, ',')
+				if err := w.PrepareRowType(emptyRowType()); err != nil {
+					t.Fatalf("PrepareRowType() error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*DelimitedWriter).WriteValues(columnNames, values)
+			},
+		},
+		{
+			name: "jsonl PrepareColumnNames",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewJSONLWriter(t, &bytes.Buffer{})
+				if err := w.PrepareRowType(nil); err != nil {
+					t.Fatalf("PrepareRowType(nil) error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*JSONLWriter).PrepareColumnNames(columnNames)
+			},
+		},
+		{
+			name: "jsonl WriteValues",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewJSONLWriter(t, &bytes.Buffer{})
+				if err := w.PrepareRowType(emptyRowType()); err != nil {
+					t.Fatalf("PrepareRowType() error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*JSONLWriter).WriteValues(columnNames, values)
+			},
+		},
+		{
+			name: "sql insert PrepareColumnNames",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
+				if err := w.PrepareRowType(nil); err != nil {
+					t.Fatalf("PrepareRowType(nil) error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*SQLInsertWriter).PrepareColumnNames(columnNames)
+			},
+		},
+		{
+			name: "sql insert WriteValues",
+			setup: func(t *testing.T) Writer {
+				t.Helper()
+				w := mustNewSQLInsertWriter(t, &bytes.Buffer{}, "users")
+				if err := w.PrepareRowType(emptyRowType()); err != nil {
+					t.Fatalf("PrepareRowType() error = %v", err)
+				}
+				return w
+			},
+			invoke: func(t *testing.T, w Writer) error {
+				t.Helper()
+				return w.(*SQLInsertWriter).WriteValues(columnNames, values)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := tt.setup(t)
+			err := tt.invoke(t, w)
+			if !errors.Is(err, ErrColumnNamesMismatch) {
+				t.Fatalf("error = %v, want ErrColumnNamesMismatch", err)
+			}
+		})
+	}
+}
+
 func TestWithColumnNamesHeaderlessDelimited(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Thread `schema.registered` into `validatedColumnNames` and `initOrValidateColumnNames` so a registered zero-column schema cannot be silently overwritten by later non-empty column names.
- Return `ErrColumnNamesMismatch` when `PrepareColumnNames` or `WriteValues` runs after `PrepareRowType(nil)` / empty row type.

Fixes #157.

## Test plan
- [x] `make check`
- [x] New `TestWriterRejectsNonEmptyColumnNamesAfterRegisteredZeroColumnSchema` covers delimited, JSONL, and SQL INSERT writers via `PrepareColumnNames` and `WriteValues`
- [x] Existing zero-column flush/no-op tests unchanged


Made with [Cursor](https://cursor.com)