### PR TITLE
docs: record spanenc adoption boundary (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 
 - **`dbsqlrows/`** owns the shared `*sql.Rows` loop (`RunRows`/`RunRowsAtData` + `SQLRowsHooks`, parallel to `writer.RunRowIterator`); csv/jsonl use `SQLRowsHooksFromGCVWriter`. No go-sql-spanner in root `go.mod`. **`dbsqlrows/gospanner/`** is optional one-shot export + ExecOptions reference (not for REPLs — spannersh uses core only). Table layout and batch orchestration stay in apps. See [#109](https://github.com/apstndb/spanvalue/issues/109) / [#110](https://github.com/apstndb/spanvalue/issues/110).
 - **No string→GCV parsing** in `FormatConfig` (`gcvctor` / app). PG table cells: **spanpg**, not spanvalue.
+- **Reflection / client-tag Go value → GCV** (struct tags, `Null*` wrappers, `spanner.Encoder`, typed-NULL inference mirroring the official client's `encodeValue`) lives in [**spanenc**](https://github.com/apstndb/spanenc) with [**structfields**](https://github.com/apstndb/structfields); `gcvctor` stays explicit, strict constructors with caller-supplied types.
 
 ## gcvctor & errors (short)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 
 - **`dbsqlrows/`** owns the shared `*sql.Rows` loop (`RunRows`/`RunRowsAtData` + `SQLRowsHooks`, parallel to `writer.RunRowIterator`); csv/jsonl use `SQLRowsHooksFromGCVWriter`. No go-sql-spanner in root `go.mod`. **`dbsqlrows/gospanner/`** is optional one-shot export + ExecOptions reference (not for REPLs — spannersh uses core only). Table layout and batch orchestration stay in apps. See [#109](https://github.com/apstndb/spanvalue/issues/109) / [#110](https://github.com/apstndb/spanvalue/issues/110).
 - **No string→GCV parsing** in `FormatConfig` (`gcvctor` / app). PG table cells: **spanpg**, not spanvalue.
-- **Reflection / client-tag Go value → GCV** (struct tags, `Null*` wrappers, `spanner.Encoder`, typed-NULL inference mirroring the official client's `encodeValue`) lives in [**spanenc**](https://github.com/apstndb/spanenc) with [**structfields**](https://github.com/apstndb/structfields); `gcvctor` stays explicit, strict constructors with caller-supplied types.
+- **Reflection / client-tag Go value → GCV** (struct tags, `Null*` wrappers, `spanner.Encoder`, typed-NULL inference mirroring the official client's `encodeValue`) lives in [**spanenc**](https://github.com/apstndb/spanenc) with [**structfields**](https://github.com/apstndb/structfields) (separate Apache-2.0 module hosting the upstream `cloud.google.com/go/internal/fields` fork and `spannertag` port so MIT modules never embed upstream-derived code); `gcvctor` stays explicit, strict constructors with caller-supplied types.
 
 ## gcvctor & errors (short)
 

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -55,7 +55,9 @@
 // formatters treat NUMERIC string payloads as authoritative and do not parse them again.
 //
 // Formatting these values as strings is provided by the sibling package
-// [github.com/apstndb/spanvalue].
+// [github.com/apstndb/spanvalue]. For converting arbitrary Go values with the official
+// Cloud Spanner Go client's encoding semantics (struct tags, null wrappers, Encoder), see
+// [github.com/apstndb/spanenc].
 //
 // # Test fixtures
 //


### PR DESCRIPTION
## Summary

- Add spanenc to AGENTS.md adoption boundaries: reflection / client-tag Go value → GCV lives in spanenc; gcvctor stays explicit strict constructors.
- Add one-line spanenc discoverability pointer in gcvctor package doc.

Requested by [spanenc](https://github.com/apstndb/spanenc) downstream feedback.

## Test plan

- [x] `make check`

Closes #233


Made with [Cursor](https://cursor.com)