### PR TITLE
WIP: SQL INSERT fragment helpers (#79)

### DIFF
--- a/writer/sql_insert_fragment.go
+++ b/writer/sql_insert_fragment.go
@@ -1,0 +1,53 @@
+package writer
+
+import (
+	"fmt"
+	"strings"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
+
+// FormatSQLInsertPrefix returns the INSERT statement prefix through the VALUES
+// keyword, before the parenthesized tuple from [FormatSQLInsertValuesTuple], for example:
+//
+//	INSERT INTO `users` (`id`, `name`) VALUES
+//
+// FormatSQLInsertPrefix is a WIP scaffold for custom batching layers (#79). It mirrors
+// [SQLInsertWriter] identifier quoting and INSERT kind prefixes but does not format
+// cell values; callers supply literals via [FormatSQLInsertValuesTuple] or their own
+// formatter. API shape and batching helpers may change before stabilization.
+func FormatSQLInsertPrefix(kind SQLInsertKind, dialect databasepb.DatabaseDialect, table string, columnNames []string) (string, error) {
+	if table == "" {
+		return "", ErrEmptyTableName
+	}
+	quotedTable, err := quoteQualifiedIdentifier(table, dialect)
+	if err != nil {
+		return "", err
+	}
+	quotedColumns, err := quoteIdentifiers(columnNames, dialect)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s INTO %s (%s) VALUES", kind.String(), quotedTable, strings.Join(quotedColumns, ", ")), nil
+}
+
+// FormatSQLInsertValuesTuple formats a parenthesized, comma-separated VALUES tuple
+// from pre-formatted column literals, for example (42, "Alice").
+func FormatSQLInsertValuesTuple(formattedValues []string) string {
+	var b strings.Builder
+	b.WriteByte('(')
+	for i, val := range formattedValues {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(val)
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+// FormatSQLInsertStatement assembles a complete single-row INSERT statement from a
+// prefix, a parenthesized value tuple, and the statement terminator.
+func FormatSQLInsertStatement(prefix string, formattedValues []string) string {
+	return prefix + " " + FormatSQLInsertValuesTuple(formattedValues) + ";\n"
+}

--- a/writer/sql_insert_fragment_test.go
+++ b/writer/sql_insert_fragment_test.go
@@ -1,0 +1,54 @@
+package writer
+
+import (
+	"bytes"
+	"testing"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatSQLInsertFragment_matchesWriter_scaffold(t *testing.T) {
+	t.Parallel()
+
+	columnNames := []string{"id", "name"}
+	values := []spanner.GenericColumnValue{gcvctor.Int64Value(42), gcvctor.StringValue("Alice")}
+	formatter := spanvalue.LiteralFormatConfig()
+
+	var writerOut bytes.Buffer
+	w := mustNewSQLInsertWriter(t, &writerOut, "users")
+	if err := w.WriteValues(columnNames, values); err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+
+	formatted, err := spanvalue.FormatRowColumns(formatter, columnNames, values)
+	if err != nil {
+		t.Fatalf("FormatRowColumns() error = %v", err)
+	}
+	prefix, err := FormatSQLInsertPrefix(SQLInsert, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "users", columnNames)
+	if err != nil {
+		t.Fatalf("FormatSQLInsertPrefix() error = %v", err)
+	}
+	got := FormatSQLInsertStatement(prefix, formatted)
+
+	if diff := cmp.Diff(writerOut.String(), got); diff != "" {
+		t.Fatalf("fragment assembly mismatch (-writer +fragment):\n%s", diff)
+	}
+}
+
+func TestFormatSQLInsertFragment_batchedAssembly(t *testing.T) {
+	t.Parallel()
+	t.Skip("WIP #79: multi-row fragment helpers (VALUES joiner, Flush suffix) not designed yet")
+
+	// Intended sketch: custom batchers assemble
+	//   prefix + tuple1 + ",\n  (" + tuple2 + ");\n"
+	// matching SQLInsertWriter batch output from TestSQLInsertWriterBatching.
+}
+
+func TestFormatSQLInsertFragment_insertOrKinds(t *testing.T) {
+	t.Parallel()
+	t.Skip("WIP #79: document whether INSERT OR IGNORE prefixes belong in FormatSQLInsertPrefix only or need sibling helpers")
+}


### PR DESCRIPTION
## Summary

Draft scaffold for #79 — **not merge-ready**.

Adds small helpers for custom batching/export layers that want INSERT-shaped output without `SQLInsertWriter` buffering:

- `FormatSQLInsertPrefix(kind, dialect, table, columnNames)` — through `VALUES`
- `FormatSQLInsertValuesTuple(formattedValues)` — parenthesized literal list
- `FormatSQLInsertStatement(prefix, formattedValues)` — single-row statement

### What works today (scaffold)

- `TestFormatSQLInsertFragment_matchesWriter_scaffold` — fragment assembly matches `SQLInsertWriter` for a single GoogleSQL row.

### Skipped sketches

- Multi-row batch assembly (`VALUES (…), (…)` joiner, `Flush` suffix)
- Whether `INSERT OR IGNORE` / `INSERT OR UPDATE` prefixes need sibling helpers beyond `FormatSQLInsertPrefix`

Note: `SQLInsertWriter` already supports `WithSQLInsertKind`, `WithSQLBatchSize`, and dialect quoting — this issue targets **fragment-level** APIs for tools that assemble their own batching.

## Open design questions

- Export batch join/close helpers (`FormatSQLInsertBatchSeparator`, `FormatSQLInsertBatchClose`)?
- Share implementation with `SQLInsertWriter` internals vs keep parallel?
- Relationship to table placeholders (#146)?

## Test plan

- [x] `make check` passes
- [ ] Un-skip batched fragment tests once API is settled
- [ ] Downstream recipe in `writer/README.md`

Closes #79 when complete — **this PR is design review only.**


Made with [Cursor](https://cursor.com)