### PR TITLE
gcvctor: use generic name/id pairs in struct fixture examples

### DIFF
--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -125,8 +125,8 @@ func ExampleNullOf_structContainer() {
 
 func ExampleStructValueOfFields() {
 	row, err := gcvctor.StructValueOfFields(
-		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("alice")),
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
 	)
 	if err != nil {
 		panic(err)
@@ -142,19 +142,19 @@ func ExampleStructValueOfFields() {
 	fmt.Println(row.Type.StructType.Fields[0].Name, row.Value.GetListValue().Values[0].GetStringValue())
 	fmt.Println(len(unnamed.Type.StructType.Fields), unnamed.Type.StructType.Fields[0].Name == "")
 	// Output:
-	// Code 10
+	// name alice
 	// 2 true
 }
 
 func ExampleMustStructValueOfFields() {
 	row := gcvctor.MustStructValueOfFields(
-		gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-		gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+		gcvctor.StructFieldKVOf("name", gcvctor.StringValue("alice")),
+		gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
 	)
 
 	fmt.Println(row.Type.StructType.Fields[1].Name, row.Value.GetListValue().Values[1].GetStringValue())
 	// Output:
-	// DisplayOrder 1
+	// id 1
 }
 
 func ExampleInt64FromPtr_fromNullable() {

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -984,17 +984,17 @@ func TestStructValueOfFields(t *testing.T) {
 		{
 			desc: "named fields",
 			fields: []gcvctor.StructFieldKV{
-				gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-				gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+				gcvctor.StructFieldKVOf("name", gcvctor.StringValue("alice")),
+				gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
 			},
 			want: spanner.GenericColumnValue{
 				Type: must(typector.NameCodeSlicesToStructType(
-					[]string{"Code", "DisplayOrder"},
+					[]string{"name", "id"},
 					[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
 				)),
 				Value: structpb.NewListValue(&structpb.ListValue{
 					Values: []*structpb.Value{
-						structpb.NewStringValue("10"),
+						structpb.NewStringValue("alice"),
 						structpb.NewStringValue("1"),
 					},
 				}),

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -54,7 +54,7 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 	t.Parallel()
 
 	structType, err := typector.NameCodeSlicesToStructType(
-		[]string{"Code", "DisplayOrder"},
+		[]string{"name", "id"},
 		[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
 	)
 	if err != nil {
@@ -63,8 +63,8 @@ func TestMustStructValueOfFields_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOfFields(
-			gcvctor.StructFieldKVOf("Code", gcvctor.StringValue("10")),
-			gcvctor.StructFieldKVOf("DisplayOrder", gcvctor.Int64Value(1)),
+			gcvctor.StructFieldKVOf("name", gcvctor.StringValue("alice")),
+			gcvctor.StructFieldKVOf("id", gcvctor.Int64Value(1)),
 		),
 		gcvctor.NullOf(structType),
 	)
@@ -156,7 +156,7 @@ func TestMustArrayValueOf_nestedStruct(t *testing.T) {
 	t.Parallel()
 
 	structType, err := typector.NameCodeSlicesToStructType(
-		[]string{"Code", "DisplayOrder"},
+		[]string{"name", "id"},
 		[]sppb.TypeCode{sppb.TypeCode_STRING, sppb.TypeCode_INT64},
 	)
 	if err != nil {
@@ -165,8 +165,8 @@ func TestMustArrayValueOf_nestedStruct(t *testing.T) {
 
 	arrayParam := gcvctor.MustArrayValueOf(structType,
 		gcvctor.MustStructValueOf(
-			[]string{"Code", "DisplayOrder"},
-			[]spanner.GenericColumnValue{gcvctor.StringValue("10"), gcvctor.Int64Value(1)},
+			[]string{"name", "id"},
+			[]spanner.GenericColumnValue{gcvctor.StringValue("alice"), gcvctor.Int64Value(1)},
 		),
 		gcvctor.NullOf(structType),
 	)


### PR DESCRIPTION
## Summary

- Use generic `name` / `id` field pairs in `gcvctor` examples and tests instead of domain-specific fixture names.
- Issue bodies updated on #161 and #179 to match.

## Test plan

- [x] `make check`