### PR TITLE
gcvctor: add StructFieldValue paired-field STRUCT constructors

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -7,7 +7,8 @@
 // [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
-// names with values; counts must match.
+// names with values; counts must match. [StructValueOfFields] accepts [StructFieldValue] pairs from [StructField]
+// for inline fixture construction; empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type
 // (protobuf: array_element_type; Go field name ArrayElementType); omitting it yields an invalid ARRAY
@@ -58,8 +59,8 @@
 // # Test fixtures
 //
 // For nested ARRAY and STRUCT trees in tests, prefer [MustArrayValueOf], [MustStructValueOf],
-// and [MustNormalizeArrayElements] over local panic-on-error helpers. They wrap the
-// error-returning constructors and are intended for schema-known fixture data, not production paths.
+// [MustStructValueOfFields], and [MustNormalizeArrayElements] over local panic-on-error helpers.
+// They wrap the error-returning constructors and are intended for schema-known fixture data, not production paths.
 //
 // String payloads: [StringBasedValueFromCode] stores the wire string as-is with no validation
 // (no extra imports beyond typector). When the test cares about canonical wire form, use validated

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -123,6 +123,23 @@ func ExampleNullOf_structContainer() {
 	// false STRUCT
 }
 
+func ExampleStructValueOfFields() {
+	row := gcvctor.MustStructValueOfFields(
+		gcvctor.StructField("Code", gcvctor.StringValue("10")),
+		gcvctor.StructField("DisplayOrder", gcvctor.Int64Value(1)),
+	)
+	unnamed := gcvctor.MustStructValueOfFields(
+		gcvctor.StructField("", gcvctor.StringValue("value")),
+		gcvctor.StructField("", gcvctor.Int64Value(42)),
+	)
+
+	fmt.Println(row.Type.StructType.Fields[0].Name, row.Value.GetListValue().Values[0].GetStringValue())
+	fmt.Println(len(unnamed.Type.StructType.Fields), unnamed.Type.StructType.Fields[0].Name == "")
+	// Output:
+	// Code 10
+	// 2 true
+}
+
 func ExampleInt64FromPtr_fromNullable() {
 	var optional *int64
 	fromPtr := gcvctor.Int64FromPtr(optional)

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -401,7 +401,7 @@ type StructFieldValue struct {
 	Value spanner.GenericColumnValue
 }
 
-// StructField returns f as a [StructFieldValue] with name and value.
+// StructField returns a [StructFieldValue] with the given name and value.
 // Empty name is valid for unnamed STRUCT fields.
 func StructField(name string, value spanner.GenericColumnValue) StructFieldValue {
 	return StructFieldValue{Name: name, Value: value}

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -394,6 +394,31 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 	}, nil
 }
 
+// StructFieldValue pairs one STRUCT field name with its GCV.
+// An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
+type StructFieldValue struct {
+	Name  string
+	Value spanner.GenericColumnValue
+}
+
+// StructField returns f as a [StructFieldValue] with name and value.
+// Empty name is valid for unnamed STRUCT fields.
+func StructField(name string, value spanner.GenericColumnValue) StructFieldValue {
+	return StructFieldValue{Name: name, Value: value}
+}
+
+// StructValueOfFields is like [StructValueOf] but takes paired fields.
+// Empty field names are valid for unnamed STRUCT fields.
+func StructValueOfFields(fields ...StructFieldValue) (spanner.GenericColumnValue, error) {
+	names := make([]string, len(fields))
+	gcvs := make([]spanner.GenericColumnValue, len(fields))
+	for i, f := range fields {
+		names[i] = f.Name
+		gcvs[i] = f.Value
+	}
+	return StructValueOf(names, gcvs)
+}
+
 // StructValueOf constructs STRUCT GenericColumnValue.
 // A nil field Type returns [ErrNilFieldType] wrapped in [StructFieldError].
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -970,6 +970,129 @@ func TestStructValueOf(t *testing.T) {
 	}
 }
 
+func TestStructValueOfFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc      string
+		fields    []gcvctor.StructFieldValue
+		want      spanner.GenericColumnValue
+		expectErr bool
+		errIs     error
+		errSubstr string
+	}{
+		{
+			desc: "named fields",
+			fields: []gcvctor.StructFieldValue{
+				gcvctor.StructField("Code", gcvctor.StringValue("10")),
+				gcvctor.StructField("DisplayOrder", gcvctor.Int64Value(1)),
+			},
+			want: spanner.GenericColumnValue{
+				Type: must(typector.NameCodeSlicesToStructType(
+					[]string{"Code", "DisplayOrder"},
+					[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
+				)),
+				Value: structpb.NewListValue(&structpb.ListValue{
+					Values: []*structpb.Value{
+						structpb.NewStringValue("10"),
+						structpb.NewStringValue("1"),
+					},
+				}),
+			},
+		},
+		{
+			desc: "unnamed fields",
+			fields: []gcvctor.StructFieldValue{
+				gcvctor.StructField("", gcvctor.StringValue("value")),
+				gcvctor.StructField("", gcvctor.Int64Value(42)),
+			},
+			want: spanner.GenericColumnValue{
+				Type: must(typector.NameCodeSlicesToStructType(
+					[]string{"", ""},
+					[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
+				)),
+				Value: structpb.NewListValue(&structpb.ListValue{
+					Values: []*structpb.Value{
+						structpb.NewStringValue("value"),
+						structpb.NewStringValue("42"),
+					},
+				}),
+			},
+		},
+		{
+			desc: "nil field type named",
+			fields: []gcvctor.StructFieldValue{
+				gcvctor.StructField("broken", spanner.GenericColumnValue{}),
+			},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: `field 0 ("broken")`,
+		},
+		{
+			desc: "nil field type unnamed",
+			fields: []gcvctor.StructFieldValue{
+				gcvctor.StructField("", spanner.GenericColumnValue{}),
+			},
+			expectErr: true,
+			errIs:     gcvctor.ErrNilFieldType,
+			errSubstr: "field 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := gcvctor.StructValueOfFields(tt.fields...)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Fatalf("errors.Is(err, %v) = false; err = %v", tt.errIs, err)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err, tt.errSubstr)
+				}
+				var zero spanner.GenericColumnValue
+				if diff := cmp.Diff(zero, got, protocmp.Transform()); diff != "" {
+					t.Errorf("expected zero value on error (-want +got):\n%s", diff)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStructValueOfFields_matchesStructValueOf(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"id", "name"}
+	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
+	fields := []gcvctor.StructFieldValue{
+		gcvctor.StructField("id", gcvctor.Int64Value(1)),
+		gcvctor.StructField("name", gcvctor.StringValue("foo")),
+	}
+
+	want, err := gcvctor.StructValueOf(names, gcvs)
+	if err != nil {
+		t.Fatalf("StructValueOf: %v", err)
+	}
+	got, err := gcvctor.StructValueOfFields(fields...)
+	if err != nil {
+		t.Fatalf("StructValueOfFields: %v", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestStructValueOfNilFieldTypeReturnsStructFieldError(t *testing.T) {
 	t.Parallel()
 

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -25,6 +25,16 @@ func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanne
 	return gcv
 }
 
+// MustStructValueOfFields is like [StructValueOfFields] but panics on error.
+// Use only in tests and table-driven fixtures where schema and inputs are known good.
+func MustStructValueOfFields(fields ...StructFieldValue) spanner.GenericColumnValue {
+	gcv, err := StructValueOfFields(fields...)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
 // MustNormalizeArrayElements is like [NormalizeArrayElements] but panics on error.
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
 func MustNormalizeArrayElements(elemType *sppb.Type, elems ...spanner.GenericColumnValue) []spanner.GenericColumnValue {

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -25,6 +25,66 @@ func expectPanic(t *testing.T, fn func()) {
 	fn()
 }
 
+func TestMustStructValueOfFields_matchesStructValueOfFields(t *testing.T) {
+	t.Parallel()
+
+	fields := []gcvctor.StructFieldValue{
+		gcvctor.StructField("id", gcvctor.Int64Value(1)),
+		gcvctor.StructField("name", gcvctor.StringValue("foo")),
+	}
+	want, err := gcvctor.StructValueOfFields(fields...)
+	if err != nil {
+		t.Fatalf("StructValueOfFields: %v", err)
+	}
+	got := gcvctor.MustStructValueOfFields(fields...)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustStructValueOfFields mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustStructValueOfFields_panicsOnNilFieldType(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustStructValueOfFields(gcvctor.StructField("broken", spanner.GenericColumnValue{}))
+	})
+}
+
+func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
+	t.Parallel()
+
+	structType, err := typector.NameCodeSlicesToStructType(
+		[]string{"Code", "DisplayOrder"},
+		[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
+	)
+	if err != nil {
+		t.Fatalf("NameCodeSlicesToStructType: %v", err)
+	}
+
+	arrayParam := gcvctor.MustArrayValueOf(structType,
+		gcvctor.MustStructValueOfFields(
+			gcvctor.StructField("Code", gcvctor.StringValue("10")),
+			gcvctor.StructField("DisplayOrder", gcvctor.Int64Value(1)),
+		),
+		gcvctor.NullOf(structType),
+	)
+
+	if arrayParam.Type.Code != sppb.TypeCode_ARRAY {
+		t.Fatalf("Type.Code = %v, want ARRAY", arrayParam.Type.Code)
+	}
+	values := arrayParam.Value.GetListValue().Values
+	if len(values) != 2 {
+		t.Fatalf("len(values) = %d, want 2", len(values))
+	}
+	if values[0].GetListValue() == nil {
+		t.Fatal("first element: expected non-null struct list value")
+	}
+	nullElem := spanner.GenericColumnValue{Type: structType, Value: values[1]}
+	if !spanvalue.IsNull(nullElem) {
+		t.Fatal("second element: expected SQL NULL")
+	}
+}
+
 func TestMustStructValueOf_panicsOnMismatchedCounts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `StructFieldValue`, `StructField`, `StructValueOfFields`, and `MustStructValueOfFields` for inline STRUCT fixture construction with name/value pairs adjacent at the call site.
- Delegate to existing `StructValueOf` / `MustStructValueOf`; slice-based APIs are unchanged.
- Support unnamed STRUCT fields via `StructField("", value)`; empty names are not rejected.

Closes #179.

## Test plan
- [x] `make check`
- [x] `TestStructValueOfFields` (named/unnamed fields, nil field type errors)
- [x] `TestStructValueOfFields_matchesStructValueOf`
- [x] `TestMustStructValueOfFields_*` (parity, panic, nested ARRAY fixture)
- [x] `ExampleStructValueOfFields`


Made with [Cursor](https://cursor.com)