### PR TITLE
docs: adoption guides for Validate, ARRAY literals, and duplicate aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ fc.FormatStruct.FormatStructParen = spanvalue.FormatTupleStruct
 See [ExampleSpannerCLICompatibleFormatConfig_tupleStruct](https://pkg.go.dev/github.com/apstndb/spanvalue#example-SpannerCLICompatibleFormatConfig-TupleStruct).
 Keep product-specific combinations in your application (not as new spanvalue presets).
 
+## Hand-built FormatConfig
+
+Preset constructors ([`LiteralFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#LiteralFormatConfig), [`SimpleFormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue#SimpleFormatConfig), and others) return configs that pass [`FormatConfig.Validate`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig.Validate). After hand-assembling or mutating a config—[`Clone()`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig.Clone) then edit [`FormatComplexPlugins`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig.FormatComplexPlugins), or strip scalar plugins with [`FormatConfigWithoutScalarPlugins`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfigWithoutScalarPlugins)—call `Validate` before the first format or export so nil callbacks and an empty `NullString` fail at construction time rather than on the first row.
+
+Custom scalar plugins in `FormatComplexPlugins` are not detected by `Validate`; keep `FormatNullable` set when using them. Writers accept any `*FormatConfig` via [`writer.WithFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithFormatter) but do **not** call `Validate` today—validate hand-built formatters before passing them to writers.
+
+```go
+fc := spanvalue.SimpleFormatConfig().Clone()
+fc.FormatComplexPlugins = append(fc.FormatComplexPlugins, myPlugin)
+if err := fc.Validate(); err != nil {
+	return err
+}
+```
+
 ## Adoption snippets
 
 Use the small helper APIs directly when replacing ad hoc downstream formatting
@@ -76,6 +90,19 @@ if err := w.WriteValues(columnNames, gcvs); err != nil {
     return err
 }
 return w.Flush()
+```
+
+Nested ARRAY/STRUCT test fixtures: [`gcvctor.MustStructValueOf`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#MustStructValueOf) and [`gcvctor.MustArrayValueOf`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor#MustArrayValueOf) wrap the error-returning constructors and panic on construction errors—use only in tests with schema-known inputs (see [`gcvctor`](https://pkg.go.dev/github.com/apstndb/spanvalue/gcvctor) package docs).
+
+```go
+elemType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+row := gcvctor.MustStructValueOf(
+	[]string{"id", "tags"},
+	[]spanner.GenericColumnValue{
+		gcvctor.Int64Value(1),
+		gcvctor.MustArrayValueOf(elemType, gcvctor.StringValue("a"), gcvctor.StringValue("b")),
+	},
+)
 ```
 
 ## Streaming row exports
@@ -128,6 +155,8 @@ is appropriate. For display headers outside the writer, use
 on the **same** field list with the **same**
 [`spanvalue.UnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue#UnnamedFieldNamer)
 as [`writer.WithUnnamedFieldNamer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithUnnamedFieldNamer).
+
+**Duplicate aliases:** explicit duplicate field names from Spanner (for example `SELECT 1 AS a, 2 AS a`) are preserved in `ColumnNames` output (`["a", "a"]`). Only `UnnamedFieldNamer` collisions return errors. CSV/TSV headers and JSONL field names follow the same resolved names; see [writer/README.md](writer/README.md).
 
 **CSV / JSONL:** register schema and formatting at construction, stream rows, then
 `Flush` (CSV may emit a header on zero-row `SELECT`; JSONL `Flush` is a no-op).

--- a/doc.go
+++ b/doc.go
@@ -11,8 +11,8 @@
 // and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig].Literal.Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
 // After hand-assembling a [FormatConfig], call [*FormatConfig.Validate] at construction
-// time (or immediately after [FormatConfig.Clone] and mutation) to catch nil callbacks
-// or an empty [FormatConfig.NullString] before the first [FormatConfig.FormatRow] call.
+// time (or immediately after [*FormatConfig.Clone] and mutation) to catch nil callbacks
+// or an empty [FormatConfig.NullString] before the first [*FormatConfig.FormatRow] call.
 // [FormatConfigWithoutScalarPlugins] and edits to [FormatConfig.FormatComplexPlugins]
 // can remove preset scalar plugins; re-validate after such changes. Custom scalar
 // plugins in [FormatConfig.FormatComplexPlugins] are not detected by Validate—keep
@@ -25,8 +25,8 @@
 // [FormatConfig.FormatComplexPlugins] to use Decode + [FormatConfig.FormatNullable]
 // (set FormatNullable on the clone; nil returns [ErrFormatNullableRequired]).
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is set.
-// Constructors return a new [FormatConfig]; call [FormatConfig.Clone] before mutating
-// a config you may reuse ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
+// Constructors return a new [FormatConfig]; call [*FormatConfig.Clone] before mutating
+// a config you may reuse ([*FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
 // For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]
 // and set [FormatTupleStruct] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in

--- a/doc.go
+++ b/doc.go
@@ -10,8 +10,15 @@
 // [LiteralFormatConfigWithOptions], [SimpleFormatConfig], [SpannerCLICompatibleFormatConfig],
 // and [JSONFormatConfig] to pick a preset. [WithLiteralQuote] sets [FormatConfig].Literal.Quote
 // on the literal preset (string/bytes delimiter policy for SQL-style literals).
-// After hand-assembling a [FormatConfig], call [*FormatConfig.Validate] to catch nil callbacks
-// or an empty [FormatConfig.NullString] before formatting rows.
+// After hand-assembling a [FormatConfig], call [*FormatConfig.Validate] at construction
+// time (or immediately after [FormatConfig.Clone] and mutation) to catch nil callbacks
+// or an empty [FormatConfig.NullString] before the first [FormatConfig.FormatRow] call.
+// [FormatConfigWithoutScalarPlugins] and edits to [FormatConfig.FormatComplexPlugins]
+// can remove preset scalar plugins; re-validate after such changes. Custom scalar
+// plugins in [FormatConfig.FormatComplexPlugins] are not detected by Validate—keep
+// [FormatConfig.FormatNullable] non-nil when using them. Package writer does not call
+// Validate on [writer.WithFormatter] configs; validate hand-built formatters before
+// passing them to writers.
 // Scalar plugins ([FormatSimpleValue], [FormatLiteralValue],
 // [FormatSpannerCLIValue], [FormatJSONSimpleValue]) format GenericColumnValue directly
 // without Decode; remove them with [FormatConfigWithoutScalarPlugins] or from

--- a/format_func.go
+++ b/format_func.go
@@ -52,6 +52,11 @@ func FormatUntypedArray(_ *sppb.Type, _ bool, elemStrings []string) (string, err
 	return "[" + strings.Join(elemStrings, ", ") + "]", nil
 }
 
+// FormatOptionallyTypedArray formats ARRAY values for SQL literals. It prefixes the
+// bracket list with an ARRAY<...> type annotation only when toplevel is true and the
+// array element type is complex (STRUCT or nested ARRAY). Scalar element arrays at
+// top level are untyped ([1, 2], not ARRAY<INT64>[1, 2]). Empty arrays format as
+// [] regardless of element type. [LiteralFormatConfig] wires this as [FormatConfig.FormatArray].
 func FormatOptionallyTypedArray(typ *sppb.Type, toplevel bool, elemStrings []string) (string, error) {
 	return fmt.Sprintf("%v[%v]",
 		lo.Ternary(toplevel && isComplexType(typ.ArrayElementType.GetCode()), spantype.FormatTypeVerbose(typ), ""),

--- a/format_func.go
+++ b/format_func.go
@@ -54,9 +54,9 @@ func FormatUntypedArray(_ *sppb.Type, _ bool, elemStrings []string) (string, err
 
 // FormatOptionallyTypedArray formats ARRAY values for SQL literals. It prefixes the
 // bracket list with an ARRAY<...> type annotation only when toplevel is true and the
-// array element type is complex (STRUCT or nested ARRAY). Scalar element arrays at
-// top level are untyped ([1, 2], not ARRAY<INT64>[1, 2]). Empty arrays format as
-// [] regardless of element type. [LiteralFormatConfig] wires this as [FormatConfig.FormatArray].
+// array element type is complex (STRUCT or nested ARRAY), independent of element count.
+// Scalar element arrays at top level are untyped ([], [1, 2], not ARRAY<INT64>[1, 2]).
+// [LiteralFormatConfig] wires this as [FormatConfig.FormatArray].
 func FormatOptionallyTypedArray(typ *sppb.Type, toplevel bool, elemStrings []string) (string, error) {
 	return fmt.Sprintf("%v[%v]",
 		lo.Ternary(toplevel && isComplexType(typ.ArrayElementType.GetCode()), spantype.FormatTypeVerbose(typ), ""),

--- a/literal.go
+++ b/literal.go
@@ -25,7 +25,9 @@ func FormatColumnLiteral(value spanner.GenericColumnValue) (string, error) {
 }
 
 // LiteralFormatConfig returns a new FormatConfig that produces parseable SQL
-// literal expressions with type annotations.
+// literal expressions with type annotations. ARRAY values use
+// [FormatOptionallyTypedArray]: scalar and empty top-level arrays omit the
+// ARRAY<...> prefix; arrays of STRUCT or nested ARRAY may include it when typed.
 func LiteralFormatConfig() *FormatConfig {
 	return &FormatConfig{
 		NullString:     nullStringUpperCase,

--- a/literal.go
+++ b/literal.go
@@ -26,8 +26,9 @@ func FormatColumnLiteral(value spanner.GenericColumnValue) (string, error) {
 
 // LiteralFormatConfig returns a new FormatConfig that produces parseable SQL
 // literal expressions with type annotations. ARRAY values use
-// [FormatOptionallyTypedArray]: scalar and empty top-level arrays omit the
-// ARRAY<...> prefix; arrays of STRUCT or nested ARRAY may include it when typed.
+// [FormatOptionallyTypedArray]: top-level arrays with scalar elements omit the
+// ARRAY<...> prefix (empty or not); arrays of STRUCT or nested ARRAY include it when
+// toplevel is true (empty or not).
 func LiteralFormatConfig() *FormatConfig {
 	return &FormatConfig{
 		NullString:     nullStringUpperCase,

--- a/row.go
+++ b/row.go
@@ -15,7 +15,9 @@ import (
 // is used to generate names for unnamed fields. If a non-nil UnnamedFieldNamer
 // returns an empty string or repeatedly returns colliding names such that a
 // unique column name cannot be chosen, ColumnNames returns a non-nil error
-// describing the contract violation.
+// describing the contract violation. Explicit duplicate field names from the
+// query schema (for example SELECT 1 AS a, 2 AS a) are preserved as-is; only
+// namer-resolution collisions are errors.
 func ColumnNames(fields []*sppb.StructType_Field, namer UnnamedFieldNamer) ([]string, error) {
 	names := make([]string, len(fields))
 	for i, field := range fields {

--- a/row_test.go
+++ b/row_test.go
@@ -30,6 +30,12 @@ func TestColumnNames(t *testing.T) {
 			namer:  IndexedUnnamedFieldNamer,
 			want:   []string{"_0", "_2", "_1"},
 		},
+		{
+			name:   "explicit duplicate aliases preserved",
+			fields: typector.MustNameCodeSlicesToStructType([]string{"a", "a"}, []sppb.TypeCode{sppb.TypeCode_INT64, sppb.TypeCode_INT64}).GetStructType().GetFields(),
+			namer:  IndexedUnnamedFieldNamer,
+			want:   []string{"a", "a"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/writer/README.md
+++ b/writer/README.md
@@ -10,7 +10,7 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 
 **Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
 
-**Formatter:** set [`WithFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithFormatter) at construction; inspect the effective preset with [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.FormatConfig) on delimited, JSONL, or SQL INSERT writers (fields are not exported in v0.5.0+).
+**Formatter:** set [`WithFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#WithFormatter) at construction; inspect the effective preset with [`FormatConfig`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedWriter.FormatConfig) on delimited, JSONL, or SQL INSERT writers (fields are not exported in v0.5.0+). Writers do not call [`spanvalue.FormatConfig.Validate`](https://pkg.go.dev/github.com/apstndb/spanvalue#FormatConfig.Validate) on the supplied config—validate hand-built formatters before construction (see root README).
 
 ## RowIterator
 
@@ -141,6 +141,7 @@ Match out-of-band headers with [`spanvalue.ColumnNames`](https://pkg.go.dev/gith
 
 ## Formats and edge cases
 
+- **Duplicate column headers:** CSV/TSV header rows follow resolved [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames) output, **including duplicate explicit aliases** (for example `SELECT 1 AS a, 2 AS a` → header `a,a`). RFC 4180 permits repeated header names; consumers that require unique headers must disambiguate in the application. JSONL object keys from duplicate aliases are a separate concern—see [`spanvalue.NewJSONObjectStructFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue#NewJSONObjectStructFormatter) and root JSON row docs for duplicate-key behavior.
 - **Quoted TSV:** `NewDelimitedWriter(out, '\t')` uses CSV escaping, not raw tab joins. Legacy raw TAB: implement `Writer` or `RowIteratorWriter` and join formatted columns with `'\t'`.
 - **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name at construction (whitespace-only per strings.TrimSpace) and qualified names with empty segments on the first write. After any write error from `SQLInsertWriter`, discard the writer.
 - **Delimited vs JSONL vs SQL:** spanvalue formats each cell; encodings differ afterward. One-shot helpers: `FormatDelimitedRow`, `FormatJSONLRow`, `RowData`.

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -35,7 +35,8 @@
 // example [database/sql] scans—see the root README go-sql-spanner section).
 //
 // [DelimitedGCVExportOptions] and [JSONLGCVExportOptions] group metadata, formatter,
-// and unnamed-field namer options for GCV slice export.
+// and unnamed-field namer options for GCV slice export. [WithFormatter] does not call
+// [spanvalue.FormatConfig.Validate]; validate hand-built formatters before construction.
 //
 // # Quoted delimited text vs raw tab-separated
 //

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -36,7 +36,7 @@
 //
 // [DelimitedGCVExportOptions] and [JSONLGCVExportOptions] group metadata, formatter,
 // and unnamed-field namer options for GCV slice export. [WithFormatter] does not call
-// [spanvalue.FormatConfig.Validate]; validate hand-built formatters before construction.
+// [*spanvalue.FormatConfig.Validate]; validate hand-built formatters before construction.
 //
 // # Quoted delimited text vs raw tab-separated
 //

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -345,7 +345,7 @@ type formatterOption struct {
 // [DelimitedWriter] uses [spanvalue.SimpleFormatConfig],
 // [JSONLWriter] uses [spanvalue.JSONFormatConfig],
 // and [SQLInsertWriter] uses [spanvalue.LiteralFormatConfig].
-// Writers do not call [spanvalue.FormatConfig.Validate] on the supplied config;
+// Writers do not call [*spanvalue.FormatConfig.Validate] on the supplied config;
 // validate hand-built formatters before construction when early failure is desired.
 func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -345,6 +345,8 @@ type formatterOption struct {
 // [DelimitedWriter] uses [spanvalue.SimpleFormatConfig],
 // [JSONLWriter] uses [spanvalue.JSONFormatConfig],
 // and [SQLInsertWriter] uses [spanvalue.LiteralFormatConfig].
+// Writers do not call [spanvalue.FormatConfig.Validate] on the supplied config;
+// validate hand-built formatters before construction when early failure is desired.
 func WithFormatter(formatter *spanvalue.FormatConfig) Option {
 	return formatterOption{formatter: formatter}
 }


### PR DESCRIPTION
## Summary

Bundles documentation for five related adoption issues:

- **#175** — Document `FormatOptionallyTypedArray` / `LiteralFormatConfig` ARRAY literal policy (scalar and empty top-level arrays omit `ARRAY<...>` prefix).
- **#176** — Expand `FormatConfig.Validate` adoption guidance in root docs; note that writers do not validate `WithFormatter` configs.
- **#182** — Document that `ColumnNames` preserves explicit duplicate aliases; add regression test.
- **#183** — Document duplicate column headers in CSV/TSV exports (`writer/README.md`).
- **#184** — Add `gcvctor.Must*` adoption snippet to root README.

No API changes.

## Test plan

- [x] `make check`
- [x] New `TestColumnNames` case for explicit duplicate aliases (`["a", "a"]`)

Closes #175, #176, #182, #183, #184.

Made with [Cursor](https://cursor.com)