### PR TITLE
spanvalue: add FormatConfig.Validate() for hand-built configs

### DIFF
--- a/common.go
+++ b/common.go
@@ -33,6 +33,9 @@ var (
 	// ErrNilFormatStructParen is returned by [*FormatConfig.Validate] when
 	// [FormatStruct.FormatStructParen] is nil.
 	ErrNilFormatStructParen = errors.New("nil format struct paren callback")
+	// ErrNilFormatComplexPlugin is returned by [*FormatConfig.Validate] when
+	// [FormatConfig.FormatComplexPlugins] contains a nil element.
+	ErrNilFormatComplexPlugin = errors.New("nil format complex plugin")
 	// ErrFormatNullableRequired is returned from the scalar slow path when
 	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting), and by
 	// [*FormatConfig.Validate] when FormatNullable is nil and no preset scalar plugin is configured.

--- a/common.go
+++ b/common.go
@@ -21,8 +21,21 @@ var (
 	ErrMismatchedFields           = errors.New("mismatched struct value/field count")
 	ErrUnexpectedComplexValueKind = errors.New("unexpected complex value kind")
 	ErrEmptyTypeFQN               = errors.New("empty type FQN")
+	// ErrNilFormatConfig is returned by [FormatConfig.Validate] when the receiver is nil.
+	ErrNilFormatConfig = errors.New("nil format config")
+	// ErrEmptyNullString is returned by [FormatConfig.Validate] when [FormatConfig.NullString] is empty.
+	ErrEmptyNullString = errors.New("empty null string")
+	// ErrNilFormatArray is returned by [FormatConfig.Validate] when [FormatConfig.FormatArray] is nil.
+	ErrNilFormatArray = errors.New("nil format array callback")
+	// ErrNilFormatStructField is returned by [FormatConfig.Validate] when
+	// [FormatStruct.FormatStructField] is nil.
+	ErrNilFormatStructField = errors.New("nil format struct field callback")
+	// ErrNilFormatStructParen is returned by [FormatConfig.Validate] when
+	// [FormatStruct.FormatStructParen] is nil.
+	ErrNilFormatStructParen = errors.New("nil format struct paren callback")
 	// ErrFormatNullableRequired is returned from the scalar slow path when
-	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting).
+	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting), and by
+	// [FormatConfig.Validate] when FormatNullable is nil and no preset scalar plugin is configured.
 	ErrFormatNullableRequired = errors.New("format nullable required")
 )
 
@@ -214,6 +227,8 @@ type Formatter interface {
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
+// Call [FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
+// or an empty [FormatConfig.NullString].
 type FormatConfig struct {
 	NullString           string
 	FormatArray          FormatArrayFunc

--- a/common.go
+++ b/common.go
@@ -21,21 +21,21 @@ var (
 	ErrMismatchedFields           = errors.New("mismatched struct value/field count")
 	ErrUnexpectedComplexValueKind = errors.New("unexpected complex value kind")
 	ErrEmptyTypeFQN               = errors.New("empty type FQN")
-	// ErrNilFormatConfig is returned by [FormatConfig.Validate] when the receiver is nil.
+	// ErrNilFormatConfig is returned by [*FormatConfig.Validate] when the receiver is nil.
 	ErrNilFormatConfig = errors.New("nil format config")
-	// ErrEmptyNullString is returned by [FormatConfig.Validate] when [FormatConfig.NullString] is empty.
+	// ErrEmptyNullString is returned by [*FormatConfig.Validate] when [FormatConfig.NullString] is empty.
 	ErrEmptyNullString = errors.New("empty null string")
-	// ErrNilFormatArray is returned by [FormatConfig.Validate] when [FormatConfig.FormatArray] is nil.
+	// ErrNilFormatArray is returned by [*FormatConfig.Validate] when [FormatConfig.FormatArray] is nil.
 	ErrNilFormatArray = errors.New("nil format array callback")
-	// ErrNilFormatStructField is returned by [FormatConfig.Validate] when
+	// ErrNilFormatStructField is returned by [*FormatConfig.Validate] when
 	// [FormatStruct.FormatStructField] is nil.
 	ErrNilFormatStructField = errors.New("nil format struct field callback")
-	// ErrNilFormatStructParen is returned by [FormatConfig.Validate] when
+	// ErrNilFormatStructParen is returned by [*FormatConfig.Validate] when
 	// [FormatStruct.FormatStructParen] is nil.
 	ErrNilFormatStructParen = errors.New("nil format struct paren callback")
 	// ErrFormatNullableRequired is returned from the scalar slow path when
 	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting), and by
-	// [FormatConfig.Validate] when FormatNullable is nil and no preset scalar plugin is configured.
+	// [*FormatConfig.Validate] when FormatNullable is nil and no preset scalar plugin is configured.
 	ErrFormatNullableRequired = errors.New("format nullable required")
 )
 
@@ -227,7 +227,7 @@ type Formatter interface {
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
 // Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
-// Call [FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
+// Call [*FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
 // or an empty [FormatConfig.NullString].
 type FormatConfig struct {
 	NullString           string

--- a/common.go
+++ b/common.go
@@ -37,8 +37,8 @@ var (
 	// [FormatConfig.FormatComplexPlugins] contains a nil element.
 	ErrNilFormatComplexPlugin = errors.New("nil format complex plugin")
 	// ErrFormatNullableRequired is returned from the scalar slow path when
-	// [FormatConfig.FormatNullable] is nil (no Decode-based formatting), and by
-	// [*FormatConfig.Validate] when FormatNullable is nil and no preset scalar plugin is configured.
+	// the FormatNullable field is nil (no Decode-based formatting), and by
+	// [*FormatConfig.Validate] when the FormatNullable field is nil and no preset scalar plugin is configured.
 	ErrFormatNullableRequired = errors.New("format nullable required")
 )
 

--- a/doc.go
+++ b/doc.go
@@ -10,6 +10,8 @@
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
 // and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig].Literal.Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
+// After hand-assembling a [FormatConfig], call [FormatConfig.Validate] to catch nil callbacks
+// or an empty [FormatConfig.NullString] before formatting rows.
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
 // and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig].Literal.Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
-// After hand-assembling a [FormatConfig], call [FormatConfig.Validate] to catch nil callbacks
+// After hand-assembling a [FormatConfig], call [*FormatConfig.Validate] to catch nil callbacks
 // or an empty [FormatConfig.NullString] before formatting rows.
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly

--- a/format_config.go
+++ b/format_config.go
@@ -7,7 +7,7 @@ import "slices"
 //
 // Static checks: non-empty [FormatConfig.NullString] (empty is rejected so NULL
 // output is explicit, not ambiguous with an empty STRING); non-nil
-// [FormatConfig.FormatArray] and [FormatStruct] callbacks; non-nil elements in
+// [FormatConfig.FormatArray] and [FormatStruct] callback fields; non-nil elements in
 // [FormatConfig.FormatComplexPlugins]. [FormatConfig.FormatNullable] may be nil when
 // a preset scalar plugin is present in FormatComplexPlugins; when scalar plugins are
 // absent, nil FormatNullable fails validation because non-NULL scalars have no

--- a/format_config.go
+++ b/format_config.go
@@ -5,12 +5,12 @@ import "slices"
 // Validate reports invalid hand-built [FormatConfig] values. Preset constructors return
 // configs that pass Validate. Nil fc returns [ErrNilFormatConfig].
 //
-// Static checks: non-empty [FormatConfig.NullString]; non-nil [FormatConfig.FormatArray]
+// Static checks: non-empty [FormatConfig.NullString] (empty is rejected so NULL output is explicit, not ambiguous with an empty STRING); non-nil [FormatConfig.FormatArray]
 // and [FormatStruct] callbacks. [FormatConfig.FormatNullable] may be nil when a preset
 // scalar plugin is present in [FormatConfig.FormatComplexPlugins]; when scalar plugins
 // are absent, nil FormatNullable fails validation because non-NULL scalars have no
 // formatter (runtime behavior is defined in #163). Validate does not prove that
-// plugin-only configs format every type.
+// plugin-only configs format every type. Only preset scalar plugins satisfy the FormatNullable exemption; custom scalar plugins in FormatComplexPlugins are not detected, so keep FormatNullable non-nil to pass Validate when using custom plugins.
 func (fc *FormatConfig) Validate() error {
 	if fc == nil {
 		return ErrNilFormatConfig

--- a/format_config.go
+++ b/format_config.go
@@ -3,14 +3,13 @@ package spanvalue
 import "slices"
 
 // Validate reports invalid hand-built [FormatConfig] values. Preset constructors return
-// configs that pass Validate. Nil fc returns [ErrNilFormatConfig].
+// configs that pass [*FormatConfig.Validate]. Nil fc returns [ErrNilFormatConfig].
 //
-// Static checks: non-empty [FormatConfig.NullString] (empty is rejected so NULL
-// output is explicit, not ambiguous with an empty STRING); non-nil
-// [FormatConfig.FormatArray] and [FormatStruct] callback fields; non-nil elements in
-// [FormatConfig.FormatComplexPlugins]. [FormatConfig.FormatNullable] may be nil when
-// a preset scalar plugin is present in FormatComplexPlugins; when scalar plugins are
-// absent, nil FormatNullable fails validation because non-NULL scalars have no
+// Static checks: non-empty NullString (empty is rejected so NULL output is explicit,
+// not ambiguous with an empty STRING); non-nil FormatArray and FormatStruct callback
+// fields; non-nil elements in FormatComplexPlugins. The FormatNullable field may be nil
+// when a preset scalar plugin is present in FormatComplexPlugins; when scalar plugins are
+// absent, a nil FormatNullable field fails validation because non-NULL scalars have no
 // formatter (runtime behavior is defined in #163). Validate does not prove that
 // plugin-only configs format every type. Only preset scalar plugins satisfy the
 // FormatNullable exemption; custom scalar plugins in FormatComplexPlugins are not

--- a/format_config.go
+++ b/format_config.go
@@ -2,6 +2,41 @@ package spanvalue
 
 import "slices"
 
+// Validate reports invalid hand-built [FormatConfig] values. Preset constructors return
+// configs that pass Validate. Nil fc returns [ErrNilFormatConfig].
+//
+// Static checks: non-empty [FormatConfig.NullString]; non-nil [FormatConfig.FormatArray]
+// and [FormatStruct] callbacks. [FormatConfig.FormatNullable] may be nil when a preset
+// scalar plugin is present in [FormatConfig.FormatComplexPlugins]; when scalar plugins
+// are absent, nil FormatNullable fails validation because non-NULL scalars have no
+// formatter (runtime behavior is defined in #163). Validate does not prove that
+// plugin-only configs format every type.
+func (fc *FormatConfig) Validate() error {
+	if fc == nil {
+		return ErrNilFormatConfig
+	}
+	if fc.NullString == "" {
+		return ErrEmptyNullString
+	}
+	if fc.FormatArray == nil {
+		return ErrNilFormatArray
+	}
+	if fc.FormatStruct.FormatStructField == nil {
+		return ErrNilFormatStructField
+	}
+	if fc.FormatStruct.FormatStructParen == nil {
+		return ErrNilFormatStructParen
+	}
+	if fc.FormatNullable == nil && !hasPresetScalarPlugin(fc) {
+		return ErrFormatNullableRequired
+	}
+	return nil
+}
+
+func hasPresetScalarPlugin(fc *FormatConfig) bool {
+	return slices.ContainsFunc(fc.FormatComplexPlugins, isPresetScalarPlugin)
+}
+
 // Clone returns a shallow copy of fc with a copied FormatComplexPlugins slice.
 // The returned config is independent for field assignment and plugin list
 // mutation; callback values themselves are shared with the source.

--- a/format_config.go
+++ b/format_config.go
@@ -5,12 +5,16 @@ import "slices"
 // Validate reports invalid hand-built [FormatConfig] values. Preset constructors return
 // configs that pass Validate. Nil fc returns [ErrNilFormatConfig].
 //
-// Static checks: non-empty [FormatConfig.NullString] (empty is rejected so NULL output is explicit, not ambiguous with an empty STRING); non-nil [FormatConfig.FormatArray]
-// and [FormatStruct] callbacks. [FormatConfig.FormatNullable] may be nil when a preset
-// scalar plugin is present in [FormatConfig.FormatComplexPlugins]; when scalar plugins
-// are absent, nil FormatNullable fails validation because non-NULL scalars have no
+// Static checks: non-empty [FormatConfig.NullString] (empty is rejected so NULL
+// output is explicit, not ambiguous with an empty STRING); non-nil
+// [FormatConfig.FormatArray] and [FormatStruct] callbacks; non-nil elements in
+// [FormatConfig.FormatComplexPlugins]. [FormatConfig.FormatNullable] may be nil when
+// a preset scalar plugin is present in FormatComplexPlugins; when scalar plugins are
+// absent, nil FormatNullable fails validation because non-NULL scalars have no
 // formatter (runtime behavior is defined in #163). Validate does not prove that
-// plugin-only configs format every type. Only preset scalar plugins satisfy the FormatNullable exemption; custom scalar plugins in FormatComplexPlugins are not detected, so keep FormatNullable non-nil to pass Validate when using custom plugins.
+// plugin-only configs format every type. Only preset scalar plugins satisfy the
+// FormatNullable exemption; custom scalar plugins in FormatComplexPlugins are not
+// detected, so keep FormatNullable non-nil to pass Validate when using custom plugins.
 func (fc *FormatConfig) Validate() error {
 	if fc == nil {
 		return ErrNilFormatConfig
@@ -26,6 +30,11 @@ func (fc *FormatConfig) Validate() error {
 	}
 	if fc.FormatStruct.FormatStructParen == nil {
 		return ErrNilFormatStructParen
+	}
+	for _, plugin := range fc.FormatComplexPlugins {
+		if plugin == nil {
+			return ErrNilFormatComplexPlugin
+		}
 	}
 	if fc.FormatNullable == nil && !hasPresetScalarPlugin(fc) {
 		return ErrFormatNullableRequired

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -49,7 +49,6 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 		{
 			name: "empty null string",
 			mutate: func(fc *FormatConfig) {
-				*fc = *valid
 				fc.NullString = ""
 			},
 			wantErr: ErrEmptyNullString,
@@ -57,7 +56,6 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 		{
 			name: "nil format array",
 			mutate: func(fc *FormatConfig) {
-				*fc = *valid
 				fc.FormatArray = nil
 			},
 			wantErr: ErrNilFormatArray,
@@ -65,7 +63,6 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 		{
 			name: "nil format struct field",
 			mutate: func(fc *FormatConfig) {
-				*fc = *valid
 				fc.FormatStruct.FormatStructField = nil
 			},
 			wantErr: ErrNilFormatStructField,
@@ -73,7 +70,6 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 		{
 			name: "nil format struct paren",
 			mutate: func(fc *FormatConfig) {
-				*fc = *valid
 				fc.FormatStruct.FormatStructParen = nil
 			},
 			wantErr: ErrNilFormatStructParen,
@@ -81,7 +77,6 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 		{
 			name: "nil format nullable without scalar plugins",
 			mutate: func(fc *FormatConfig) {
-				*fc = *valid
 				fc.FormatNullable = nil
 				fc.FormatComplexPlugins = nil
 			},

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -1,10 +1,122 @@
 package spanvalue
 
 import (
+	"errors"
 	"testing"
 
 	"cloud.google.com/go/spanner"
 )
+
+func TestFormatConfigValidate_presets(t *testing.T) {
+	t.Parallel()
+
+	presets := []*FormatConfig{
+		LiteralFormatConfig(),
+		SimpleFormatConfig(),
+		SpannerCLICompatibleFormatConfig(),
+		JSONFormatConfig(),
+	}
+	for i, fc := range presets {
+		if err := fc.Validate(); err != nil {
+			t.Errorf("preset[%d].Validate() = %v, want nil", i, err)
+		}
+	}
+}
+
+func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
+	t.Parallel()
+
+	valid := &FormatConfig{
+		NullString:           "NULL",
+		FormatArray:          FormatCompactArray,
+		FormatStruct:         TypedStructFormat(),
+		FormatNullable:       formatNullableValueSimple,
+		FormatComplexPlugins: []FormatComplexFunc{FormatSimpleValue},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid.Validate() = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*FormatConfig)
+		wantErr error
+	}{
+		{
+			name:    "nil config",
+			wantErr: ErrNilFormatConfig,
+		},
+		{
+			name: "empty null string",
+			mutate: func(fc *FormatConfig) {
+				*fc = *valid
+				fc.NullString = ""
+			},
+			wantErr: ErrEmptyNullString,
+		},
+		{
+			name: "nil format array",
+			mutate: func(fc *FormatConfig) {
+				*fc = *valid
+				fc.FormatArray = nil
+			},
+			wantErr: ErrNilFormatArray,
+		},
+		{
+			name: "nil format struct field",
+			mutate: func(fc *FormatConfig) {
+				*fc = *valid
+				fc.FormatStruct.FormatStructField = nil
+			},
+			wantErr: ErrNilFormatStructField,
+		},
+		{
+			name: "nil format struct paren",
+			mutate: func(fc *FormatConfig) {
+				*fc = *valid
+				fc.FormatStruct.FormatStructParen = nil
+			},
+			wantErr: ErrNilFormatStructParen,
+		},
+		{
+			name: "nil format nullable without scalar plugins",
+			mutate: func(fc *FormatConfig) {
+				*fc = *valid
+				fc.FormatNullable = nil
+				fc.FormatComplexPlugins = nil
+			},
+			wantErr: ErrFormatNullableRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var fc *FormatConfig
+			if tt.name == "nil config" {
+				fc = nil
+			} else {
+				fc = valid.Clone()
+				tt.mutate(fc)
+			}
+			err := fc.Validate()
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFormatConfigValidate_nilFormatNullableWithScalarPlugins(t *testing.T) {
+	t.Parallel()
+
+	fc := SimpleFormatConfig()
+	fc.FormatNullable = nil
+	if err := fc.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil when scalar plugins remain", err)
+	}
+}
 
 func TestFormatConfigClone(t *testing.T) {
 	t.Parallel()

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -2,6 +2,7 @@ package spanvalue
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -73,6 +74,13 @@ func TestFormatConfigValidate_handBuiltInvalid(t *testing.T) {
 				fc.FormatStruct.FormatStructParen = nil
 			},
 			wantErr: ErrNilFormatStructParen,
+		},
+		{
+			name: "nil plugin in format complex plugins",
+			mutate: func(fc *FormatConfig) {
+				fc.FormatComplexPlugins = append(slices.Clone(fc.FormatComplexPlugins), nil)
+			},
+			wantErr: ErrNilFormatComplexPlugin,
 		},
 		{
 			name: "nil format nullable without scalar plugins",


### PR DESCRIPTION
## Summary

- Add `FormatConfig.Validate()` with sentinel errors for nil receiver, empty `NullString`, nil `FormatArray` / `FormatStruct` callbacks
- Allow nil `FormatNullable` only when a preset scalar plugin remains in `FormatComplexPlugins` (aligned with #163 semantics)
- Document `Validate` in root `doc.go` and `FormatConfig` godoc
- Tests: all presets pass; hand-built invalid configs fail; nil `FormatNullable` with scalar plugins passes

Closes #158

## Notes

- `FormatNullable` validation semantics depend on #163 (nil `FormatNullable` + scalar plugins = valid; absent plugins = `ErrFormatNullableUnset`). Reconcile godoc if #163 lands with different error naming.

## Test plan

- [x] `make check`
- [x] `TestFormatConfigValidate_presets`
- [x] `TestFormatConfigValidate_handBuiltInvalid`
- [x] `TestFormatConfigValidate_nilFormatNullableWithScalarPlugins`


Made with [Cursor](https://cursor.com)