### PR TITLE
gcvctor trap docs, JSONObjectStructFormat deprecation, root godoc (#222, #215, #218)

### DIFF
--- a/common.go
+++ b/common.go
@@ -48,6 +48,8 @@ const (
 	nullStringClientLib = "<null>"
 )
 
+// NullableValue is the scalar null wrapper type accepted by [FormatNullableFunc].
+// It includes [cloud.google.com/go/spanner] null types and [NullBytes] for BYTES/PROTO.
 type NullableValue interface {
 	spanner.NullableValue
 	fmt.Stringer
@@ -76,6 +78,7 @@ var _, _ NullableValue = spanner.PGJsonB{}, (*spanner.PGJsonB)(nil)
 // If it returns ErrFallthrough, value will pass through to next step.
 type FormatComplexFunc = func(formatter Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error)
 
+// ErrFallthrough tells [FormatComplexFunc] plugins to defer to the next plugin or built-in path.
 var ErrFallthrough = errors.New("fallthrough")
 
 func typeValueToGCV(typ *sppb.Type, value *structpb.Value) spanner.GenericColumnValue {
@@ -206,6 +209,7 @@ func FormatEnumAsCast(formatter Formatter, value spanner.GenericColumnValue, top
 	return fmt.Sprintf("CAST(%v AS `%v`)", s, typeFQN), nil
 }
 
+// Formatter is the minimal surface [FormatComplexFunc] plugins use to recurse into nested values.
 type Formatter interface {
 	FormatColumn(value spanner.GenericColumnValue, toplevel bool) (string, error)
 	GetNullString() string

--- a/dialect.go
+++ b/dialect.go
@@ -7,7 +7,8 @@ import (
 )
 
 // QuoteIdentifier quotes a single identifier for dialect.
-// It does not validate the identifier; for example, an empty string becomes an empty quoted identifier.
+// It does not validate the identifier; for example, an empty string becomes an empty quoted
+// identifier (“ for GoogleSQL, "" for PostgreSQL), which is invalid SQL in both dialects.
 // DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
 func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {

--- a/dialect.go
+++ b/dialect.go
@@ -8,7 +8,7 @@ import (
 
 // QuoteIdentifier quotes a single identifier for dialect.
 // It does not validate the identifier; for example, an empty string becomes an empty quoted
-// identifier (“ for GoogleSQL, "" for PostgreSQL), which is invalid SQL in both dialects.
+// identifier (two backticks for GoogleSQL, "" for PostgreSQL), which is invalid SQL in both dialects.
 // DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
 func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	switch dialect {

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -114,7 +114,9 @@ func Int64Value(v int64) spanner.GenericColumnValue {
 }
 
 // Float64Value returns a non-null FLOAT64 GenericColumnValue. NaN and ±Inf use string wire values
-// matching Spanner's encoding.
+// ("NaN", "Infinity", "-Infinity") matching what Spanner returns on the wire. The official client's
+// encodeValue sends finite and non-finite floats as protobuf NumberValue when building params;
+// Spanner accepts both forms.
 func Float64Value(v float64) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(sppb.TypeCode_FLOAT64),
@@ -123,7 +125,9 @@ func Float64Value(v float64) spanner.GenericColumnValue {
 }
 
 // Float32Value returns a non-null FLOAT32 GenericColumnValue. NaN and ±Inf use string wire values
-// matching Spanner's encoding.
+// ("NaN", "Infinity", "-Infinity") matching what Spanner returns on the wire. The official client's
+// encodeValue sends finite and non-finite floats as protobuf NumberValue when building params;
+// Spanner accepts both forms.
 func Float32Value(v float32) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(sppb.TypeCode_FLOAT32),

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -156,6 +156,8 @@ func StringValue(v string) spanner.GenericColumnValue {
 }
 
 // BytesValue returns a non-null BYTES GenericColumnValue (base64 wire encoding).
+// A nil slice is non-null empty BYTES (wire base64 ""), not typed SQL NULL; for typed NULL
+// use [BytesFromSlice] with nil.
 func BytesValue(v []byte) spanner.GenericColumnValue {
 	return BytesBasedValueOf(typector.CodeToSimpleType(sppb.TypeCode_BYTES), v)
 }
@@ -178,6 +180,9 @@ func BytesBasedValueOf(typ *sppb.Type, v []byte) spanner.GenericColumnValue {
 // wire string as-is and do not re-normalize. Prefer [NumericValue], [PGNumericValue], or values
 // from the Spanner client (including the emulator and Spanner Omni) over passing arbitrary
 // decimals here.
+//
+// Accepts simple scalar type codes only. ARRAY and STRUCT codes produce a malformed Type
+// (missing array_element_type or struct_type); use typector for composite shapes.
 func StringBasedValueFromCode(code sppb.TypeCode, v string) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  typector.CodeToSimpleType(code),
@@ -344,6 +349,9 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 // [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or [github.com/apstndb/spantype/typector.ElemTypeToArrayType]).
 //
 // For other element types or explicit typing policy, use [ArrayValueOf] or [EmptyArrayOf].
+// At a spread call site (ArrayValue(elems...) where elems is a slice), a nil or empty slice
+// still yields ARRAY<INT64>, not an element type inferred from the slice variable. Prefer
+// [ArrayValueOf] or [EmptyArrayOf] when the slice may be empty.
 //
 // Note: Currently, it doesn't support implicit type conversion a.k.a. coercion so variant typed input is not supported.
 // If the inferred element type from vs[0] is invalid, the error is wrapped in [ArrayElementError]
@@ -487,6 +495,8 @@ func NullFromCode(code sppb.TypeCode) spanner.GenericColumnValue {
 // It does not represent a non-null STRUCT whose fields are all null—use [StructValueOf] with
 // per-field nulls (using [NullOf] or [NullFromCode] for each field) when you need that shape.
 // A nil typ is normalized to TYPE_CODE_UNSPECIFIED to avoid a malformed nil Type pointer.
+// Spanner rejects TYPE_CODE_UNSPECIFIED at the server, so a nil-Type bug surfaces there
+// rather than at construction time.
 func NullOf(typ *sppb.Type) spanner.GenericColumnValue {
 	return spanner.GenericColumnValue{
 		Type:  normalizeNilType(typ),

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -357,7 +357,7 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 // [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or [github.com/apstndb/spantype/typector.ElemTypeToArrayType]).
 //
 // For other element types or explicit typing policy, use [ArrayValueOf] or [EmptyArrayOf].
-// At a spread call site (ArrayValue(elems...) where elems is a slice), a nil or empty slice
+// At a spread call site ([ArrayValue](elems...) where elems is a slice), a nil or empty slice
 // still yields ARRAY<INT64>, not an element type inferred from the slice variable. Prefer
 // [ArrayValueOf] or [EmptyArrayOf] when the slice may be empty.
 //

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -357,7 +357,7 @@ func EnumValue(fqn string, v int64) spanner.GenericColumnValue {
 // [github.com/apstndb/spantype/typector.ElemCodeToArrayType] (or [github.com/apstndb/spantype/typector.ElemTypeToArrayType]).
 //
 // For other element types or explicit typing policy, use [ArrayValueOf] or [EmptyArrayOf].
-// At a spread call site ([ArrayValue](elems...) where elems is a slice), a nil or empty slice
+// At a spread call site ([ArrayValue] (elems...) where elems is a slice), a nil or empty slice
 // still yields ARRAY<INT64>, not an element type inferred from the slice variable. Prefer
 // [ArrayValueOf] or [EmptyArrayOf] when the slice may be empty.
 //

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -50,6 +50,7 @@ func StringFromPtr(p *string) spanner.GenericColumnValue {
 }
 
 // BytesFromSlice returns a BYTES GenericColumnValue. A nil slice yields typed SQL NULL.
+// For non-null empty BYTES (wire base64 ""), use [BytesValue] even with a nil slice.
 func BytesFromSlice(v []byte) spanner.GenericColumnValue {
 	if v == nil {
 		return NullFromCode(sppb.TypeCode_BYTES)

--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ import (
 //
 // INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
 // float64-based consumers (JavaScript, encoding/json into any). For lossless export,
-// customize FormatComplexPlugins to quote INT64/ENUM wire strings.
+// customize [FormatConfig.FormatComplexPlugins] to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]

--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ import (
 //
 // INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
 // float64-based consumers (JavaScript, encoding/json into any). For lossless export,
-// customize the [FormatConfig.FormatComplexPlugins] field to quote INT64/ENUM wire strings.
+// customize the [FormatConfig] FormatComplexPlugins field to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]

--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ import (
 //
 // INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
 // float64-based consumers (JavaScript, encoding/json into any). For lossless export,
-// customize [FormatConfig]'s FormatComplexPlugins to quote INT64/ENUM wire strings.
+// customize the FormatComplexPlugins field to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]

--- a/json.go
+++ b/json.go
@@ -23,6 +23,10 @@ import (
 //   - INT64 → 42 (unquoted number)
 //   - FLOAT32/FLOAT64 → 3.14 (NaN/Inf as quoted strings)
 //   - ENUM → 42 (unquoted number, Spanner stores proto enum values as INT64)
+//
+// INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
+// float64-based consumers (JavaScript, encoding/json into any). For lossless export,
+// customize FormatComplexPlugins to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]
@@ -98,6 +102,8 @@ func IndexedUnnamedFieldNamer(index int) string {
 // JSONObjectStructFormat returns a FormatStructParenFunc that formats struct fields
 // as a JSON object. When namer is nil, unnamed struct fields produce empty-string keys,
 // matching Spanner's own representation.
+//
+// Deprecated: use [NewJSONObjectStructFormatter] instead.
 func JSONObjectStructFormat(namer UnnamedFieldNamer) FormatStructParenFunc {
 	return NewJSONObjectStructFormatter(namer)
 }

--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ import (
 //
 // INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
 // float64-based consumers (JavaScript, encoding/json into any). For lossless export,
-// customize [FormatConfig.FormatComplexPlugins] to quote INT64/ENUM wire strings.
+// customize [FormatConfig]'s FormatComplexPlugins to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]

--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ import (
 //
 // INT64 and ENUM emit unquoted JSON numbers. Values beyond 2^53 lose precision in
 // float64-based consumers (JavaScript, encoding/json into any). For lossless export,
-// customize the FormatComplexPlugins field to quote INT64/ENUM wire strings.
+// customize the [FormatConfig.FormatComplexPlugins] field to quote INT64/ENUM wire strings.
 //   - STRING, BYTES, TIMESTAMP, DATE, NUMERIC, PROTO, INTERVAL, UUID → "quoted string"
 //   - JSON column → raw JSON value (passed through)
 //   - ARRAY → [elem1,elem2,...]

--- a/literal.go
+++ b/literal.go
@@ -16,10 +16,12 @@ import (
 // Do not mutate: it is shared across all callers.
 var literalFormatConfig = LiteralFormatConfig()
 
+// FormatRowLiteral formats each column of row using [LiteralFormatConfig].
 func FormatRowLiteral(value *spanner.Row) ([]string, error) {
 	return literalFormatConfig.FormatRow(value)
 }
 
+// FormatColumnLiteral formats value using [LiteralFormatConfig] at top level.
 func FormatColumnLiteral(value spanner.GenericColumnValue) (string, error) {
 	return literalFormatConfig.FormatToplevelColumn(value)
 }

--- a/spanner_cli_compatible.go
+++ b/spanner_cli_compatible.go
@@ -47,12 +47,14 @@ func SpannerCLICompatibleFormatConfig() *FormatConfig {
 	}
 }
 
+// FormatRowSpannerCLICompatible formats each column of row using [SpannerCLICompatibleFormatConfig].
 func FormatRowSpannerCLICompatible(row *spanner.Row) ([]string, error) {
 	return spannerCLICompatibleFormatConfig.FormatRow(row)
 }
 
 func FormatNullableSpannerCLICompatible(value NullableValue) (string, error) {
-	// Actually, it is redundant to check IsNull() here, but it is for consistency.
+	// NULL is already handled in formatSimpleColumn before FormatNullable is called; this
+	// re-check keeps FormatNullableSpannerCLICompatible safe when used as a standalone callback.
 	if value.IsNull() {
 		return nullStringUpperCase, nil
 	}
@@ -79,6 +81,7 @@ func FormatNullableSpannerCLICompatible(value NullableValue) (string, error) {
 	}
 }
 
+// FormatColumnSpannerCLICompatible formats value using [SpannerCLICompatibleFormatConfig] at top level.
 func FormatColumnSpannerCLICompatible(value spanner.GenericColumnValue) (string, error) {
 	return spannerCLICompatibleFormatConfig.FormatToplevelColumn(value)
 }


### PR DESCRIPTION
## Summary

- **#222:** Cross-reference `BytesValue`/`BytesFromSlice` nil semantics; warn that `ArrayValue(elems...)` with an empty slice still yields `ARRAY<INT64>`; document `StringBasedValueFromCode` scalar-only scope; note that `NullOf(nil)` surfaces at the Spanner server as `TYPE_CODE_UNSPECIFIED`.
- **#215:** Deprecate `JSONObjectStructFormat` in favor of `NewJSONObjectStructFormatter`.
- **#218 (partial):** JSON preset INT64/ENUM precision caveat; `QuoteIdentifier` empty-name invalid SQL note; godoc on `NullableValue`, `ErrFallthrough`, `Formatter`, and preset convenience wrappers; clarify NULL ownership in `FormatNullableSpannerCLICompatible`.

## Test plan

- [x] `make check`

Closes #222
Closes #215

Partially addresses #218 (doc.go Primary API restructuring and remaining missing godoc deferred).

Made with [Cursor](https://cursor.com)