### PR TITLE
gcvctor: add StructFieldKV and StructFieldKVOf

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -7,9 +7,9 @@
 // [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
-// names with values; counts must match. [StructValueOfFields] accepts [StructField] pairs;
-// [StructFieldOf] is the usual constructor; positional composite literals
-// (StructField{name, value}) are also valid. Empty field names denote unnamed STRUCT fields.
+// names with values; counts must match. [StructValueOfFields] accepts [StructFieldKV] pairs;
+// [StructFieldKVOf] is the usual constructor; positional composite literals
+// (StructFieldKV{name, value}) are also valid. Empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type
 // (protobuf: array_element_type; Go field name ArrayElementType); omitting it yields an invalid ARRAY

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -8,7 +8,7 @@
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
 // names with values; counts must match. [StructValueOfFields] accepts [StructField] pairs;
-// [StructFieldKVOf] is the usual constructor; positional composite literals
+// [StructFieldOf] is the usual constructor; positional composite literals
 // (StructField{name, value}) are also valid. Empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -8,8 +8,8 @@
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
 // names with values; counts must match. [StructValueOfFields] accepts [StructFieldKV] pairs;
-// [StructFieldKVOf] is the usual constructor; positional composite literals
-// (StructFieldKV{name, value}) are also valid. Empty field names denote unnamed STRUCT fields.
+// [StructFieldKVOf] is the usual constructor; keyed composite literals
+// (StructFieldKV{Name: name, Value: value}) are also valid. Empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type
 // (protobuf: array_element_type; Go field name ArrayElementType); omitting it yields an invalid ARRAY

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -7,8 +7,8 @@
 // [github.com/apstndb/spantype/typector.ElemTypeToArrayType] or [github.com/apstndb/spantype/typector.ElemCodeToArrayType] instead of relying
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
-// names with values; counts must match. [StructValueOfFields] accepts [StructField] pairs.
-// for inline fixture construction; empty field names denote unnamed STRUCT fields.
+// names with values; counts must match. [StructValueOfFields] accepts [StructField] pairs;
+// [StructFieldKV] is the usual constructor. Empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type
 // (protobuf: array_element_type; Go field name ArrayElementType); omitting it yields an invalid ARRAY

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -8,7 +8,8 @@
 // on variadic nil. [NormalizeArrayElements] rewrites SQL NULL elements to [NullOf] with elemType before
 // a strict [ArrayValueOf] call when callers already know the final array element type. [StructValueOf] pairs field
 // names with values; counts must match. [StructValueOfFields] accepts [StructField] pairs;
-// [StructFieldKV] is the usual constructor. Empty field names denote unnamed STRUCT fields.
+// [StructFieldKVOf] is the usual constructor; positional composite literals
+// (StructField{name, value}) are also valid. Empty field names denote unnamed STRUCT fields.
 //
 // ARRAY-typed [cloud.google.com/go/spanner/apiv1/spannerpb.Type] values require array_element_type
 // (protobuf: array_element_type; Go field name ArrayElementType); omitting it yields an invalid ARRAY

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -125,15 +125,15 @@ func ExampleNullOf_structContainer() {
 
 func ExampleStructValueOfFields() {
 	row, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 	if err != nil {
 		panic(err)
 	}
 	unnamed, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
-		gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
+		gcvctor.StructFieldOf("", gcvctor.StringValue("value")),
+		gcvctor.StructFieldOf("", gcvctor.Int64Value(42)),
 	)
 	if err != nil {
 		panic(err)
@@ -148,8 +148,8 @@ func ExampleStructValueOfFields() {
 
 func ExampleMustStructValueOfFields() {
 	row := gcvctor.MustStructValueOfFields(
-		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 
 	fmt.Println(row.Type.StructType.Fields[1].Name, row.Value.GetListValue().Values[1].GetStringValue())

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -124,20 +124,37 @@ func ExampleNullOf_structContainer() {
 }
 
 func ExampleStructValueOfFields() {
-	row := gcvctor.MustStructValueOfFields(
+	row, err := gcvctor.StructValueOfFields(
 		gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
 		gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
 	)
-	unnamed := gcvctor.MustStructValueOfFields(
+	if err != nil {
+		panic(err)
+	}
+	unnamed, err := gcvctor.StructValueOfFields(
 		gcvctor.StructFieldKV("", gcvctor.StringValue("value")),
 		gcvctor.StructFieldKV("", gcvctor.Int64Value(42)),
 	)
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Println(row.Type.StructType.Fields[0].Name, row.Value.GetListValue().Values[0].GetStringValue())
 	fmt.Println(len(unnamed.Type.StructType.Fields), unnamed.Type.StructType.Fields[0].Name == "")
 	// Output:
 	// Code 10
 	// 2 true
+}
+
+func ExampleMustStructValueOfFields() {
+	row := gcvctor.MustStructValueOfFields(
+		gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
+	)
+
+	fmt.Println(row.Type.StructType.Fields[1].Name, row.Value.GetListValue().Values[1].GetStringValue())
+	// Output:
+	// DisplayOrder 1
 }
 
 func ExampleInt64FromPtr_fromNullable() {

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -125,12 +125,12 @@ func ExampleNullOf_structContainer() {
 
 func ExampleStructValueOfFields() {
 	row := gcvctor.MustStructValueOfFields(
-		gcvctor.StructField{Name: "Code", Value: gcvctor.StringValue("10")},
-		gcvctor.StructField{Name: "DisplayOrder", Value: gcvctor.Int64Value(1)},
+		gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 	unnamed := gcvctor.MustStructValueOfFields(
-		gcvctor.StructField{Name: "", Value: gcvctor.StringValue("value")},
-		gcvctor.StructField{Name: "", Value: gcvctor.Int64Value(42)},
+		gcvctor.StructFieldKV("", gcvctor.StringValue("value")),
+		gcvctor.StructFieldKV("", gcvctor.Int64Value(42)),
 	)
 
 	fmt.Println(row.Type.StructType.Fields[0].Name, row.Value.GetListValue().Values[0].GetStringValue())

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -125,15 +125,15 @@ func ExampleNullOf_structContainer() {
 
 func ExampleStructValueOfFields() {
 	row, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 	if err != nil {
 		panic(err)
 	}
 	unnamed, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldKV("", gcvctor.StringValue("value")),
-		gcvctor.StructFieldKV("", gcvctor.Int64Value(42)),
+		gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
+		gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
 	)
 	if err != nil {
 		panic(err)
@@ -148,8 +148,8 @@ func ExampleStructValueOfFields() {
 
 func ExampleMustStructValueOfFields() {
 	row := gcvctor.MustStructValueOfFields(
-		gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 
 	fmt.Println(row.Type.StructType.Fields[1].Name, row.Value.GetListValue().Values[1].GetStringValue())

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -125,15 +125,15 @@ func ExampleNullOf_structContainer() {
 
 func ExampleStructValueOfFields() {
 	row, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 	if err != nil {
 		panic(err)
 	}
 	unnamed, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldOf("", gcvctor.StringValue("value")),
-		gcvctor.StructFieldOf("", gcvctor.Int64Value(42)),
+		gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
+		gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
 	)
 	if err != nil {
 		panic(err)
@@ -148,8 +148,8 @@ func ExampleStructValueOfFields() {
 
 func ExampleMustStructValueOfFields() {
 	row := gcvctor.MustStructValueOfFields(
-		gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 	)
 
 	fmt.Println(row.Type.StructType.Fields[1].Name, row.Value.GetListValue().Values[1].GetStringValue())

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -410,6 +410,7 @@ func StructFieldKV(name string, value spanner.GenericColumnValue) StructField {
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.
+// Prefer [StructFieldKV] at call sites; composite [StructField] literals are also valid.
 // Empty field names are valid for unnamed STRUCT fields.
 func StructValueOfFields(fields ...StructField) (spanner.GenericColumnValue, error) {
 	names := make([]string, len(fields))

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -396,21 +396,22 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 
 // StructField pairs one STRUCT field name with its GCV.
 // An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
-// Prefer [StructFieldKV] at call sites for brevity; composite literals remain valid when
-// field names or values need extra clarity.
+// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// (StructField{name, value}) are also valid when field names or values need extra clarity.
 type StructField struct {
 	Name  string
 	Value spanner.GenericColumnValue
 }
 
-// StructFieldKV returns a [StructField] with the given name and value.
-// Empty name is valid for unnamed STRUCT fields.
-func StructFieldKV(name string, value spanner.GenericColumnValue) StructField {
+// StructFieldKVOf returns a [StructField] with the given name and value in Key/Value order.
+// The struct has no other members. Empty name is valid for unnamed STRUCT fields.
+func StructFieldKVOf(name string, value spanner.GenericColumnValue) StructField {
 	return StructField{Name: name, Value: value}
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.
-// Prefer [StructFieldKV] at call sites; composite [StructField] literals are also valid.
+// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// (StructField{name, value}) are also valid.
 // Empty field names are valid for unnamed STRUCT fields.
 func StructValueOfFields(fields ...StructField) (spanner.GenericColumnValue, error) {
 	names := make([]string, len(fields))

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -396,9 +396,17 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 
 // StructField pairs one STRUCT field name with its GCV.
 // An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
+// Prefer [StructFieldKV] at call sites for brevity; composite literals remain valid when
+// field names or values need extra clarity.
 type StructField struct {
 	Name  string
 	Value spanner.GenericColumnValue
+}
+
+// StructFieldKV returns a [StructField] with the given name and value.
+// Empty name is valid for unnamed STRUCT fields.
+func StructFieldKV(name string, value spanner.GenericColumnValue) StructField {
+	return StructField{Name: name, Value: value}
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -396,8 +396,8 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 
 // StructFieldKV pairs one STRUCT field name with its GCV.
 // An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
-// Prefer [StructFieldKVOf] at call sites; positional composite literals
-// (StructFieldKV{name, value}) are also valid when field names or values need extra clarity.
+// Prefer [StructFieldKVOf] at call sites; keyed composite literals
+// (StructFieldKV{Name: name, Value: value}) are also valid.
 type StructFieldKV struct {
 	Name  string
 	Value spanner.GenericColumnValue
@@ -410,8 +410,8 @@ func StructFieldKVOf(name string, value spanner.GenericColumnValue) StructFieldK
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.
-// Prefer [StructFieldKVOf] at call sites; positional composite literals
-// (StructFieldKV{name, value}) are also valid.
+// Prefer [StructFieldKVOf] at call sites; keyed composite literals
+// (StructFieldKV{Name: name, Value: value}) are also valid.
 // Empty field names are valid for unnamed STRUCT fields.
 func StructValueOfFields(fields ...StructFieldKV) (spanner.GenericColumnValue, error) {
 	names := make([]string, len(fields))

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -396,21 +396,21 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 
 // StructField pairs one STRUCT field name with its GCV.
 // An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
-// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// Prefer [StructFieldOf] at call sites; positional composite literals
 // (StructField{name, value}) are also valid when field names or values need extra clarity.
 type StructField struct {
 	Name  string
 	Value spanner.GenericColumnValue
 }
 
-// StructFieldKVOf returns a [StructField] with the given name and value in Key/Value order.
-// The struct has no other members. Empty name is valid for unnamed STRUCT fields.
-func StructFieldKVOf(name string, value spanner.GenericColumnValue) StructField {
+// StructFieldOf returns a [StructField] with the given name and value.
+// Empty name is valid for unnamed STRUCT fields.
+func StructFieldOf(name string, value spanner.GenericColumnValue) StructField {
 	return StructField{Name: name, Value: value}
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.
-// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// Prefer [StructFieldOf] at call sites; positional composite literals
 // (StructField{name, value}) are also valid.
 // Empty field names are valid for unnamed STRUCT fields.
 func StructValueOfFields(fields ...StructField) (spanner.GenericColumnValue, error) {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -394,26 +394,26 @@ func ArrayValueOf(elemType *sppb.Type, elems ...spanner.GenericColumnValue) (spa
 	}, nil
 }
 
-// StructField pairs one STRUCT field name with its GCV.
+// StructFieldKV pairs one STRUCT field name with its GCV.
 // An empty Name is valid for unnamed STRUCT fields; see [StructValueOfFields].
-// Prefer [StructFieldOf] at call sites; positional composite literals
-// (StructField{name, value}) are also valid when field names or values need extra clarity.
-type StructField struct {
+// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// (StructFieldKV{name, value}) are also valid when field names or values need extra clarity.
+type StructFieldKV struct {
 	Name  string
 	Value spanner.GenericColumnValue
 }
 
-// StructFieldOf returns a [StructField] with the given name and value.
+// StructFieldKVOf returns a [StructFieldKV] with the given name and value.
 // Empty name is valid for unnamed STRUCT fields.
-func StructFieldOf(name string, value spanner.GenericColumnValue) StructField {
-	return StructField{Name: name, Value: value}
+func StructFieldKVOf(name string, value spanner.GenericColumnValue) StructFieldKV {
+	return StructFieldKV{Name: name, Value: value}
 }
 
 // StructValueOfFields is like [StructValueOf] but takes paired fields.
-// Prefer [StructFieldOf] at call sites; positional composite literals
-// (StructField{name, value}) are also valid.
+// Prefer [StructFieldKVOf] at call sites; positional composite literals
+// (StructFieldKV{name, value}) are also valid.
 // Empty field names are valid for unnamed STRUCT fields.
-func StructValueOfFields(fields ...StructField) (spanner.GenericColumnValue, error) {
+func StructValueOfFields(fields ...StructFieldKV) (spanner.GenericColumnValue, error) {
 	names := make([]string, len(fields))
 	gcvs := make([]spanner.GenericColumnValue, len(fields))
 	for i, f := range fields {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -975,7 +975,7 @@ func TestStructValueOfFields(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		fields    []gcvctor.StructField
+		fields    []gcvctor.StructFieldKV
 		want      spanner.GenericColumnValue
 		expectErr bool
 		errIs     error
@@ -983,9 +983,9 @@ func TestStructValueOfFields(t *testing.T) {
 	}{
 		{
 			desc: "named fields",
-			fields: []gcvctor.StructField{
-				gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
-				gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
+			fields: []gcvctor.StructFieldKV{
+				gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+				gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1002,9 +1002,9 @@ func TestStructValueOfFields(t *testing.T) {
 		},
 		{
 			desc: "unnamed fields",
-			fields: []gcvctor.StructField{
-				gcvctor.StructFieldOf("", gcvctor.StringValue("value")),
-				gcvctor.StructFieldOf("", gcvctor.Int64Value(42)),
+			fields: []gcvctor.StructFieldKV{
+				gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
+				gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1021,8 +1021,8 @@ func TestStructValueOfFields(t *testing.T) {
 		},
 		{
 			desc: "nil field type named",
-			fields: []gcvctor.StructField{
-				gcvctor.StructFieldOf("broken", spanner.GenericColumnValue{}),
+			fields: []gcvctor.StructFieldKV{
+				gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1030,8 +1030,8 @@ func TestStructValueOfFields(t *testing.T) {
 		},
 		{
 			desc: "nil field type unnamed",
-			fields: []gcvctor.StructField{
-				gcvctor.StructFieldOf("", spanner.GenericColumnValue{}),
+			fields: []gcvctor.StructFieldKV{
+				gcvctor.StructFieldKVOf("", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1075,9 +1075,9 @@ func TestStructValueOfFields_matchesStructValueOf(t *testing.T) {
 
 	names := []string{"id", "name"}
 	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
-	fields := []gcvctor.StructField{
-		gcvctor.StructFieldOf("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldOf("name", gcvctor.StringValue("foo")),
+	fields := []gcvctor.StructFieldKV{
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
 	}
 
 	want, err := gcvctor.StructValueOf(names, gcvs)

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -984,8 +984,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "named fields",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-				gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+				gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
+				gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1003,8 +1003,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "unnamed fields",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
-				gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
+				gcvctor.StructFieldOf("", gcvctor.StringValue("value")),
+				gcvctor.StructFieldOf("", gcvctor.Int64Value(42)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1022,7 +1022,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type named",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}),
+				gcvctor.StructFieldOf("broken", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1031,7 +1031,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type unnamed",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKVOf("", spanner.GenericColumnValue{}),
+				gcvctor.StructFieldOf("", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1076,8 +1076,8 @@ func TestStructValueOfFields_matchesStructValueOf(t *testing.T) {
 	names := []string{"id", "name"}
 	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
 	fields := []gcvctor.StructField{
-		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
+		gcvctor.StructFieldOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldOf("name", gcvctor.StringValue("foo")),
 	}
 
 	want, err := gcvctor.StructValueOf(names, gcvs)

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -984,8 +984,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "named fields",
 			fields: []gcvctor.StructField{
-				{Name: "Code", Value: gcvctor.StringValue("10")},
-				{Name: "DisplayOrder", Value: gcvctor.Int64Value(1)},
+				gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
+				gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1003,8 +1003,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "unnamed fields",
 			fields: []gcvctor.StructField{
-				{Name: "", Value: gcvctor.StringValue("value")},
-				{Name: "", Value: gcvctor.Int64Value(42)},
+				gcvctor.StructFieldKV("", gcvctor.StringValue("value")),
+				gcvctor.StructFieldKV("", gcvctor.Int64Value(42)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1022,7 +1022,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type named",
 			fields: []gcvctor.StructField{
-				{Name: "broken", Value: spanner.GenericColumnValue{}},
+				gcvctor.StructFieldKV("broken", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1031,7 +1031,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type unnamed",
 			fields: []gcvctor.StructField{
-				{Name: "", Value: spanner.GenericColumnValue{}},
+				gcvctor.StructFieldKV("", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1076,8 +1076,8 @@ func TestStructValueOfFields_matchesStructValueOf(t *testing.T) {
 	names := []string{"id", "name"}
 	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
 	fields := []gcvctor.StructField{
-		{Name: "id", Value: gcvctor.Int64Value(1)},
-		{Name: "name", Value: gcvctor.StringValue("foo")},
+		gcvctor.StructFieldKV("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKV("name", gcvctor.StringValue("foo")),
 	}
 
 	want, err := gcvctor.StructValueOf(names, gcvs)

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -984,8 +984,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "named fields",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
-				gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
+				gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+				gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1003,8 +1003,8 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "unnamed fields",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKV("", gcvctor.StringValue("value")),
-				gcvctor.StructFieldKV("", gcvctor.Int64Value(42)),
+				gcvctor.StructFieldKVOf("", gcvctor.StringValue("value")),
+				gcvctor.StructFieldKVOf("", gcvctor.Int64Value(42)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
@@ -1022,7 +1022,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type named",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKV("broken", spanner.GenericColumnValue{}),
+				gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1031,7 +1031,7 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "nil field type unnamed",
 			fields: []gcvctor.StructField{
-				gcvctor.StructFieldKV("", spanner.GenericColumnValue{}),
+				gcvctor.StructFieldKVOf("", spanner.GenericColumnValue{}),
 			},
 			expectErr: true,
 			errIs:     gcvctor.ErrNilFieldType,
@@ -1076,8 +1076,8 @@ func TestStructValueOfFields_matchesStructValueOf(t *testing.T) {
 	names := []string{"id", "name"}
 	gcvs := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo")}
 	fields := []gcvctor.StructField{
-		gcvctor.StructFieldKV("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldKV("name", gcvctor.StringValue("foo")),
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
 	}
 
 	want, err := gcvctor.StructValueOf(names, gcvs)

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -26,9 +26,9 @@ func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanne
 }
 
 // MustStructValueOfFields is like [StructValueOfFields] but panics on error.
-// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldOf].
+// It accepts the same [StructFieldKV] pairs as [StructValueOfFields], including from [StructFieldKVOf].
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
-func MustStructValueOfFields(fields ...StructField) spanner.GenericColumnValue {
+func MustStructValueOfFields(fields ...StructFieldKV) spanner.GenericColumnValue {
 	gcv, err := StructValueOfFields(fields...)
 	if err != nil {
 		panic(err)

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -26,7 +26,7 @@ func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanne
 }
 
 // MustStructValueOfFields is like [StructValueOfFields] but panics on error.
-// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldKV].
+// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldKVOf].
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
 func MustStructValueOfFields(fields ...StructField) spanner.GenericColumnValue {
 	gcv, err := StructValueOfFields(fields...)

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -26,7 +26,7 @@ func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanne
 }
 
 // MustStructValueOfFields is like [StructValueOfFields] but panics on error.
-// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldKVOf].
+// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldOf].
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
 func MustStructValueOfFields(fields ...StructField) spanner.GenericColumnValue {
 	gcv, err := StructValueOfFields(fields...)

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -26,6 +26,7 @@ func MustStructValueOf(names []string, gcvs []spanner.GenericColumnValue) spanne
 }
 
 // MustStructValueOfFields is like [StructValueOfFields] but panics on error.
+// It accepts the same [StructField] pairs as [StructValueOfFields], including from [StructFieldKV].
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
 func MustStructValueOfFields(fields ...StructField) spanner.GenericColumnValue {
 	gcv, err := StructValueOfFields(fields...)

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -29,8 +29,8 @@ func TestMustStructValueOfFields_matchesStructValueOfFields(t *testing.T) {
 	t.Parallel()
 
 	fields := []gcvctor.StructField{
-		{Name: "id", Value: gcvctor.Int64Value(1)},
-		{Name: "name", Value: gcvctor.StringValue("foo")},
+		gcvctor.StructFieldKV("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKV("name", gcvctor.StringValue("foo")),
 	}
 	want, err := gcvctor.StructValueOfFields(fields...)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestMustStructValueOfFields_panicsOnNilFieldType(t *testing.T) {
 	t.Parallel()
 
 	expectPanic(t, func() {
-		gcvctor.MustStructValueOfFields(gcvctor.StructField{Name: "broken", Value: spanner.GenericColumnValue{}})
+		gcvctor.MustStructValueOfFields(gcvctor.StructFieldKV("broken", spanner.GenericColumnValue{}))
 	})
 }
 
@@ -63,8 +63,8 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOfFields(
-			gcvctor.StructField{Name: "Code", Value: gcvctor.StringValue("10")},
-			gcvctor.StructField{Name: "DisplayOrder", Value: gcvctor.Int64Value(1)},
+			gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
+			gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
 		),
 		gcvctor.NullOf(structType),
 	)

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -29,8 +29,8 @@ func TestMustStructValueOfFields_matchesStructValueOfFields(t *testing.T) {
 	t.Parallel()
 
 	fields := []gcvctor.StructField{
-		gcvctor.StructFieldKV("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldKV("name", gcvctor.StringValue("foo")),
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
 	}
 	want, err := gcvctor.StructValueOfFields(fields...)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestMustStructValueOfFields_panicsOnNilFieldType(t *testing.T) {
 	t.Parallel()
 
 	expectPanic(t, func() {
-		gcvctor.MustStructValueOfFields(gcvctor.StructFieldKV("broken", spanner.GenericColumnValue{}))
+		gcvctor.MustStructValueOfFields(gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}))
 	})
 }
 
@@ -63,8 +63,8 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOfFields(
-			gcvctor.StructFieldKV("Code", gcvctor.StringValue("10")),
-			gcvctor.StructFieldKV("DisplayOrder", gcvctor.Int64Value(1)),
+			gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+			gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 		),
 		gcvctor.NullOf(structType),
 	)

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -28,9 +28,9 @@ func expectPanic(t *testing.T, fn func()) {
 func TestMustStructValueOfFields_matchesStructValueOfFields(t *testing.T) {
 	t.Parallel()
 
-	fields := []gcvctor.StructField{
-		gcvctor.StructFieldOf("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldOf("name", gcvctor.StringValue("foo")),
+	fields := []gcvctor.StructFieldKV{
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
 	}
 	want, err := gcvctor.StructValueOfFields(fields...)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestMustStructValueOfFields_panicsOnNilFieldType(t *testing.T) {
 	t.Parallel()
 
 	expectPanic(t, func() {
-		gcvctor.MustStructValueOfFields(gcvctor.StructFieldOf("broken", spanner.GenericColumnValue{}))
+		gcvctor.MustStructValueOfFields(gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}))
 	})
 }
 
@@ -63,8 +63,8 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOfFields(
-			gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
-			gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
+			gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
+			gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
 		),
 		gcvctor.NullOf(structType),
 	)

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -29,8 +29,8 @@ func TestMustStructValueOfFields_matchesStructValueOfFields(t *testing.T) {
 	t.Parallel()
 
 	fields := []gcvctor.StructField{
-		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
-		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("foo")),
+		gcvctor.StructFieldOf("id", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldOf("name", gcvctor.StringValue("foo")),
 	}
 	want, err := gcvctor.StructValueOfFields(fields...)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestMustStructValueOfFields_panicsOnNilFieldType(t *testing.T) {
 	t.Parallel()
 
 	expectPanic(t, func() {
-		gcvctor.MustStructValueOfFields(gcvctor.StructFieldKVOf("broken", spanner.GenericColumnValue{}))
+		gcvctor.MustStructValueOfFields(gcvctor.StructFieldOf("broken", spanner.GenericColumnValue{}))
 	})
 }
 
@@ -63,8 +63,8 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOfFields(
-			gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-			gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+			gcvctor.StructFieldOf("Code", gcvctor.StringValue("10")),
+			gcvctor.StructFieldOf("DisplayOrder", gcvctor.Int64Value(1)),
 		),
 		gcvctor.NullOf(structType),
 	)


### PR DESCRIPTION
## Summary
- Rename `StructField` → `StructFieldKV` so the type and constructor share a consistent KV suffix without clashing with stable `StructFieldError` (v0.6.0+).
- Add `StructFieldKVOf(name, value) StructFieldKV` as the usual constructor for `StructValueOfFields` / `MustStructValueOfFields`.
- Document positional composite literals `StructFieldKV{name, value}` as a valid alternative.

Follow-up to #193. Option B from #192: both type and constructor use the KV suffix (`StructFieldKV` / `StructFieldKVOf`). `StructFieldError` is unchanged.

## Test plan
- [x] `make check`