### PR TITLE
gcvctor: add pkg.go.dev examples for empty arrays, container NULLs, and pointer input

### DIFF
--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -76,7 +76,7 @@ func ExampleIntervalStringValue() {
 func ExampleEmptyArrayOf() {
 	elemType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
 	empty := gcvctor.EmptyArrayOf(elemType)
-	viaArrayValueOf := must(gcvctor.ArrayValueOf(elemType))
+	viaArrayValueOf := gcvctor.MustArrayValueOf(elemType)
 
 	fmt.Println(spanvalue.IsNull(empty), len(empty.Value.GetListValue().GetValues()))
 	fmt.Println(empty.Type.ArrayElementType.Code.String())
@@ -100,18 +100,21 @@ func ExampleNullArrayOf() {
 }
 
 func ExampleNullOf_structContainer() {
-	structType := must(typector.NameCodeSlicesToStructType(
+	structType, err := typector.NameCodeSlicesToStructType(
 		[]string{"id", "name"},
 		[]sppb.TypeCode{sppb.TypeCode_INT64, sppb.TypeCode_STRING},
-	))
+	)
+	if err != nil {
+		panic(err)
+	}
 	nullStruct := gcvctor.NullOf(structType)
-	fieldsAllNull := must(gcvctor.StructValueOf(
+	fieldsAllNull := gcvctor.MustStructValueOf(
 		[]string{"id", "name"},
 		[]spanner.GenericColumnValue{
 			gcvctor.NullOf(typector.CodeToSimpleType(sppb.TypeCode_INT64)),
 			gcvctor.NullOf(typector.CodeToSimpleType(sppb.TypeCode_STRING)),
 		},
-	))
+	)
 
 	fmt.Println(spanvalue.IsNull(nullStruct), nullStruct.Type.Code.String())
 	fmt.Println(spanvalue.IsNull(fieldsAllNull), fieldsAllNull.Type.Code.String())

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -72,3 +72,71 @@ func ExampleIntervalStringValue() {
 	// Output:
 	// INTERVAL P1Y2M3DT4H5M6S
 }
+
+func ExampleEmptyArrayOf() {
+	elemType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+	empty := gcvctor.EmptyArrayOf(elemType)
+	viaArrayValueOf := must(gcvctor.ArrayValueOf(elemType))
+
+	fmt.Println(spanvalue.IsNull(empty), len(empty.Value.GetListValue().GetValues()))
+	fmt.Println(empty.Type.ArrayElementType.Code.String())
+	fmt.Println(spanvalue.IsNull(viaArrayValueOf), len(viaArrayValueOf.Value.GetListValue().GetValues()))
+	// Output:
+	// false 0
+	// STRING
+	// false 0
+}
+
+func ExampleNullArrayOf() {
+	elemType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+	nullArray := gcvctor.NullArrayOf(elemType)
+	nullViaNullOf := gcvctor.NullOf(typector.ElemTypeToArrayType(elemType))
+
+	fmt.Println(spanvalue.IsNull(nullArray), nullArray.Type.ArrayElementType.Code.String())
+	fmt.Println(spanvalue.IsNull(nullViaNullOf))
+	// Output:
+	// true STRING
+	// true
+}
+
+func ExampleNullOf_structContainer() {
+	structType := must(typector.NameCodeSlicesToStructType(
+		[]string{"id", "name"},
+		[]sppb.TypeCode{sppb.TypeCode_INT64, sppb.TypeCode_STRING},
+	))
+	nullStruct := gcvctor.NullOf(structType)
+	fieldsAllNull := must(gcvctor.StructValueOf(
+		[]string{"id", "name"},
+		[]spanner.GenericColumnValue{
+			gcvctor.NullOf(typector.CodeToSimpleType(sppb.TypeCode_INT64)),
+			gcvctor.NullOf(typector.CodeToSimpleType(sppb.TypeCode_STRING)),
+		},
+	))
+
+	fmt.Println(spanvalue.IsNull(nullStruct), nullStruct.Type.Code.String())
+	fmt.Println(spanvalue.IsNull(fieldsAllNull), fieldsAllNull.Type.Code.String())
+	// Output:
+	// true STRUCT
+	// false STRUCT
+}
+
+func ExampleInt64FromPtr_fromNullable() {
+	var optional *int64
+	fromPtr := gcvctor.Int64FromPtr(optional)
+	fromNullable := gcvctor.Int64FromNullable(spanner.NullInt64{})
+
+	fmt.Println(spanvalue.IsNull(fromPtr))
+	fmt.Println(spanvalue.IsNull(fromNullable))
+
+	v := int64(42)
+	fromPtr = gcvctor.Int64FromPtr(&v)
+	fromNullable = gcvctor.Int64FromNullable(spanner.NullInt64{Int64: 42, Valid: true})
+
+	fmt.Println(fromPtr.Value.GetStringValue())
+	fmt.Println(fromNullable.Value.GetStringValue())
+	// Output:
+	// true
+	// true
+	// 42
+	// 42
+}


### PR DESCRIPTION
## Summary

- Add `ExampleEmptyArrayOf` and `ExampleNullArrayOf` contrasting empty `ARRAY<elemType>` (length zero) with typed SQL NULL `ARRAY`
- Add `ExampleNullOf_structContainer` for `NullOf(STRUCT)` vs non-null `STRUCT` whose fields are all NULL (`StructValueOf`)
- Add `ExampleInt64FromPtr_fromNullable` side-by-side for `*FromPtr` (nil pointer) and `*FromNullable` (`spanner.NullInt64`)

Closes #160

## Notes

- May need rebase after #162 merges (`gcvctor` overlap: `Must*` helpers and example fixture style)

## Test plan

- [x] `make check`
- [x] `go test ./gcvctor -run '^Example'`


Made with [Cursor](https://cursor.com)