### PR TITLE
Add FormatConfig.WithComplexPlugin for safe plugin registration

### DIFF
--- a/common.go
+++ b/common.go
@@ -229,7 +229,7 @@ type Formatter interface {
 //     [ErrFormatNullableRequired] without Decode. NULL scalars use [*FormatConfig.GetNullString]
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
-// Use [FormatConfig.Clone] or [FormatConfig.WithComplexPlugin] to customize a preset
+// Use [*FormatConfig.Clone] or [*FormatConfig.WithComplexPlugin] to customize a preset
 // without mutating shared instances.
 // Call [*FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
 // or an empty [FormatConfig.NullString].

--- a/common.go
+++ b/common.go
@@ -229,7 +229,8 @@ type Formatter interface {
 //     [ErrFormatNullableRequired] without Decode. NULL scalars use [*FormatConfig.GetNullString]
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
-// Use [FormatConfig.Clone] to customize a preset without mutating shared instances.
+// Use [FormatConfig.Clone] or [FormatConfig.WithComplexPlugin] to customize a preset
+// without mutating shared instances.
 // Call [*FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
 // or an empty [FormatConfig.NullString].
 type FormatConfig struct {

--- a/doc.go
+++ b/doc.go
@@ -18,9 +18,9 @@
 // [FormatConfig.FormatComplexPlugins] to use Decode + [FormatConfig.FormatNullable]
 // (set FormatNullable on the clone; nil returns [ErrFormatNullableRequired]).
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is set.
-// Constructors return a new [FormatConfig]; call [FormatConfig.Clone] or
-// [FormatConfig.WithComplexPlugin] before mutating a config you may reuse
-// ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
+// Constructors return a new [FormatConfig]; call [*FormatConfig.Clone] or
+// [*FormatConfig.WithComplexPlugin] before mutating a config you may reuse
+// ([*FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
 // For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]
 // and set [FormatTupleStruct] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in

--- a/doc.go
+++ b/doc.go
@@ -18,8 +18,9 @@
 // [FormatConfig.FormatComplexPlugins] to use Decode + [FormatConfig.FormatNullable]
 // (set FormatNullable on the clone; nil returns [ErrFormatNullableRequired]).
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is set.
-// Constructors return a new [FormatConfig]; call [FormatConfig.Clone] before mutating
-// a config you may reuse ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
+// Constructors return a new [FormatConfig]; call [FormatConfig.Clone] or
+// [FormatConfig.WithComplexPlugin] before mutating a config you may reuse
+// ([FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
 // For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]
 // and set [FormatTupleStruct] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in

--- a/format_config.go
+++ b/format_config.go
@@ -45,6 +45,19 @@ func hasPresetScalarPlugin(fc *FormatConfig) bool {
 	return slices.ContainsFunc(fc.FormatComplexPlugins, isPresetScalarPlugin)
 }
 
+// WithComplexPlugin returns a clone of fc with plugin appended to FormatComplexPlugins.
+// The original config, including shared preset singletons, is not mutated. Chain
+// further calls on the returned config for additional plugins. Nil fc or nil plugin
+// returns nil.
+func (fc *FormatConfig) WithComplexPlugin(plugin FormatComplexFunc) *FormatConfig {
+	if fc == nil || plugin == nil {
+		return nil
+	}
+	clone := fc.Clone()
+	clone.FormatComplexPlugins = append(clone.FormatComplexPlugins, plugin)
+	return clone
+}
+
 // Clone returns a shallow copy of fc with a copied FormatComplexPlugins slice.
 // The returned config is independent for field assignment and plugin list
 // mutation; callback values themselves are shared with the source.

--- a/format_config.go
+++ b/format_config.go
@@ -47,11 +47,15 @@ func hasPresetScalarPlugin(fc *FormatConfig) bool {
 
 // WithComplexPlugin returns a clone of fc with plugin appended to FormatComplexPlugins.
 // The original config, including shared preset singletons, is not mutated. Chain
-// further calls on the returned config for additional plugins. Nil fc or nil plugin
-// returns nil.
+// further calls on the returned config for additional plugins. Nil fc returns nil.
+// A nil plugin panics so a mistaken nil in a chain fails at the call site instead of
+// collapsing the chain to nil.
 func (fc *FormatConfig) WithComplexPlugin(plugin FormatComplexFunc) *FormatConfig {
-	if fc == nil || plugin == nil {
+	if fc == nil {
 		return nil
+	}
+	if plugin == nil {
+		panic("spanvalue: WithComplexPlugin: nil plugin")
 	}
 	clone := fc.Clone()
 	clone.FormatComplexPlugins = append(clone.FormatComplexPlugins, plugin)

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -173,12 +173,15 @@ func TestFormatConfigWithComplexPlugin(t *testing.T) {
 		}
 	})
 
-	t.Run("nil plugin", func(t *testing.T) {
+	t.Run("nil plugin panics", func(t *testing.T) {
 		t.Parallel()
 		fc := SimpleFormatConfig()
-		if got := fc.WithComplexPlugin(nil); got != nil {
-			t.Fatalf("WithComplexPlugin(nil) = %v, want nil", got)
-		}
+		defer func() {
+			if recover() == nil {
+				t.Fatal("WithComplexPlugin(nil) did not panic")
+			}
+		}()
+		_ = fc.WithComplexPlugin(nil)
 	})
 
 	t.Run("preset singleton unchanged", func(t *testing.T) {

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -156,6 +156,92 @@ func TestFormatConfigClone(t *testing.T) {
 	}
 }
 
+func TestFormatConfigWithComplexPlugin(t *testing.T) {
+	t.Parallel()
+
+	plugin := FormatComplexFunc(func(Formatter, spanner.GenericColumnValue, bool) (string, error) {
+		return "plugin", nil
+	})
+	other := FormatComplexFunc(func(Formatter, spanner.GenericColumnValue, bool) (string, error) {
+		return "other", nil
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		if got := (*FormatConfig)(nil).WithComplexPlugin(plugin); got != nil {
+			t.Fatalf("WithComplexPlugin on nil receiver = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil plugin", func(t *testing.T) {
+		t.Parallel()
+		fc := SimpleFormatConfig()
+		if got := fc.WithComplexPlugin(nil); got != nil {
+			t.Fatalf("WithComplexPlugin(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("preset singleton unchanged", func(t *testing.T) {
+		t.Parallel()
+		preset := SimpleFormatConfig()
+		before := len(preset.FormatComplexPlugins)
+		got := preset.WithComplexPlugin(plugin)
+		if len(preset.FormatComplexPlugins) != before {
+			t.Fatalf("preset len = %d, want %d unchanged", len(preset.FormatComplexPlugins), before)
+		}
+		if got == preset {
+			t.Fatal("WithComplexPlugin returned preset singleton")
+		}
+		if len(got.FormatComplexPlugins) != before+1 {
+			t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(got.FormatComplexPlugins), before+1)
+		}
+		if got.FormatComplexPlugins[len(got.FormatComplexPlugins)-1] == nil {
+			t.Fatal("appended nil plugin")
+		}
+	})
+
+	t.Run("chain", func(t *testing.T) {
+		t.Parallel()
+		preset := SimpleFormatConfig()
+		before := len(preset.FormatComplexPlugins)
+		got := preset.WithComplexPlugin(plugin).WithComplexPlugin(other)
+		if len(preset.FormatComplexPlugins) != before {
+			t.Fatalf("preset len = %d, want %d unchanged", len(preset.FormatComplexPlugins), before)
+		}
+		if len(got.FormatComplexPlugins) != before+2 {
+			t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(got.FormatComplexPlugins), before+2)
+		}
+		if err := got.Validate(); err != nil {
+			t.Fatalf("Validate() = %v, want nil", err)
+		}
+	})
+
+	t.Run("hand-built clone isolation", func(t *testing.T) {
+		t.Parallel()
+		original := &FormatConfig{
+			NullString:           "NULL",
+			FormatArray:          FormatCompactArray,
+			FormatStruct:         TypedStructFormat(),
+			FormatNullable:       formatNullableValueSimple,
+			FormatComplexPlugins: []FormatComplexFunc{plugin},
+		}
+		got := original.WithComplexPlugin(other)
+		if got == original {
+			t.Fatal("WithComplexPlugin returned same pointer as original")
+		}
+		if len(original.FormatComplexPlugins) != 1 {
+			t.Fatalf("original len = %d, want 1", len(original.FormatComplexPlugins))
+		}
+		if len(got.FormatComplexPlugins) != 2 {
+			t.Fatalf("got len = %d, want 2", len(got.FormatComplexPlugins))
+		}
+		got.FormatComplexPlugins[0] = nil
+		if original.FormatComplexPlugins[0] == nil {
+			t.Fatal("mutating returned config changed original plugin slice element")
+		}
+	})
+}
+
 func TestFormatConfigClonePluginAppendIsolation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add `(*FormatConfig).WithComplexPlugin` to clone a config and append one `FormatComplexFunc` without mutating shared preset singletons.
- Document the helper in package, `FormatConfig`, and `doc.go` godoc.
- Add tests for nil receiver/plugin rejection, preset isolation, chaining, and clone independence.

Closes #181.

## Test plan

- [x] `make check`
- [x] `go test ./... -run TestFormatConfigWithComplexPlugin`


Made with [Cursor](https://cursor.com)