### PR TITLE
ci: run govulncheck on Go 1.25 with @latest scanner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,10 +86,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # golang.org/x/vuln v1.2.0+ requires Go 1.25 to install. Other jobs stay on
+      # go.mod's 1.23 toolchain; govulncheck only needs a toolchain new enough to
+      # build this module (>= go 1.23) and run the scanner binary.
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: false
 
       - name: Run govulncheck

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,6 +89,8 @@ jobs:
       # golang.org/x/vuln v1.2.0+ requires Go 1.25 to install. Other jobs stay on
       # go.mod's 1.23 toolchain; govulncheck only needs a toolchain new enough to
       # build this module (>= go 1.23) and run the scanner binary.
+      # Stdlib findings are relative to this job's Go toolchain (1.25), not go.mod's
+      # 1.23 target; dependency reachability is the main signal for a library module.
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

- Run the `govulncheck` CI job on **Go 1.25** instead of `go-version-file: go.mod` (Go 1.23.2).
- Keep `go install golang.org/x/vuln/cmd/govulncheck@latest` — no pin to v1.1.4.
- Leave `go.mod` at `go 1.23` / `toolchain go1.23.2`; `make check` and other jobs unchanged.

Supersedes the pin approach from the first revision of this PR.

## Why not pin govulncheck?

`govulncheck` analyzes the **compiled module graph** of the repo (`go build -deps` semantics). It needs a Go toolchain that can **build** this module (≥ `go 1.23` here) and a **scanner binary** installable on that runner.

`golang.org/x/vuln` **v1.2.0+** requires Go **≥ 1.25** to `go install`. CI used Go 1.23.2 with `GOTOOLCHAIN=local` (setup-go default), so `@latest` failed before the scan ran:

```
go: golang.org/x/vuln/cmd/govulncheck@latest: golang.org/x/vuln@v1.3.0 requires go >= 1.25.0 (running go 1.23.2; GOTOOLCHAIN=local)
```

**govulncheck does not need to run on the same Go minor as `go.mod`.** The `go` directive is a minimum language version for the module, not a cap. A job on Go 1.25 with `GOTOOLCHAIN=local` still builds 1.23-compatible code and can install current `govulncheck`.

| Option | Pros | Cons |
|--------|------|------|
| Pin `govulncheck@v1.1.4` (prior PR revision) | No workflow Go bump | Stale scanner/DB wiring; manual bumps |
| **Govulncheck job on Go 1.25 + `@latest` (this PR)** | Current scanner; `go.mod` unchanged | One job on newer Go |
| Bump `toolchain` / `go` in `go.mod` | Single Go everywhere | Wider contributor/CI surface change |

## `continue-on-error`

Left **enabled**: the scan can exit non-zero when it reports reachable vulns (e.g. stdlib via `cloud.google.com/go/spanner`), not only on tool failure. Remove in a follow-up if you want advisory findings to fail the workflow.

## Test plan

- [x] Reproduced install failure: `GOTOOLCHAIN=go1.23.2 go install …@latest`
- [x] Verified `GOTOOLCHAIN=go1.25.0 go install …@latest` and `govulncheck ./...` on `main`
- [ ] CI `govulncheck` job installs scanner and completes on this PR