### PR TITLE
fix(writer): reject empty SQL INSERT table at construction

### DIFF
--- a/writer/README.md
+++ b/writer/README.md
@@ -6,7 +6,7 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 |--------|-------------|--------|
 | Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row |
 | JSONL | `NewJSONLWriter` | `Flush` is a no-op |
-| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; empty table name rejected at construction; discard writer after a write error |
+| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; empty table name rejected at construction; qualified names with empty segments on first write; discard writer after a write error |
 
 **Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
 
@@ -142,7 +142,7 @@ Match out-of-band headers with [`spanvalue.ColumnNames`](https://pkg.go.dev/gith
 ## Formats and edge cases
 
 - **Quoted TSV:** `NewDelimitedWriter(out, '\t')` uses CSV escaping, not raw tab joins. Legacy raw TAB: implement `Writer` or `RowIteratorWriter` and join formatted columns with `'\t'`.
-- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name (whitespace-only counts as empty). After any write error from `SQLInsertWriter`, discard the writer.
+- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name at construction (whitespace-only per strings.TrimSpace) and qualified names with empty segments on the first write. After any write error from `SQLInsertWriter`, discard the writer.
 - **Delimited vs JSONL vs SQL:** spanvalue formats each cell; encodings differ afterward. One-shot helpers: `FormatDelimitedRow`, `FormatJSONLRow`, `RowData`.
 
 ## Future module split

--- a/writer/README.md
+++ b/writer/README.md
@@ -6,7 +6,7 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 |--------|-------------|--------|
 | Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row |
 | JSONL | `NewJSONLWriter` | `Flush` is a no-op |
-| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; discard writer after a write error |
+| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; empty table name rejected at construction; discard writer after a write error |
 
 **Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
 
@@ -142,7 +142,7 @@ Match out-of-band headers with [`spanvalue.ColumnNames`](https://pkg.go.dev/gith
 ## Formats and edge cases
 
 - **Quoted TSV:** `NewDelimitedWriter(out, '\t')` uses CSV escaping, not raw tab joins. Legacy raw TAB: implement `Writer` or `RowIteratorWriter` and join formatted columns with `'\t'`.
-- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. After any write error from `SQLInsertWriter`, discard the writer.
+- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name (whitespace-only counts as empty). After any write error from `SQLInsertWriter`, discard the writer.
 - **Delimited vs JSONL vs SQL:** spanvalue formats each cell; encodings differ afterward. One-shot helpers: `FormatDelimitedRow`, `FormatJSONLRow`, `RowData`.
 
 ## Future module split

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -55,7 +55,7 @@
 // # SQL INSERT
 //
 // [NewSQLInsertWriter] accepts [WithSQLInsertKind], [WithSQLDialect], and [WithSQLBatchSize].
-// It rejects an empty table name (after ASCII whitespace trim) at construction with [ErrEmptyTableName].
+// It rejects an empty table name (after strings.TrimSpace) at construction with [ErrEmptyTableName]. Qualified names with empty segments are rejected on the first write with [ErrEmptyTableName].
 // After any write error from [SQLInsertWriter], discard the writer. [*SQLInsertWriter.Flush]
 // closes a partial batch when batching.
 package writer

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -55,6 +55,7 @@
 // # SQL INSERT
 //
 // [NewSQLInsertWriter] accepts [WithSQLInsertKind], [WithSQLDialect], and [WithSQLBatchSize].
+// It rejects an empty table name (after ASCII whitespace trim) at construction with [ErrEmptyTableName].
 // After any write error from [SQLInsertWriter], discard the writer. [*SQLInsertWriter.Flush]
 // closes a partial batch when batching.
 package writer

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -976,7 +976,7 @@ type SQLInsertWriter struct {
 }
 
 // NewSQLInsertWriter returns a SQL INSERT writer configured by options.
-// table must be non-empty after trimming whitespace (per strings.TrimSpace); otherwise NewSQLInsertWriter
+// table must be non-empty after trimming whitespace (per strings.TrimSpace); otherwise [NewSQLInsertWriter]
 // returns [ErrEmptyTableName]. Qualified names with empty segments (for example "db..users")
 // are rejected at the first write via [ErrEmptyTableName].
 func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -976,7 +976,7 @@ type SQLInsertWriter struct {
 }
 
 // NewSQLInsertWriter returns a SQL INSERT writer configured by options.
-// table must be non-empty after trimming ASCII whitespace; otherwise NewSQLInsertWriter
+// table must be non-empty after trimming whitespace (per strings.TrimSpace); otherwise NewSQLInsertWriter
 // returns [ErrEmptyTableName]. Qualified names with empty segments (for example "db..users")
 // are rejected at the first write via [ErrEmptyTableName].
 func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -976,6 +976,9 @@ type SQLInsertWriter struct {
 }
 
 // NewSQLInsertWriter returns a SQL INSERT writer configured by options.
+// table must be non-empty after trimming ASCII whitespace; otherwise NewSQLInsertWriter
+// returns [ErrEmptyTableName]. Qualified names with empty segments (for example "db..users")
+// are rejected at the first write via [ErrEmptyTableName].
 func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption) (*SQLInsertWriter, error) {
 	if out == nil {
 		return nil, ErrNilOutputWriter
@@ -986,6 +989,9 @@ func NewSQLInsertWriter(out io.Writer, table string, options ...SQLInsertOption)
 	}
 	if err := w.validateSQLInsertConfig(); err != nil {
 		return nil, err
+	}
+	if strings.TrimSpace(w.table) == "" {
+		return nil, ErrEmptyTableName
 	}
 	if len(w.schema.names) > 0 {
 		if _, err := w.initOrValidateQuotedColumns(nil); err != nil {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1291,18 +1291,26 @@ func TestSQLInsertWriterWriteValuesTableChangeAfterCache(t *testing.T) {
 	}
 }
 
-func TestSQLInsertWriterWriteValuesEmptyTableName(t *testing.T) {
+func TestNewSQLInsertWriterEmptyTableName(t *testing.T) {
 	t.Parallel()
 
-	var out bytes.Buffer
-	w := mustNewSQLInsertWriter(t, &out, "")
-
-	err := w.WriteValues(
-		[]string{"id"},
-		[]spanner.GenericColumnValue{gcvctor.Int64Value(42)},
-	)
+	_, err := NewSQLInsertWriter(&bytes.Buffer{}, "")
 	if !errors.Is(err, ErrEmptyTableName) {
-		t.Fatalf("WriteValues() error = %v, want ErrEmptyTableName", err)
+		t.Fatalf("NewSQLInsertWriter() error = %v, want ErrEmptyTableName", err)
+	}
+
+	_, err = NewSQLInsertWriter(&bytes.Buffer{}, "", WithMetadata(metadataWithColumnNames("id")))
+	if !errors.Is(err, ErrEmptyTableName) {
+		t.Fatalf("NewSQLInsertWriter() with metadata error = %v, want ErrEmptyTableName", err)
+	}
+}
+
+func TestNewSQLInsertWriterWhitespaceTableName(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSQLInsertWriter(&bytes.Buffer{}, "   ")
+	if !errors.Is(err, ErrEmptyTableName) {
+		t.Fatalf("NewSQLInsertWriter() error = %v, want ErrEmptyTableName", err)
 	}
 }
 
@@ -1330,18 +1338,6 @@ func TestSQLInsertWriterWriteGCVsWithoutMetadata(t *testing.T) {
 	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
 	if !errors.Is(err, ErrMissingColumnNames) {
 		t.Fatalf("WriteGCVs() error = %v, want ErrMissingColumnNames", err)
-	}
-}
-
-func TestSQLInsertWriterWriteGCVsEmptyTableName(t *testing.T) {
-	t.Parallel()
-
-	var out bytes.Buffer
-	w := mustNewSQLInsertWriter(t, &out, "", WithMetadata(metadataWithColumnNames("id")))
-
-	err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.Int64Value(42)})
-	if !errors.Is(err, ErrEmptyTableName) {
-		t.Fatalf("WriteGCVs() error = %v, want ErrEmptyTableName", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject empty or whitespace-only table names in `NewSQLInsertWriter`, returning `ErrEmptyTableName` at construction instead of on the first write.
- Qualified names with empty segments (e.g. `db..users`) still fail at first write via existing `quotedQualifiedTable` validation.
- Update tests and docs per #147 design note.

Closes #147

## Test plan
- [x] `make check`
- [x] `TestNewSQLInsertWriterEmptyTableName` / `TestNewSQLInsertWriterWhitespaceTableName`
- [x] Existing `TestSQLInsertWriterWriteValuesEmptyQualifiedTableSegment` unchanged


Made with [Cursor](https://cursor.com)