### PR TITLE
writer: reject SQL INSERT writes for zero-column registered schema

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1189,7 +1189,7 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if w.table == "" {
 		return ErrEmptyTableName
 	}
-	if w.schema.registered && len(w.schema.names) == 0 {
+	if len(w.schema.names) == 0 {
 		return ErrMissingColumnNames
 	}
 	formattedValues, err := spanvalue.FormatRowColumns(w.insertFormatter(), w.schema.names, values)

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1189,6 +1189,9 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	if w.table == "" {
 		return ErrEmptyTableName
 	}
+	if w.schema.registered && len(w.schema.names) == 0 {
+		return ErrMissingColumnNames
+	}
 	formattedValues, err := spanvalue.FormatRowColumns(w.insertFormatter(), w.schema.names, values)
 	if err != nil {
 		return err

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1641,6 +1641,22 @@ func TestSQLInsertWriterPrepareEmptyRowTypeFlushNoOp(t *testing.T) {
 	}
 }
 
+func TestSQLInsertWriterWriteValuesZeroColumnSchema(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewSQLInsertWriter(t, &out, "users")
+	if err := w.PrepareRowType(emptyRowType()); err != nil {
+		t.Fatalf("PrepareRowType() error = %v", err)
+	}
+	if err := w.WriteValues(nil, nil); !errors.Is(err, ErrMissingColumnNames) {
+		t.Fatalf("WriteValues(nil, nil) error = %v, want ErrMissingColumnNames", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+}
+
 func TestWriterRejectsNonEmptyColumnNamesAfterRegisteredZeroColumnSchema(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Guard `SQLInsertWriter.writeGCVs` so `WriteValues` / `WriteRow` return `ErrMissingColumnNames` for a registered empty row type, matching `WriteGCVs`.
- Prevents invalid `INSERT INTO t () VALUES ();` output.

## Test plan
- [x] `make check`
- [x] `TestSQLInsertWriterWriteValuesZeroColumnSchema`

Closes #203


Made with [Cursor](https://cursor.com)