### PR TITLE
docs: godoc accuracy sweep (writer, gcvctor, dbsqlrows)

### DIFF
--- a/dbsqlrows/export.go
+++ b/dbsqlrows/export.go
@@ -9,11 +9,15 @@ import (
 )
 
 var (
-	// ErrNilRows reports that WriteRows was called with a nil *sql.Rows.
+	// ErrNilRows reports that a dbsqlrows entry point was called with a nil *sql.Rows
+	// (for example [WriteRows], [RunRows], [RunRowsAtData], [WriteRowsAtData], or
+	// [ReadMetadataAndAdvanceToData]).
 	ErrNilRows = errors.New("nil sql.Rows")
-	// ErrNilWriter reports that WriteRows was called with a nil GCVStreamWriter.
+	// ErrNilWriter reports that an export entry point was called with a nil [GCVStreamWriter]
+	// (for example [WriteRows] or [WriteRowsAtData]).
 	ErrNilWriter = errors.New("nil GCV stream writer")
-	// ErrNilMetadata reports that WriteRowsAtData was called with nil metadata.
+	// ErrNilMetadata reports that a data-phase entry point was called with nil metadata
+	// (for example [WriteRowsAtData] or [RunRowsAtData]).
 	ErrNilMetadata = errors.New("nil result set metadata")
 	// ErrMissingMetadataRow reports that the iterator produced no metadata
 	// pseudo-row when WriteRows expected one.

--- a/dbsqlrows/hooks.go
+++ b/dbsqlrows/hooks.go
@@ -56,7 +56,8 @@ func (h SQLRowsHooks) WithFinish(fn func(*SQLRowsResult) error) SQLRowsHooks {
 // SQLRowsHooksFromGCVWriter returns hooks that register metadata via
 // [GCVStreamWriter] PrepareRowType or Prepare when implemented, write each row
 // with [GCVStreamWriter.WriteGCVs], and call [GCVStreamWriter.Flush] in Finish.
-// Flush is not called when PrepareMetadata or WriteDataRow returns an error.
+// Finish (and thus Flush) runs only after all rows and optional stats consumption succeed;
+// it is skipped when PrepareMetadata, WriteDataRow, or the stats phase returns an error.
 // A nil writer returns empty hooks.
 func SQLRowsHooksFromGCVWriter(w GCVStreamWriter) SQLRowsHooks {
 	if w == nil {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -23,11 +23,13 @@ import (
 )
 
 var (
-	// ErrTypeMismatch is returned by [ArrayValueOf] when an element's type does not match elemType.
+	// ErrTypeMismatch is returned by [ArrayValueOf], [ArrayValue], and [NormalizeArrayElements]
+	// when an element's type does not match the expected element type.
 	ErrTypeMismatch = errors.New("gcvctor: type mismatch")
 	// ErrMismatchedCounts is returned by [StructValueOf] when len(names) != len(gcvs).
 	ErrMismatchedCounts = errors.New("gcvctor: mismatched name/value count")
-	// ErrNilElementType is returned by [ArrayValueOf] when elemType is nil.
+	// ErrNilElementType is returned by [ArrayValueOf], [ArrayValue], and [NormalizeArrayElements]
+	// when elemType is nil.
 	ErrNilElementType = errors.New("gcvctor: nil array element type")
 	// ErrNilFieldType is returned by [StructValueOf] when a field's Type is nil.
 	ErrNilFieldType = errors.New("gcvctor: nil struct field type")
@@ -301,14 +303,14 @@ func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
 
 // ProtoValue returns a non-null PROTO GenericColumnValue for the fully qualified message name fqn.
 // The message bytes are stored in the GCV as a base64-encoded string. Delimited export decodes that
-// wire payload for SimpleFormatConfig when possible (see writer.TestDelimitedWriterWriteGCVsEnumProto).
+// wire payload for SimpleFormatConfig when possible.
 func ProtoValue(fqn string, b []byte) spanner.GenericColumnValue {
 	return BytesBasedValueOf(typector.FQNToProtoType(fqn), b)
 }
 
 // EnumValue returns a non-null ENUM GenericColumnValue for the fully qualified enum name fqn.
 // The structpb value is the enum number as a decimal string; delimited export prints that
-// string (see writer.TestDelimitedWriterWriteGCVsEnumProto).
+// decimal string on the wire.
 func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.FQNToEnumType(fqn),

--- a/writer/README.md
+++ b/writer/README.md
@@ -129,7 +129,7 @@ When the app consumes `Next` but skips row bodies, register `PrepareRowType(iter
 | Zero columns (DML without `THEN RETURN`) | `PrepareRowType(nil)` or empty row type—not `PrepareColumnNames([])` |
 | Zero-row `SELECT` | `PrepareRowType` after first `Next`, then `Flush` for header-only CSV |
 
-Without registration and with no row written, `Flush` / `WriteHeader` return `ErrMissingColumnNames`. Registered empty schema (`len(names)==0`) is valid: `Flush` writes nothing.
+Without registration and with no row written, `WriteHeader` returns `ErrMissingColumnNames`; `Flush` returns that error only when `Header` is true (see `DelimitedWriter.Flush` godoc). Registered empty schema (`len(names)==0`) is valid: `Flush` writes nothing.
 
 ## go-sql-spanner and GCV slices
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -37,8 +37,8 @@ var (
 	// ErrMissingColumnNames reports that an operation requires a registered column schema
 	// when none was registered yet, or column names/types are insufficient for the write
 	// (for example values without names). It is not returned for a registered zero-column
-	// schema (see package doc "Registered schema vs missing schema"). [DelimitedWriter.PrepareColumnNames]
-	// and [WithColumnNames] with an empty name list return this error; use [DelimitedWriter.PrepareRowType]
+	// schema (see package doc "Registered schema vs missing schema"). [*DelimitedWriter.PrepareColumnNames]
+	// and [WithColumnNames] with an empty name list return this error; use [*DelimitedWriter.PrepareRowType]
 	// or [WithRowType] for zero-column result sets.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
@@ -972,9 +972,9 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 }
 
 // SQLInsertWriter streams INSERT (or INSERT OR …) statements with dialect-aware identifier
-// quoting for a fixed table. After any error from [SQLInsertWriter.WriteRow],
-// [SQLInsertWriter.WriteGCVs], [SQLInsertWriter.WriteValues], or
-// [SQLInsertWriter.WriteStructValues], discard the writer; partial batched INSERT output
+// quoting for a fixed table. After any error from [*SQLInsertWriter.WriteRow],
+// [*SQLInsertWriter.WriteGCVs], [*SQLInsertWriter.WriteValues], or
+// [*SQLInsertWriter.WriteStructValues], discard the writer; partial batched INSERT output
 // may be unrecoverable on retry.
 type SQLInsertWriter struct {
 	table     string
@@ -1066,8 +1066,8 @@ func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
 // When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use [RunRowIterator]
-// or [SQLInsertWriter.PrepareRowType] with iter.Metadata.GetRowType() after the first Next. Nil rowType registers an empty schema;
-// [SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
+// or [*SQLInsertWriter.PrepareRowType] with iter.Metadata.GetRowType() after the first Next. Nil rowType registers an empty schema;
+// [*SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
 }
@@ -1117,7 +1117,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [SQLInsertWriter.PrepareRowType].
+// registered by [WithRowType], [WithMetadata], or [*SQLInsertWriter.PrepareRowType].
 func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -37,8 +37,8 @@ var (
 	// ErrMissingColumnNames reports that an operation requires a registered column schema
 	// when none was registered yet, or column names/types are insufficient for the write
 	// (for example values without names). It is not returned for a registered zero-column
-	// schema (see package doc "Registered schema vs missing schema"). [PrepareColumnNames]
-	// and [WithColumnNames] with an empty name list return this error; use [PrepareRowType]
+	// schema (see package doc "Registered schema vs missing schema"). [DelimitedWriter.PrepareColumnNames]
+	// and [WithColumnNames] with an empty name list return this error; use [DelimitedWriter.PrepareRowType]
 	// or [WithRowType] for zero-column result sets.
 	ErrMissingColumnNames = errors.New("missing column names")
 	// ErrColumnNamesMismatch reports that provided column names differ from initialized schema.
@@ -118,7 +118,7 @@ type JSONLOption interface {
 //
 // [SQLInsertOrIgnore] and [SQLInsertOrUpdate] are invalid with
 // [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL); [NewSQLInsertWriter] rejects
-// that combination via [ErrInvalidSQLInsertKindForDialect] on the first write.
+// that combination at construction via [ErrInvalidSQLInsertKindForDialect].
 type SQLInsertKind int
 
 const (
@@ -167,7 +167,7 @@ type sqlDialectOption struct {
 // ([databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL]).
 //
 // PostgreSQL dialect does not support [SQLInsertOrIgnore] or [SQLInsertOrUpdate]
-// prefixes; combining them returns [ErrInvalidSQLInsertKindForDialect] on write.
+// prefixes; combining them returns [ErrInvalidSQLInsertKindForDialect] at construction.
 func WithSQLDialect(dialect databasepb.DatabaseDialect) SQLInsertOption {
 	return sqlDialectOption{dialect: dialect}
 }
@@ -753,7 +753,6 @@ func (w *DelimitedWriter) resolvedNames() ([]string, error) {
 	return resolvedNames, nil
 }
 
-// JSONLWriter writes one JSON object per line.
 // JSONLWriter streams one JSON object per line using [github.com/apstndb/spanvalue] JSON formatting.
 type JSONLWriter struct {
 	formatter *spanvalue.FormatConfig
@@ -972,12 +971,11 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 	return marshaledKeys, nil
 }
 
-// SQLInsertWriter writes rows as SQL INSERT statements with dialect-aware identifier quoting.
-//
-// After any error from [SQLInsertWriter.WriteRow], [SQLInsertWriter.WriteGCVs],
-// [SQLInsertWriter.WriteValues], or [SQLInsertWriter.WriteStructValues], discard the
-// writer; partial batched INSERT output may be unrecoverable on retry.
-// SQLInsertWriter streams INSERT (or INSERT OR …) statements for a fixed table.
+// SQLInsertWriter streams INSERT (or INSERT OR …) statements with dialect-aware identifier
+// quoting for a fixed table. After any error from [SQLInsertWriter.WriteRow],
+// [SQLInsertWriter.WriteGCVs], [SQLInsertWriter.WriteValues], or
+// [SQLInsertWriter.WriteStructValues], discard the writer; partial batched INSERT output
+// may be unrecoverable on retry.
 type SQLInsertWriter struct {
 	table     string
 	formatter *spanvalue.FormatConfig
@@ -1068,7 +1066,7 @@ func (w *SQLInsertWriter) Prepare(metadata *sppb.ResultSetMetadata) error {
 
 // PrepareRowType initializes the SQL INSERT schema from a row type before the first row is written.
 // When the row type comes from a [cloud.google.com/go/spanner.RowIterator], use [RunRowIterator]
-// or [PrepareRowType] with iter.Metadata.GetRowType() after the first Next. Nil rowType registers an empty schema;
+// or [SQLInsertWriter.PrepareRowType] with iter.Metadata.GetRowType() after the first Next. Nil rowType registers an empty schema;
 // [SQLInsertWriter.WriteGCVs] still requires at least one column to emit SQL.
 func (w *SQLInsertWriter) PrepareRowType(rowType *sppb.StructType) error {
 	return w.prepareRowType(rowType)
@@ -1119,7 +1117,7 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 }
 
 // WriteStructValues writes one row from structpb values using the field-type schema
-// registered by [WithRowType], [WithMetadata], or [PrepareRowType].
+// registered by [WithRowType], [WithMetadata], or [SQLInsertWriter.PrepareRowType].
 func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix SQL INSERT kind validation docs (constructor-time, not first write).
- Qualify broken `[PrepareRowType]` / `[PrepareColumnNames]` links; dedupe JSONL/SQLInsertWriter summaries.
- Correct writer README `Flush` / `ErrMissingColumnNames` qualifier.
- Broaden gcvctor sentinel docs and remove internal test-name references from public godoc.
- Align `SQLRowsHooksFromGCVWriter` Finish/Flush wording with `SQLRowsHooks` type doc; generalize dbsqlrows sentinel docs.

## Test plan
- [x] `make check` (docs-only; no behavior change)

Closes #212


Made with [Cursor](https://cursor.com)