### PR TITLE
Fix pre-v0.7.0 review: WithComplexPlugin prepend and dbsqlrows errors

### DIFF
--- a/common.go
+++ b/common.go
@@ -229,7 +229,7 @@ type Formatter interface {
 //     [ErrFormatNullableRequired] without Decode. NULL scalars use [*FormatConfig.GetNullString]
 //     before the slow path runs (FormatNullable is not called for NULL).
 //
-// Use [*FormatConfig.Clone] or [*FormatConfig.WithComplexPlugin] to customize a preset
+// Use [*FormatConfig.Clone] or [*FormatConfig.WithComplexPlugin] (prepends plugins) to customize a preset
 // without mutating shared instances.
 // Call [*FormatConfig.Validate] after hand-assembling a config to fail fast on nil callbacks
 // or an empty [FormatConfig.NullString].

--- a/dbsqlrows/export.go
+++ b/dbsqlrows/export.go
@@ -139,10 +139,7 @@ func runRows(fac rowsFacade, hooks SQLRowsHooks, run exportRunConfig) (*SQLRowsR
 			if err := fac.err(); err != nil {
 				return abort(err)
 			}
-			if err := callPrepareMetadata(hooks, md); err != nil {
-				return abort(err)
-			}
-			return finishRun(result, hooks)
+			return abort(ErrMissingDataResultSet)
 		}
 	} else if run.metadata == nil {
 		return nil, ErrNilMetadata
@@ -216,13 +213,20 @@ func readResultSetStats(fac rowsFacade) (*sppb.ResultSetStats, error) {
 		return nil, nil
 	}
 	if !fac.next() {
+		if err := fac.err(); err != nil {
+			return nil, err
+		}
 		return nil, ErrMissingStatsRow
 	}
 	var stats *sppb.ResultSetStats
 	if err := fac.scan(&stats); err != nil {
 		return nil, err
 	}
-	_ = fac.nextResultSet()
+	if !fac.nextResultSet() {
+		if err := fac.err(); err != nil {
+			return nil, err
+		}
+	}
 	return stats, nil
 }
 

--- a/dbsqlrows/export_test.go
+++ b/dbsqlrows/export_test.go
@@ -19,14 +19,19 @@ import (
 var _ rowsFacade = (*stubSQLRows)(nil)
 
 type stubSQLRows struct {
-	resultSets [][]stubRow
-	set        int
-	row        int
-	scanErr    error
-	nextRSErr  error
-	lastErr    error
-	nextRSOK   bool
-	columns    []string
+	resultSets  [][]stubRow
+	set         int
+	row         int
+	scanErr     error
+	nextErr     error
+	nextErrOn   int
+	nextCalls   int
+	nextRSErr   error
+	nextRSErrOn int
+	nextRSCalls int
+	lastErr     error
+	nextRSOK    bool
+	columns     []string
 }
 
 type stubRow struct {
@@ -43,12 +48,23 @@ func (s *stubSQLRows) next() bool {
 	if s.row >= len(s.resultSets[s.set]) {
 		return false
 	}
+	s.nextCalls++
+	errOn := s.nextErrOn
+	if s.nextErr != nil && errOn != 0 && s.nextCalls == errOn {
+		s.lastErr = s.nextErr
+		return false
+	}
 	s.row++
 	return true
 }
 
 func (s *stubSQLRows) nextResultSet() bool {
-	if s.nextRSErr != nil {
+	s.nextRSCalls++
+	errOn := s.nextRSErrOn
+	if errOn == 0 {
+		errOn = 1
+	}
+	if s.nextRSErr != nil && s.nextRSCalls == errOn {
 		s.lastErr = s.nextRSErr
 		return false
 	}
@@ -399,6 +415,49 @@ func TestReadMetadataAndAdvanceToData_missingDataResultSet(t *testing.T) {
 	}
 }
 
+func TestReadMetadataAndAdvanceToData_nextResultSetError(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	wantErr := errors.New("next result set failed")
+	stub := &stubSQLRows{
+		nextRSErr: wantErr,
+		resultSets: [][]stubRow{
+			{{values: []any{md}}},
+		},
+	}
+
+	_, ok, err := readMetadataAndAdvanceToData(stub)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if ok {
+		t.Fatal("ok = true, want false")
+	}
+}
+
+func TestWriteRows_missingDataResultSet(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	stub := &stubSQLRows{
+		resultSets: [][]stubRow{
+			{{values: []any{md}}},
+		},
+	}
+
+	got, err := exportRows(stub, &stubGCVWriter{}, exportRunConfig{readMetadataPseudoRow: true})
+	if !errors.Is(err, ErrMissingDataResultSet) {
+		t.Fatalf("error = %v, want ErrMissingDataResultSet", err)
+	}
+	if got.Metadata == nil {
+		t.Fatal("Metadata is nil on missing data result set")
+	}
+	if diff := cmp.Diff(md, got.Metadata, protocmp.Transform()); diff != "" {
+		t.Fatalf("Metadata mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestWriteRows_missingStatsRow(t *testing.T) {
 	t.Parallel()
 
@@ -418,6 +477,67 @@ func TestWriteRows_missingStatsRow(t *testing.T) {
 	})
 	if !errors.Is(err, ErrMissingStatsRow) {
 		t.Fatalf("error = %v, want ErrMissingStatsRow", err)
+	}
+}
+
+func TestWriteRows_statsNextError(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	wantErr := errors.New("stats next failed")
+	stats := &sppb.ResultSetStats{RowCount: &sppb.ResultSetStats_RowCountExact{RowCountExact: 1}}
+	stub := &stubSQLRows{
+		columns:   []string{"id"},
+		nextErr:   wantErr,
+		nextErrOn: 2,
+		resultSets: [][]stubRow{
+			{{values: []any{md}}},
+			nil,
+			{{values: []any{stats}}},
+		},
+	}
+
+	got, err := exportRows(stub, &stubGCVWriter{}, exportRunConfig{
+		readMetadataPseudoRow: true,
+		readResultSetStats:    true,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if got.Metadata == nil {
+		t.Fatal("Metadata is nil on stats next error")
+	}
+}
+
+func TestWriteRows_statsNextResultSetError(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	stats := &sppb.ResultSetStats{RowCount: &sppb.ResultSetStats_RowCountExact{RowCountExact: 1}}
+	wantErr := errors.New("stats next result set failed")
+	stub := &stubSQLRows{
+		columns:     []string{"id"},
+		nextRSErr:   wantErr,
+		nextRSErrOn: 3,
+		resultSets: [][]stubRow{
+			{{values: []any{md}}},
+			nil,
+			{{values: []any{stats}}},
+		},
+	}
+
+	got, err := exportRows(stub, &stubGCVWriter{}, exportRunConfig{
+		readMetadataPseudoRow: true,
+		readResultSetStats:    true,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if got.Metadata == nil {
+		t.Fatal("Metadata is nil on stats nextResultSet error")
+	}
+	if got.Stats != nil {
+		t.Fatalf("Stats = %v, want nil on error", got.Stats)
 	}
 }
 

--- a/dbsqlrows/gospanner/export.go
+++ b/dbsqlrows/gospanner/export.go
@@ -58,6 +58,10 @@ func QueryExportWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	return dbsqlrows.WriteRows(rows, w, cfg)
+	result, writeErr := dbsqlrows.WriteRows(rows, w, cfg)
+	closeErr := rows.Close()
+	if writeErr != nil {
+		return result, writeErr
+	}
+	return result, closeErr
 }

--- a/dbsqlrows/metadata.go
+++ b/dbsqlrows/metadata.go
@@ -27,6 +27,9 @@ func readMetadataAndAdvanceToData(fac rowsFacade) (*sppb.ResultSetMetadata, bool
 		return nil, false, err
 	}
 	if !fac.nextResultSet() {
+		if err := fac.err(); err != nil {
+			return nil, false, err
+		}
 		return nil, false, ErrMissingDataResultSet
 	}
 	return md, true, nil

--- a/doc.go
+++ b/doc.go
@@ -26,8 +26,8 @@
 // (set FormatNullable on the clone; nil returns [ErrFormatNullableRequired]).
 // Scalar plugins fall through to that path when [FormatConfig.FormatNullable] is set.
 // Constructors return a new [FormatConfig]; call [*FormatConfig.Clone] or
-// [*FormatConfig.WithComplexPlugin] before mutating a config you may reuse
-// ([*FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
+// [*FormatConfig.WithComplexPlugin] (prepends plugins) before mutating a config
+// you may reuse ([*FormatConfig.Clone] copies [FormatConfig.FormatComplexPlugins]).
 // For tuple STRUCT with Spanner CLI scalars, clone [SpannerCLICompatibleFormatConfig]
 // and set [FormatTupleStruct] (see README).
 // [FormatConfig.FormatColumn] runs [FormatComplexFunc] plugins first, then built-in

--- a/format_config.go
+++ b/format_config.go
@@ -45,11 +45,13 @@ func hasPresetScalarPlugin(fc *FormatConfig) bool {
 	return slices.ContainsFunc(fc.FormatComplexPlugins, isPresetScalarPlugin)
 }
 
-// WithComplexPlugin returns a clone of fc with plugin appended to FormatComplexPlugins.
-// The original config, including shared preset singletons, is not mutated. Chain
-// further calls on the returned config for additional plugins. Nil fc returns nil.
-// A nil plugin panics so a mistaken nil in a chain fails at the call site instead of
-// collapsing the chain to nil.
+// WithComplexPlugin returns a clone of fc with plugin prepended to FormatComplexPlugins
+// so it runs before existing plugins (including preset scalar plugins). This matches the
+// protofmt pattern of prepending descriptor-aware plugins before preset defaults.
+// The original config, including shared preset singletons, is not mutated. Chain further
+// calls on the returned config for additional plugins (each prepends, so the most recent
+// call runs first). Nil fc returns nil. A nil plugin panics so a mistaken nil in a chain
+// fails at the call site instead of collapsing the chain to nil.
 func (fc *FormatConfig) WithComplexPlugin(plugin FormatComplexFunc) *FormatConfig {
 	if fc == nil {
 		return nil
@@ -58,7 +60,7 @@ func (fc *FormatConfig) WithComplexPlugin(plugin FormatComplexFunc) *FormatConfi
 		panic("spanvalue: WithComplexPlugin: nil plugin")
 	}
 	clone := fc.Clone()
-	clone.FormatComplexPlugins = append(clone.FormatComplexPlugins, plugin)
+	clone.FormatComplexPlugins = append([]FormatComplexFunc{plugin}, clone.FormatComplexPlugins...)
 	return clone
 }
 

--- a/format_config_test.go
+++ b/format_config_test.go
@@ -198,8 +198,8 @@ func TestFormatConfigWithComplexPlugin(t *testing.T) {
 		if len(got.FormatComplexPlugins) != before+1 {
 			t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(got.FormatComplexPlugins), before+1)
 		}
-		if got.FormatComplexPlugins[len(got.FormatComplexPlugins)-1] == nil {
-			t.Fatal("appended nil plugin")
+		if got.FormatComplexPlugins[0] == nil {
+			t.Fatal("prepended nil plugin")
 		}
 	})
 
@@ -213,6 +213,16 @@ func TestFormatConfigWithComplexPlugin(t *testing.T) {
 		}
 		if len(got.FormatComplexPlugins) != before+2 {
 			t.Fatalf("len(FormatComplexPlugins) = %d, want %d", len(got.FormatComplexPlugins), before+2)
+		}
+		if got.FormatComplexPlugins[0] == nil || got.FormatComplexPlugins[1] == nil {
+			t.Fatal("chained prepend left nil plugin slot")
+		}
+		// Most recent WithComplexPlugin call prepends first (other before plugin).
+		if s, err := got.FormatComplexPlugins[0](nil, spanner.GenericColumnValue{}, false); err != nil || s != "other" {
+			t.Fatalf("first plugin = %q, want other", s)
+		}
+		if s, err := got.FormatComplexPlugins[1](nil, spanner.GenericColumnValue{}, false); err != nil || s != "plugin" {
+			t.Fatalf("second plugin = %q, want plugin", s)
 		}
 		if err := got.Validate(); err != nil {
 			t.Fatalf("Validate() = %v, want nil", err)


### PR DESCRIPTION
## Summary

- **Closes #194** — `WithComplexPlugin` now **prepends** plugins (matches protofmt docs and plugin precedence over preset scalars). Godoc updated in root package.
- **Closes #195** — `dbsqlrows` iterator correctness:
  - `ReadMetadataAndAdvanceToData`: check facade error after failed `NextResultSet` before `ErrMissingDataResultSet`
  - `WriteRows` / `runRows`: return `ErrMissingDataResultSet` when metadata exists but there is no data result set (aligned with `ReadMetadataAndAdvanceToData`)
  - `readResultSetStats`: check facade error on failed stats `Next()`; propagate `NextResultSet` error after stats scan
  - `gospanner.QueryExportWithOptions`: return `rows.Close()` error when export succeeded

Stacks on #193 (`fix/issue-192`). Merge #193 first, then rebase this PR onto `main` (or merge with updated base).

## Test plan

- [x] `make check`
- [x] `go test ./...` in `dbsqlrows/gospanner`
- [x] New unit tests for metadata/data/stats error paths in `dbsqlrows/export_test.go`
- [x] Updated `TestFormatConfigWithComplexPlugin` for prepend semantics


Made with [Cursor](https://cursor.com)