### PR TITLE
gcvctor: UTC timestamps and unescaped JSON wire; gospanner go.mod v0.7.0

### DIFF
--- a/dbsqlrows/gospanner/go.mod
+++ b/dbsqlrows/gospanner/go.mod
@@ -4,8 +4,8 @@ module github.com/apstndb/spanvalue/dbsqlrows/gospanner
 go 1.25.0
 
 require (
-	// Downstream go get needs spanvalue v0.6.0+ (first release with dbsqlrows).
-	github.com/apstndb/spanvalue v0.6.0
+	// Downstream go get needs spanvalue v0.7.0+ (first stable release with dbsqlrows).
+	github.com/apstndb/spanvalue v0.7.0
 	github.com/googleapis/go-sql-spanner v1.25.1
 )
 
@@ -21,7 +21,6 @@ require (
 	cloud.google.com/go/spanner v1.91.0 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
-	github.com/apstndb/spantype v0.3.11 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
@@ -36,7 +35,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/samber/lo v1.53.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -63,5 +61,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-// Dev-only: ignored by downstream consumers. Remove or bump after v0.6.0 is tagged.
+// Dev-only: ignored by downstream consumers. Remove when tagging this nested module.
 replace github.com/apstndb/spanvalue => ../..

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -1,6 +1,7 @@
 package gcvctor
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -199,7 +200,7 @@ func DateStringValue(v string) (spanner.GenericColumnValue, error) {
 
 // TimestampValue returns a non-null TIMESTAMP GenericColumnValue (RFC3339Nano string wire format).
 func TimestampValue(v time.Time) spanner.GenericColumnValue {
-	return StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, v.Format(time.RFC3339Nano))
+	return StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, v.UTC().Format(time.RFC3339Nano))
 }
 
 // TimestampStringValue validates an RFC3339Nano timestamp string and returns a non-null
@@ -254,11 +255,11 @@ func UUIDValue(v uuid.UUID) spanner.GenericColumnValue {
 
 // JSONValue marshals v to JSON and returns a non-null JSON GenericColumnValue.
 func JSONValue(v any) (spanner.GenericColumnValue, error) {
-	b, err := json.Marshal(v)
+	s, err := jsonWireString(v)
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
-	return StringBasedValueFromCode(sppb.TypeCode_JSON, string(b)), nil
+	return StringBasedValueFromCode(sppb.TypeCode_JSON, s), nil
 }
 
 // PGNumericValue returns a PostgreSQL-dialect NUMERIC GenericColumnValue
@@ -289,14 +290,30 @@ func PGNumericValueChecked(v *big.Rat) (spanner.GenericColumnValue, error) {
 // PGJSONBValue marshals v to JSON and returns a non-null PostgreSQL-dialect JSON GenericColumnValue
 // ([sppb.TypeAnnotationCode_PG_JSONB]).
 func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
-	b, err := json.Marshal(v)
+	s, err := jsonWireString(v)
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
 	return spanner.GenericColumnValue{
 		Type:  typector.PGJSONB(),
-		Value: structpb.NewStringValue(string(b)),
+		Value: structpb.NewStringValue(s),
 	}, nil
+}
+
+// jsonWireString marshals v to compact JSON without HTML character escaping,
+// matching Spanner-emitted JSON wire strings for comparison fixtures.
+func jsonWireString(v any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	b := buf.Bytes()
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	return string(b), nil
 }
 
 // ProtoValue returns a non-null PROTO GenericColumnValue for the fully qualified message name fqn.

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -1126,3 +1126,57 @@ func TestStructValueOfNilFieldTypeReturnsStructFieldError(t *testing.T) {
 		})
 	}
 }
+
+func TestTimestampValue_normalizesNonUTCToZuluWire(t *testing.T) {
+	t.Parallel()
+
+	jst := time.FixedZone("JST", 9*60*60)
+	ts := time.Date(2024, 1, 15, 21, 34, 56, 789000000, jst)
+	got := gcvctor.TimestampValue(ts)
+	want := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_TIMESTAMP),
+		Value: structpb.NewStringValue("2024-01-15T12:34:56.789Z"),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestJSONValue_doesNotHTMLEscapeWireString(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]string{"a": "<b>&c"}
+	for _, ctor := range []struct {
+		name string
+		fn   func(any) (spanner.GenericColumnValue, error)
+		typ  *sppb.Type
+	}{
+		{
+			name: "JSON",
+			fn:   gcvctor.JSONValue,
+			typ:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+		},
+		{
+			name: "PG_JSONB",
+			fn:   gcvctor.PGJSONBValue,
+			typ:  typector.PGJSONB(),
+		},
+	} {
+		t.Run(ctor.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ctor.fn(payload)
+			if err != nil {
+				t.Fatalf("constructor error: %v", err)
+			}
+			wantWire := `{"a":"<b>&c"}`
+			want := spanner.GenericColumnValue{
+				Type:  ctor.typ,
+				Value: structpb.NewStringValue(wantWire),
+			}
+			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize `TimestampValue` to UTC Zulu wire strings (matches Spanner client and `TimestampStringValue`).
- Marshal `JSONValue` / `PGJSONBValue` with `SetEscapeHTML(false)` so fixture GCVs match Spanner-emitted JSON wire.
- Bump `dbsqlrows/gospanner` require to `spanvalue v0.7.0` (first stable release containing `dbsqlrows`).

## Test plan
- [x] `make check` (vet, build, test, golangci-lint)
- [x] `TestTimestampValue_normalizesNonUTCToZuluWire`
- [x] `TestJSONValue_doesNotHTMLEscapeWireString`

Closes #202, #208, #201


Made with [Cursor](https://cursor.com)