### PR TITLE
gcvctor: StringBasedValueOf and spanenc nullable constructors (#232, #207)

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -33,9 +33,11 @@
 //
 //   - [BoolFromPtr], [Int64FromPtr], and related *FromPtr helpers take *T; nil means SQL NULL.
 //   - [BytesFromSlice] takes []byte; nil means SQL NULL (slices are already reference types).
-//   - [BoolFromNullable], [Int64FromNullable], and related *FromNullable helpers take
-//     [cloud.google.com/go/spanner.NullBool], [cloud.google.com/go/spanner.NullInt64], and
-//     other client null wrappers; Valid == false means SQL NULL.
+//   - [BoolFromNullable], [Int64FromNullable], [NumericFromNullable], [JSONFromNullable],
+//     [IntervalFromNullable], [PGNumericFromNullable], [PGJSONBFromNullable], and related
+//     *FromNullable helpers take [cloud.google.com/go/spanner.NullBool],
+//     [cloud.google.com/go/spanner.NullInt64], and other client null wrappers; Valid == false
+//     means SQL NULL.
 //
 // Use *FromPtr for optional fields modeled as Go pointers. Use *FromNullable when the value
 // already comes from the Spanner client library. For explicit typed NULL without an input
@@ -63,8 +65,10 @@
 // [MustStructValueOfFields], and [MustNormalizeArrayElements] over local panic-on-error helpers.
 // They wrap the error-returning constructors and are intended for schema-known fixture data, not production paths.
 //
-// String payloads: [StringBasedValueFromCode] stores the wire string as-is with no validation
-// (no extra imports beyond typector). When the test cares about canonical wire form, use validated
+// String payloads: [StringBasedValueOf] and [StringBasedValueFromCode] store the wire string as-is
+// with no validation (no extra imports beyond typector). Use [StringBasedValueOf] when the Type
+// carries annotations (for example PG-dialect NUMERIC). When the test cares about canonical wire
+// form, use validated
 // helpers such as [DateStringValue] or the corresponding [MustDateStringValue], [MustTimestampStringValue],
 // [MustIntervalStringValue], and [MustJSONValue] for inline nesting. Typed Go inputs ([DateValue] with
 // [cloud.google.com/go/civil.Date], [TimestampValue] with [time.Time], and so on) avoid parse errors

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -169,6 +169,18 @@ func BytesBasedValueOf(typ *sppb.Type, v []byte) spanner.GenericColumnValue {
 	}
 }
 
+// StringBasedValueOf constructs a GenericColumnValue with an arbitrary string-compatible
+// [cloud.google.com/go/spanner/apiv1/spannerpb.Type] and wire string stored as-is (no validation).
+// Prefer typed helpers such as [NumericValue] or [PGNumericFromNullable] when you hold native Go
+// values; use this when the Type carries annotations (for example PG-dialect NUMERIC) or other
+// metadata beyond a bare type code.
+func StringBasedValueOf(typ *sppb.Type, v string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typ,
+		Value: structpb.NewStringValue(v),
+	}
+}
+
 // StringBasedValueFromCode constructs a GenericColumnValue for a simple scalar type code
 // with a string wire payload.
 //
@@ -178,11 +190,12 @@ func BytesBasedValueOf(typ *sppb.Type, v []byte) spanner.GenericColumnValue {
 // wire string as-is and do not re-normalize. Prefer [NumericValue], [PGNumericValue], or values
 // from the Spanner client (including the emulator and Spanner Omni) over passing arbitrary
 // decimals here.
+//
+// Accepts simple scalar type codes only. ARRAY and STRUCT codes produce a malformed Type
+// (missing array_element_type or struct_type); use [StringBasedValueOf] with typector for
+// annotated or composite shapes.
 func StringBasedValueFromCode(code sppb.TypeCode, v string) spanner.GenericColumnValue {
-	return spanner.GenericColumnValue{
-		Type:  typector.CodeToSimpleType(code),
-		Value: structpb.NewStringValue(v),
-	}
+	return StringBasedValueOf(typector.CodeToSimpleType(code), v)
 }
 
 // DateValue returns a non-null DATE GenericColumnValue.
@@ -273,10 +286,7 @@ func PGNumericValue(v *big.Rat) spanner.GenericColumnValue {
 	if v == nil {
 		return NullOf(typector.PGNumeric())
 	}
-	return spanner.GenericColumnValue{
-		Type:  typector.PGNumeric(),
-		Value: structpb.NewStringValue(spanner.NumericString(v)),
-	}
+	return StringBasedValueOf(typector.PGNumeric(), spanner.NumericString(v))
 }
 
 // PGNumericValueChecked returns a non-null PostgreSQL-dialect NUMERIC GenericColumnValue
@@ -296,10 +306,7 @@ func PGJSONBValue(v any) (spanner.GenericColumnValue, error) {
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
-	return spanner.GenericColumnValue{
-		Type:  typector.PGJSONB(),
-		Value: structpb.NewStringValue(s),
-	}, nil
+	return StringBasedValueOf(typector.PGJSONB(), s), nil
 }
 
 // jsonWireString marshals v to compact JSON without HTML character escaping,

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -169,9 +169,14 @@ func NumericFromNullable(n spanner.NullNumeric) spanner.GenericColumnValue {
 }
 
 // JSONFromNullable returns a JSON GenericColumnValue from a Spanner null wrapper.
+// When Valid and n.Value is a string, the wire JSON is stored as-is; other Value types
+// are marshaled like [JSONValue].
 func JSONFromNullable(n spanner.NullJSON) (spanner.GenericColumnValue, error) {
 	if !n.Valid {
 		return NullFromCode(sppb.TypeCode_JSON), nil
+	}
+	if s, ok := n.Value.(string); ok {
+		return StringBasedValueFromCode(sppb.TypeCode_JSON, s), nil
 	}
 	return JSONValue(n.Value)
 }

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -6,6 +6,7 @@ import (
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
 	"github.com/google/uuid"
 )
 
@@ -66,6 +67,9 @@ func DateFromPtr(p *civil.Date) spanner.GenericColumnValue {
 }
 
 // TimestampFromPtr returns a TIMESTAMP GenericColumnValue. A nil pointer yields typed SQL NULL.
+//
+// Callers mirroring the official client's encodeValue must handle [cloud.google.com/go/spanner.CommitTimestamp]
+// separately; the client checks that sentinel before formatting timestamps.
 func TimestampFromPtr(p *time.Time) spanner.GenericColumnValue {
 	if p == nil {
 		return NullFromCode(sppb.TypeCode_TIMESTAMP)
@@ -130,6 +134,9 @@ func DateFromNullable(n spanner.NullDate) spanner.GenericColumnValue {
 }
 
 // TimestampFromNullable returns a TIMESTAMP GenericColumnValue from a Spanner null wrapper.
+//
+// Callers mirroring the official client's encodeValue must handle [cloud.google.com/go/spanner.CommitTimestamp]
+// separately; the client checks that sentinel before formatting timestamps.
 func TimestampFromNullable(n spanner.NullTime) spanner.GenericColumnValue {
 	if !n.Valid {
 		return NullFromCode(sppb.TypeCode_TIMESTAMP)
@@ -143,4 +150,54 @@ func UUIDFromNullable(n spanner.NullUUID) spanner.GenericColumnValue {
 		return NullFromCode(sppb.TypeCode_UUID)
 	}
 	return UUIDValue(n.UUID)
+}
+
+// IntervalFromPtr returns an INTERVAL GenericColumnValue. A nil pointer yields typed SQL NULL.
+func IntervalFromPtr(p *spanner.Interval) spanner.GenericColumnValue {
+	if p == nil {
+		return NullFromCode(sppb.TypeCode_INTERVAL)
+	}
+	return IntervalValue(*p)
+}
+
+// NumericFromNullable returns a NUMERIC GenericColumnValue from a Spanner null wrapper.
+func NumericFromNullable(n spanner.NullNumeric) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_NUMERIC)
+	}
+	return NumericValue(&n.Numeric)
+}
+
+// JSONFromNullable returns a JSON GenericColumnValue from a Spanner null wrapper.
+func JSONFromNullable(n spanner.NullJSON) (spanner.GenericColumnValue, error) {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_JSON), nil
+	}
+	return JSONValue(n.Value)
+}
+
+// IntervalFromNullable returns an INTERVAL GenericColumnValue from a Spanner null wrapper.
+func IntervalFromNullable(n spanner.NullInterval) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullFromCode(sppb.TypeCode_INTERVAL)
+	}
+	return IntervalValue(n.Interval)
+}
+
+// PGNumericFromNullable returns a PostgreSQL-dialect NUMERIC GenericColumnValue from a
+// [cloud.google.com/go/spanner.PGNumeric] wrapper. The wire string is stored as-is when Valid.
+func PGNumericFromNullable(n spanner.PGNumeric) spanner.GenericColumnValue {
+	if !n.Valid {
+		return NullOf(typector.PGNumeric())
+	}
+	return StringBasedValueOf(typector.PGNumeric(), n.Numeric)
+}
+
+// PGJSONBFromNullable returns a PostgreSQL-dialect JSON GenericColumnValue from a
+// [cloud.google.com/go/spanner.PGJsonB] wrapper.
+func PGJSONBFromNullable(n spanner.PGJsonB) (spanner.GenericColumnValue, error) {
+	if !n.Valid {
+		return NullOf(typector.PGJSONB()), nil
+	}
+	return PGJSONBValue(n.Value)
 }

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -194,10 +194,15 @@ func PGNumericFromNullable(n spanner.PGNumeric) spanner.GenericColumnValue {
 }
 
 // PGJSONBFromNullable returns a PostgreSQL-dialect JSON GenericColumnValue from a
-// [cloud.google.com/go/spanner.PGJsonB] wrapper.
+// [cloud.google.com/go/spanner.PGJsonB] wrapper. When Valid and n.Value is a string, the
+// wire JSON is stored as-is (not re-marshaled); other Value types are marshaled like
+// [PGJSONBValue].
 func PGJSONBFromNullable(n spanner.PGJsonB) (spanner.GenericColumnValue, error) {
 	if !n.Valid {
 		return NullOf(typector.PGJSONB()), nil
+	}
+	if s, ok := n.Value.(string); ok {
+		return StringBasedValueOf(typector.PGJSONB(), s), nil
 	}
 	return PGJSONBValue(n.Value)
 }

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -239,13 +239,20 @@ func TestExtendedFromNullableScalars(t *testing.T) {
 		})
 	}
 
-	gotJSON, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: map[string]string{"k": "v"}, Valid: true})
+	gotJSONStr, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: `{"k":"v"}`, Valid: true})
 	if err != nil {
-		t.Fatalf("JSONFromNullable value: %v", err)
+		t.Fatalf("JSONFromNullable string value: %v", err)
 	}
 	wantJSON := wantJSONWire(`{"k":"v"}`)
-	if diff := cmp.Diff(wantJSON, gotJSON, protocmp.Transform()); diff != "" {
-		t.Fatalf("JSONFromNullable value mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantJSON, gotJSONStr, protocmp.Transform()); diff != "" {
+		t.Fatalf("JSONFromNullable string value mismatch (-want +got):\n%s", diff)
+	}
+	gotJSONMap, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: map[string]string{"k": "v"}, Valid: true})
+	if err != nil {
+		t.Fatalf("JSONFromNullable map value: %v", err)
+	}
+	if diff := cmp.Diff(wantJSON, gotJSONMap, protocmp.Transform()); diff != "" {
+		t.Fatalf("JSONFromNullable map value mismatch (-want +got):\n%s", diff)
 	}
 	gotNullJSON, err := gcvctor.JSONFromNullable(spanner.NullJSON{})
 	if err != nil {

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -2,6 +2,7 @@ package gcvctor_test
 
 import (
 	"encoding/base64"
+	"math/big"
 	"strconv"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -170,5 +172,115 @@ func TestFromNullableScalars(t *testing.T) {
 				t.Fatalf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func wantNumericWire(wire string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_NUMERIC),
+		Value: structpb.NewStringValue(wire),
+	}
+}
+
+func wantPGNumericWire(wire string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.PGNumeric(),
+		Value: structpb.NewStringValue(wire),
+	}
+}
+
+func wantJSONWire(wire string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+		Value: structpb.NewStringValue(wire),
+	}
+}
+
+func wantPGJSONBWire(wire string) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.PGJSONB(),
+		Value: structpb.NewStringValue(wire),
+	}
+}
+
+func wantInterval(iv spanner.Interval) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_INTERVAL),
+		Value: structpb.NewStringValue(iv.String()),
+	}
+}
+
+func TestExtendedFromNullableScalars(t *testing.T) {
+	t.Parallel()
+
+	iv := lo.Must(spanner.ParseInterval("P1Y2M"))
+	rat := big.NewRat(314, 100)
+
+	tests := []struct {
+		name string
+		got  spanner.GenericColumnValue
+		want spanner.GenericColumnValue
+	}{
+		{"IntervalFromPtr value", gcvctor.IntervalFromPtr(&iv), wantInterval(iv)},
+		{"IntervalFromPtr null", gcvctor.IntervalFromPtr(nil), wantNull(sppb.TypeCode_INTERVAL)},
+		{"NumericFromNullable value", gcvctor.NumericFromNullable(spanner.NullNumeric{Numeric: *rat, Valid: true}), wantNumericWire(spanner.NumericString(rat))},
+		{"NumericFromNullable null", gcvctor.NumericFromNullable(spanner.NullNumeric{}), wantNull(sppb.TypeCode_NUMERIC)},
+		{"IntervalFromNullable value", gcvctor.IntervalFromNullable(spanner.NullInterval{Interval: iv, Valid: true}), wantInterval(iv)},
+		{"IntervalFromNullable null", gcvctor.IntervalFromNullable(spanner.NullInterval{}), wantNull(sppb.TypeCode_INTERVAL)},
+		{"PGNumericFromNullable value", gcvctor.PGNumericFromNullable(spanner.PGNumeric{Numeric: "3.14", Valid: true}), wantPGNumericWire("3.14")},
+		{"PGNumericFromNullable null", gcvctor.PGNumericFromNullable(spanner.PGNumeric{}), spanner.GenericColumnValue{Type: typector.PGNumeric(), Value: structpb.NewNullValue()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.got, protocmp.Transform()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	gotJSON, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: map[string]string{"k": "v"}, Valid: true})
+	if err != nil {
+		t.Fatalf("JSONFromNullable value: %v", err)
+	}
+	wantJSON := wantJSONWire(`{"k":"v"}`)
+	if diff := cmp.Diff(wantJSON, gotJSON, protocmp.Transform()); diff != "" {
+		t.Fatalf("JSONFromNullable value mismatch (-want +got):\n%s", diff)
+	}
+	gotNullJSON, err := gcvctor.JSONFromNullable(spanner.NullJSON{})
+	if err != nil {
+		t.Fatalf("JSONFromNullable null: %v", err)
+	}
+	if diff := cmp.Diff(wantNull(sppb.TypeCode_JSON), gotNullJSON, protocmp.Transform()); diff != "" {
+		t.Fatalf("JSONFromNullable null mismatch (-want +got):\n%s", diff)
+	}
+
+	gotPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: map[string]string{"k": "v"}, Valid: true})
+	if err != nil {
+		t.Fatalf("PGJSONBFromNullable value: %v", err)
+	}
+	wantPGJSON := wantPGJSONBWire(`{"k":"v"}`)
+	if diff := cmp.Diff(wantPGJSON, gotPGJSON, protocmp.Transform()); diff != "" {
+		t.Fatalf("PGJSONBFromNullable value mismatch (-want +got):\n%s", diff)
+	}
+	gotNullPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{})
+	if err != nil {
+		t.Fatalf("PGJSONBFromNullable null: %v", err)
+	}
+	if diff := cmp.Diff(spanner.GenericColumnValue{Type: typector.PGJSONB(), Value: structpb.NewNullValue()}, gotNullPGJSON, protocmp.Transform()); diff != "" {
+		t.Fatalf("PGJSONBFromNullable null mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestStringBasedValueOf(t *testing.T) {
+	t.Parallel()
+
+	got := gcvctor.StringBasedValueOf(typector.PGNumeric(), "99.5")
+	want := spanner.GenericColumnValue{
+		Type:  typector.PGNumeric(),
+		Value: structpb.NewStringValue("99.5"),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -255,13 +255,20 @@ func TestExtendedFromNullableScalars(t *testing.T) {
 		t.Fatalf("JSONFromNullable null mismatch (-want +got):\n%s", diff)
 	}
 
-	gotPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: map[string]string{"k": "v"}, Valid: true})
+	gotPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: `{"k":"v"}`, Valid: true})
 	if err != nil {
-		t.Fatalf("PGJSONBFromNullable value: %v", err)
+		t.Fatalf("PGJSONBFromNullable wire string: %v", err)
 	}
 	wantPGJSON := wantPGJSONBWire(`{"k":"v"}`)
 	if diff := cmp.Diff(wantPGJSON, gotPGJSON, protocmp.Transform()); diff != "" {
-		t.Fatalf("PGJSONBFromNullable value mismatch (-want +got):\n%s", diff)
+		t.Fatalf("PGJSONBFromNullable wire string mismatch (-want +got):\n%s", diff)
+	}
+	gotPGJSONMap, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: map[string]string{"k": "v"}, Valid: true})
+	if err != nil {
+		t.Fatalf("PGJSONBFromNullable map value: %v", err)
+	}
+	if diff := cmp.Diff(wantPGJSON, gotPGJSONMap, protocmp.Transform()); diff != "" {
+		t.Fatalf("PGJSONBFromNullable map value mismatch (-want +got):\n%s", diff)
 	}
 	gotNullPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `StringBasedValueOf(typ, string)` as the string-payload parallel to `BytesBasedValueOf`, with `StringBasedValueFromCode` delegating to it (#232).
- Extend the `FromNullable` / `FromPtr` family for spanenc: `NumericFromNullable`, `JSONFromNullable`, `IntervalFromNullable`, `IntervalFromPtr`, `PGNumericFromNullable`, `PGJSONBFromNullable` (#207 spanenc-critical subset).
- Document `CommitTimestamp` boundary on `TimestampFromPtr` / `TimestampFromNullable` per spanenc feedback.

Unblocks [spanenc](https://github.com/apstndb/spanenc) to delete hand-rolled `encodePGNumeric`, `encodePGJsonB`, `encodeNullNumeric`, `encodeNullJSON`, and inline INTERVAL nullable checks.

## Test plan

- [x] `make check`
- [x] New tests for `StringBasedValueOf` and extended nullable helpers

Closes #232
Partially addresses #207 (Must*, PGOID, UUID/JSON string validators deferred)


Made with [Cursor](https://cursor.com)