### PR TITLE
fix(literal): align NaN/±Inf CAST quotes with QuoteLegacy (v0.7)

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -169,11 +169,11 @@ func Float64ToLiteral(v float64) string {
 func Float64ToLiteralPolicy(v float64, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(v):
-		return sqlCastQuotedString("nan", "FLOAT64", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("nan", "FLOAT64", quoteForPayload(policy, "nan"))
 	case math.IsInf(v, 1):
-		return sqlCastQuotedString("inf", "FLOAT64", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("inf", "FLOAT64", quoteForPayload(policy, "inf"))
 	case math.IsInf(v, -1):
-		return sqlCastQuotedString("-inf", "FLOAT64", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("-inf", "FLOAT64", quoteForPayload(policy, "-inf"))
 	default:
 		return strconv.FormatFloat(v, 'g', -1, 64)
 	}
@@ -186,28 +186,13 @@ func Float32ToLiteral(v float32) string {
 func Float32ToLiteralPolicy(v float32, policy QuotePolicy) string {
 	switch {
 	case math.IsNaN(float64(v)):
-		return sqlCastQuotedString("nan", "FLOAT32", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("nan", "FLOAT32", quoteForPayload(policy, "nan"))
 	case math.IsInf(float64(v), 1):
-		return sqlCastQuotedString("inf", "FLOAT32", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("inf", "FLOAT32", quoteForPayload(policy, "inf"))
 	case math.IsInf(float64(v), -1):
-		return sqlCastQuotedString("-inf", "FLOAT32", nonFiniteCastDelimiter(policy))
+		return sqlCastQuotedString("-inf", "FLOAT32", quoteForPayload(policy, "-inf"))
 	default:
 		return fmt.Sprintf("CAST(%v AS FLOAT32)", strconv.FormatFloat(float64(v), 'g', -1, 32))
-	}
-}
-
-// nonFiniteCastDelimiter selects the outer delimiter for NaN/±Inf CAST payloads.
-// v0.5 compat: QuoteStrategyLegacy keeps historical single quotes; Always and
-// MinEscape use PreferredQuote. Planned v0.6: align with quoteForPayload.
-func nonFiniteCastDelimiter(policy QuotePolicy) rune {
-	switch policy.Strategy {
-	case QuoteStrategyAlways, QuoteStrategyMinEscape:
-		if policy.Preferred == PreferredQuoteDouble {
-			return '"'
-		}
-		return '\''
-	default:
-		return '\''
 	}
 }
 

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -311,6 +311,13 @@ func TestLiteralQuoteNaNInf(t *testing.T) {
 	if gotLegacySingle != "CAST('nan' AS FLOAT64)" {
 		t.Fatalf("legacy preferred single NaN = %q, want CAST('nan' AS FLOAT64)", gotLegacySingle)
 	}
+	gotLegacySingleF32, err := legacySingle.FormatToplevelColumn(gcvctor.Float32Value(float32(math.NaN())))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLegacySingleF32 != "CAST('nan' AS FLOAT32)" {
+		t.Fatalf("legacy preferred single float32 NaN = %q, want CAST('nan' AS FLOAT32)", gotLegacySingleF32)
+	}
 
 	minEscapeDouble := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
 		Strategy:       QuoteMinEscape,

--- a/literal_quote_test.go
+++ b/literal_quote_test.go
@@ -259,11 +259,11 @@ func TestLiteralQuoteNaNInf(t *testing.T) {
 		gcv  spanner.GenericColumnValue
 		want string
 	}{
-		{"float64 nan legacy", gcvctor.Float64Value(math.NaN()), "CAST('nan' AS FLOAT64)"},
-		{"float64 inf legacy", gcvctor.Float64Value(math.Inf(1)), "CAST('inf' AS FLOAT64)"},
-		{"float64 neg inf legacy", gcvctor.Float64Value(math.Inf(-1)), "CAST('-inf' AS FLOAT64)"},
-		{"float32 nan legacy", gcvctor.Float32Value(float32(math.NaN())), "CAST('nan' AS FLOAT32)"},
-		{"float32 inf legacy", gcvctor.Float32Value(float32(math.Inf(1))), "CAST('inf' AS FLOAT32)"},
+		{"float64 nan legacy", gcvctor.Float64Value(math.NaN()), `CAST("nan" AS FLOAT64)`},
+		{"float64 inf legacy", gcvctor.Float64Value(math.Inf(1)), `CAST("inf" AS FLOAT64)`},
+		{"float64 neg inf legacy", gcvctor.Float64Value(math.Inf(-1)), `CAST("-inf" AS FLOAT64)`},
+		{"float32 nan legacy", gcvctor.Float32Value(float32(math.NaN())), `CAST("nan" AS FLOAT32)`},
+		{"float32 inf legacy", gcvctor.Float32Value(float32(math.Inf(1))), `CAST("inf" AS FLOAT32)`},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -298,6 +298,18 @@ func TestLiteralQuoteNaNInf(t *testing.T) {
 				t.Fatalf("double always got %q, want %q", got, tt.want)
 			}
 		})
+	}
+
+	legacySingle := LiteralFormatConfigWithQuote(LiteralQuoteConfig{
+		Strategy:       QuoteLegacy,
+		PreferredQuote: PreferredSingleQuote,
+	})
+	gotLegacySingle, err := legacySingle.FormatToplevelColumn(gcvctor.Float64Value(math.NaN()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLegacySingle != "CAST('nan' AS FLOAT64)" {
+		t.Fatalf("legacy preferred single NaN = %q, want CAST('nan' AS FLOAT64)", gotLegacySingle)
 	}
 
 	minEscapeDouble := LiteralFormatConfigWithQuote(LiteralQuoteConfig{

--- a/literal_test.go
+++ b/literal_test.go
@@ -134,17 +134,17 @@ func TestDecodeColumnLiteral(t *testing.T) {
 		{
 			desc:  "NaN",
 			value: math.NaN(),
-			want:  "CAST('nan' AS FLOAT64)",
+			want:  `CAST("nan" AS FLOAT64)`,
 		},
 		{
 			desc:  "Inf",
 			value: math.Inf(+1),
-			want:  "CAST('inf' AS FLOAT64)",
+			want:  `CAST("inf" AS FLOAT64)`,
 		},
 		{
 			desc:  "-Inf",
 			value: math.Inf(-1),
-			want:  "CAST('-inf' AS FLOAT64)",
+			want:  `CAST("-inf" AS FLOAT64)`,
 		},
 		{
 			desc:  "int64",


### PR DESCRIPTION
## Summary

- Route NaN/±Inf `CAST(... AS FLOAT32|FLOAT64)` delimiter selection through `quoteForPayload`, matching STRING/BYTES literals under `LiteralQuoteConfig`.
- Remove the v0.5 compatibility shim `nonFiniteCastDelimiter` from `internal/internal.go`.
- Update `TestLiteralQuoteNaNInf` and `TestDecodeColumnLiteral` expectations: default `QuoteLegacy` + `PreferredDoubleQuote` now emits `CAST("nan" AS FLOAT64)` instead of single-quoted payloads.
- Add coverage that `QuoteLegacy` + `PreferredSingleQuote` still single-quotes non-finite floats.

Closes #174.

## Target release

**v0.7.0** — [v0.6.0](https://github.com/apstndb/spanvalue/releases/tag/v0.6.0) is already on GitHub without this change; #174 alignment ships in the next minor.

## Breaking change (v0.7 release notes)

Under the default literal preset (`QuoteLegacy` + `PreferredDoubleQuote`), non-finite float literals change from `CAST('nan' AS FLOAT64)` to `CAST("nan" AS FLOAT64)` (and likewise for `±inf`). Callers with golden tests or snapshots of literal output should expect this diff when upgrading from **v0.6.x** (or earlier). Those who customized quote strategy but relied on the legacy NaN/Inf single-quote exception should update expectations or stay on **v0.6.x** until they can adopt the aligned behavior.

## Test plan

- [x] `make check`
- [x] `go test ./... -run TestLiteralQuoteNaNInf`


Made with [Cursor](https://cursor.com)