### PR TITLE
feat(writer): add WithFlushEachRow for delimited streaming

### DIFF
--- a/writer/README.md
+++ b/writer/README.md
@@ -4,7 +4,7 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 
 | Writer | Constructor | Notes |
 |--------|-------------|--------|
-| Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row |
+| Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row, or `WithFlushEachRow` for incremental output |
 | JSONL | `NewJSONLWriter` | `Flush` is a no-op |
 | SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; discard writer after a write error |
 
@@ -51,7 +51,7 @@ Construct hooks with [`NewRowIteratorHooks`](https://pkg.go.dev/github.com/apstn
 
 - [`WithRowOrdinal`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithRowOrdinal) — 1-based row index for diagnostics
 - [`ObserveWriteRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#ObserveWriteRow) — callback before each row
-- [`AfterEachSuccessfulWriteRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#AfterEachSuccessfulWriteRow) — e.g. flush buffered I/O per row (not `SQLInsertWriter.Flush`)
+- [`AfterEachSuccessfulWriteRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#AfterEachSuccessfulWriteRow) — custom per-row hooks (for delimited streaming without type assertions, prefer [`WithFlushEachRow`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithFlushEachRow); not `SQLInsertWriter.Flush`)
 
 `RowsRead` counts successful `WriteRow` hook calls; it differs from [`RowIteratorStats.RowCount`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorStats.RowCount) (Spanner DML semantics). Decorators that only observe rows may call [`MarkOmitRowsRead`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#RowIteratorHooks.MarkOmitRowsRead) so side-effect-only `WriteRow` wrappers do not increment `RowsRead`.
 

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -5,7 +5,7 @@
 // [FlushWriter] interfaces. Register column schema with [WithColumnNames], [WithRowType],
 // or [WithMetadata] (or [DelimitedWriter.PrepareRowType] / [DelimitedWriter.PrepareColumnNames]
 // after construction). [DelimitedWriter] buffers through encoding/csv—call [Flusher.Flush]
-// after the final row.
+// after the final row, or pass [WithFlushEachRow] for per-row flush during streaming.
 //
 // Extended documentation, RowIterator recipes, and module-split notes:
 // https://github.com/apstndb/spanvalue/blob/main/writer/README.md

--- a/writer/row_iterator_test.go
+++ b/writer/row_iterator_test.go
@@ -117,6 +117,38 @@ func TestWriteRowIterator_emptyZeroColumnMetadata(t *testing.T) {
 	}
 }
 
+func TestWriteRowIterator_withFlushEachRow(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithColumnNames("id", "name")
+	row, err := spanner.NewRow([]string{"id", "name"}, []any{int64(1), "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := &stubRowIterator{
+		md:       md,
+		wantStat: RowIteratorStats{RowCount: 1},
+		rows:     []*spanner.Row{row},
+	}
+
+	var out bytes.Buffer
+	w := mustNewDelimitedWriter(t, &out, ',', WithHeader(true), WithFlushEachRow())
+	got, err := runRowIterator(stub, RowIteratorHooksFromWriter(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata != md {
+		t.Fatal("metadata not returned")
+	}
+	if got.Stats.RowCount != 1 {
+		t.Fatalf("RowCount = %d, want 1", got.Stats.RowCount)
+	}
+	want := "id,name\n1,a\n"
+	if out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
 func TestWriteRowIterator_withRows(t *testing.T) {
 	t.Parallel()
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -397,6 +397,16 @@ func (o unnamedFieldNamerOption) applyJSONLOption(w *JSONLWriter) error {
 	return nil
 }
 
+// WithFlushEachRow configures [DelimitedWriter] to flush the underlying encoding/csv
+// buffer after each successful data row. Use for interactive streaming when consumers
+// should see output before the export finishes; the default buffers until [Flusher.Flush].
+func WithFlushEachRow() DelimitedOption {
+	return delimitedOptionFunc(func(w *DelimitedWriter) error {
+		w.flushEachRow = true
+		return nil
+	})
+}
+
 // WithHeader sets whether [DelimitedWriter] emits a CSV/TSV header (default true).
 // The header is written before the first data row, or on [DelimitedWriter.Flush] if only
 // names were registered. See [DelimitedWriter.WriteHeader] to emit it earlier.
@@ -430,7 +440,8 @@ func (s *columnSchema) applyNamesOnly(names []string) {
 	s.registered = true
 }
 
-// DelimitedWriter writes rows as CSV-style delimited text. Call Flush after the final write.
+// DelimitedWriter writes rows as CSV-style delimited text. By default, call Flush after the
+// final write; [WithFlushEachRow] flushes encoding/csv after each data row instead.
 // Header controls automatic header output; see [WithHeader] and [DelimitedWriter.WriteHeader].
 type DelimitedWriter struct {
 	formatter *spanvalue.FormatConfig
@@ -446,6 +457,7 @@ type DelimitedWriter struct {
 	out                 io.Writer
 	writer              *csv.Writer
 	delimiter           rune
+	flushEachRow        bool
 	wroteHeader         bool
 	wroteData           bool
 }
@@ -618,6 +630,10 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 		return err
 	}
 	w.wroteData = true
+	if w.flushEachRow {
+		csvWriter.Flush()
+		return csvWriter.Error()
+	}
 	return nil
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -139,6 +139,53 @@ func TestDelimitedWriterWriteValuesWithCustomDelimiter(t *testing.T) {
 	}
 }
 
+func TestDelimitedWriterWithFlushEachRowIncrementalOutput(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewDelimitedWriter(t, &out, Comma,
+		WithMetadata(metadataWithColumnNames("name")),
+		WithFlushEachRow(),
+	)
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
+		t.Fatalf("WriteGCVs() first row error = %v", err)
+	}
+	want := "name\nAlice\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output after first row mismatch (-want +got):\n%s", diff)
+	}
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Bob")}); err != nil {
+		t.Fatalf("WriteGCVs() second row error = %v", err)
+	}
+	want = "name\nAlice\nBob\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output after second row mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDelimitedWriterWithoutFlushEachRowBuffersUntilFlush(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewDelimitedWriter(t, &out, Comma, WithMetadata(metadataWithColumnNames("name")))
+
+	if err := w.WriteGCVs([]spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
+		t.Fatalf("WriteGCVs() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output before Flush = %q, want empty buffer", out.String())
+	}
+
+	flushDelimitedWriter(t, w)
+
+	want := "name\nAlice\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("output after Flush mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestDelimitedWriterWithOptions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `WithFlushEachRow()` on `DelimitedWriter` / `NewCSVWriter` to flush `encoding/csv` after each successful data row.
- Enables incremental interactive output without `AfterEachSuccessfulWriteRow` hooks or concrete-type assertions.
- Phase 1 only; defers a generic flush-capability interface until a second writer needs it.

Closes #153

## Test plan
- [x] `make check`
- [x] `TestDelimitedWriterWithFlushEachRowIncrementalOutput` — bytes visible per row without final `Flush`
- [x] `TestDelimitedWriterWithoutFlushEachRowBuffersUntilFlush` — default buffering unchanged
- [x] `TestWriteRowIterator_withFlushEachRow` — `WriteRowIterator` path
- [x] Existing SQL INSERT batch tests unchanged


Made with [Cursor](https://cursor.com)