### PR TITLE
WIP: SQL INSERT table placeholders (#146)

### DIFF
--- a/writer/sql_insert_placeholder_test.go
+++ b/writer/sql_insert_placeholder_test.go
@@ -1,0 +1,91 @@
+package writer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSQLInsertWriterWithTablePlaceholder_scaffold(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewSQLInsertWriter(t, &out, "",
+		WithSQLTablePlaceholder("TABLE_NAME"),
+	)
+	if err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)}); err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+
+	want := "INSERT INTO TABLE_NAME (`id`) VALUES (1);\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSQLInsertWriterWithTablePlaceholder_postgresColumnsQuoted(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewSQLInsertWriter(t, &out, "",
+		WithSQLTablePlaceholder("/* unresolved table */"),
+		WithSQLDialect(databasepb.DatabaseDialect_POSTGRESQL),
+	)
+	if err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(42)}); err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+
+	want := "INSERT INTO /* unresolved table */ (\"id\") VALUES (42);\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSQLInsertWriterWithTablePlaceholder_emptyTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSQLInsertWriter(&bytes.Buffer{}, "users", WithSQLTablePlaceholder(""))
+	if !errors.Is(err, ErrEmptyTablePlaceholder) {
+		t.Fatalf("NewSQLInsertWriter() error = %v, want ErrEmptyTablePlaceholder", err)
+	}
+}
+
+func TestSQLInsertWriterEmptyTableWithoutPlaceholder(t *testing.T) {
+	t.Parallel()
+	t.Skip("WIP: #147 will reject empty table at construction; placeholder path should remain valid")
+
+	var out bytes.Buffer
+	_, err := NewSQLInsertWriter(&out, "")
+	if err != nil {
+		t.Fatalf("NewSQLInsertWriter() error = %v, want nil until #147 lands", err)
+	}
+	err = mustNewSQLInsertWriter(t, &out, "").WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)})
+	if !errors.Is(err, ErrEmptyTableName) {
+		t.Fatalf("WriteValues() error = %v, want ErrEmptyTableName", err)
+	}
+}
+
+func TestSQLInsertWriterTablePlaceholder_batchedGoldenSketch(t *testing.T) {
+	t.Parallel()
+	t.Skip("WIP #146: batched INSERT with placeholders not golden-tested yet")
+
+	var out bytes.Buffer
+	w := mustNewSQLInsertWriter(t, &out, "",
+		WithSQLTablePlaceholder("TABLE_NAME"),
+		WithSQLBatchSize(2),
+	)
+	for _, id := range []int64{1, 2} {
+		if err := w.WriteValues([]string{"id"}, []spanner.GenericColumnValue{gcvctor.Int64Value(id)}); err != nil {
+			t.Fatalf("WriteValues() error = %v", err)
+		}
+	}
+	want := "INSERT INTO TABLE_NAME (`id`) VALUES\n  (1),\n  (2);\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -58,6 +58,8 @@ var (
 	// ErrTableNameChangedMidBatch reports that the SQL INSERT table name was mutated while
 	// a multi-row INSERT batch was open.
 	ErrTableNameChangedMidBatch = errors.New("table name changed mid-batch")
+	// ErrEmptyTablePlaceholder reports that [WithSQLTablePlaceholder] received an empty token.
+	ErrEmptyTablePlaceholder = errors.New("empty table placeholder token")
 )
 
 // Writer writes Spanner rows to an output stream.
@@ -197,6 +199,31 @@ type sqlBatchSizeOption struct {
 
 func (o sqlBatchSizeOption) applySQLInsertOption(w *SQLInsertWriter) error {
 	w.batchSize = o.batchSize
+	return nil
+}
+
+type sqlTablePlaceholderOption struct {
+	token string
+}
+
+// WithSQLTablePlaceholder sets a verbatim INSERT INTO target token when the real table
+// name is unknown at export time (WIP #146).
+//
+// The token is emitted without dialect identifier quoting. This is intentionally
+// distinct from an accidentally empty table name (see #147). When a placeholder is
+// configured, [NewSQLInsertWriter]'s table argument may be empty.
+//
+// Open design questions: delimiter conventions, text/template support, and whether
+// placeholders belong on [SQLInsertWriter] or on future INSERT fragment helpers (#79).
+func WithSQLTablePlaceholder(token string) SQLInsertOption {
+	return sqlTablePlaceholderOption{token: token}
+}
+
+func (o sqlTablePlaceholderOption) applySQLInsertOption(w *SQLInsertWriter) error {
+	if o.token == "" {
+		return ErrEmptyTablePlaceholder
+	}
+	w.tablePlaceholder = o.token
 	return nil
 }
 
@@ -968,6 +995,7 @@ type SQLInsertWriter struct {
 	sqlDialect        databasepb.DatabaseDialect
 	batchSize         int
 	batchPending      int
+	tablePlaceholder  string
 	schema            columnSchema
 	quotedColumnNames string
 	quotedTable       string
@@ -1162,7 +1190,7 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}
-	if w.table == "" {
+	if w.table == "" && w.tablePlaceholder == "" {
 		return ErrEmptyTableName
 	}
 	formattedValues, err := spanvalue.FormatRowColumns(w.insertFormatter(), w.schema.names, values)
@@ -1283,6 +1311,9 @@ func (w *SQLInsertWriter) initOrValidateQuotedColumns(columnNames []string) (str
 }
 
 func (w *SQLInsertWriter) quotedQualifiedTable() (string, error) {
+	if w.tablePlaceholder != "" {
+		return w.tablePlaceholder, nil
+	}
 	if w.quotedTable != "" && w.quotedTableInput == w.table {
 		return w.quotedTable, nil
 	}


### PR DESCRIPTION
## Summary

Draft scaffold for #146 — **not merge-ready**.

- Adds `WithSQLTablePlaceholder(token)` on `SQLInsertWriter`.
- Placeholder tokens are emitted **verbatim** (no dialect identifier quoting); column names remain dialect-quoted.
- Allows `NewSQLInsertWriter(out, "")` when a placeholder is configured.
- `ErrEmptyTablePlaceholder` rejects empty placeholder tokens at construction.

### Passing scaffold tests

- `TABLE_NAME` placeholder with GoogleSQL column quoting
- `/* unresolved table */` placeholder with PostgreSQL `"id"` column quoting

### Skipped golden sketches

- Batched INSERT with placeholder
- Empty table without placeholder (documents expected interaction with #147)

## Dependency on #147

#147 proposes rejecting `NewSQLInsertWriter(out, "")` at **construction** when no placeholder is set. This scaffold intentionally allows empty `table` **only** when `WithSQLTablePlaceholder` is present — the two issues must land together with clear error semantics:

| Case | Expected behavior (TBD) |
|------|-------------------------|
| `table=""`, no placeholder | `ErrEmptyTableName` at construction (#147) |
| `table=""`, with placeholder | OK |
| `table="users"`, with placeholder | Undecided — skipped test |

## Open design questions

- Delimiter conventions for placeholder tokens (raw SQL vs bracketed sentinel)?
- `text/template` support vs single fixed token?
- Should placeholders live on `SQLInsertWriter` or on INSERT fragment helpers (#79)?

## Test plan

- [x] `make check` passes
- [ ] Resolve #147 interaction before stabilization
- [ ] Golden tests for batched placeholder output

Closes #146 when complete — **this PR is design review only.**


Made with [Cursor](https://cursor.com)