### PR TITLE
gcvctor: marshal string Values in JSONFromNullable/PGJSONBFromNullable like the client

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -43,6 +43,12 @@
 // already comes from the Spanner client library. For explicit typed NULL without an input
 // value, keep using [NullOf] or [NullFromCode].
 //
+// [JSONFromNullable] and [PGJSONBFromNullable] marshal Value like [JSONValue] and
+// [PGJSONBValue]: a Go string becomes a quoted JSON string on the wire, matching the
+// official client's encodeValue. Pass pre-encoded wire JSON as an
+// [encoding/json.RawMessage] to store it as-is (validated and compacted); see
+// ExampleJSONFromNullable.
+//
 // [NumericValueChecked] and [PGNumericValueChecked] return errors on nil [*big.Rat] input
 // instead of panicking. The legacy [NumericValue] and [PGNumericValue] helpers keep their
 // original signatures and return typed SQL NULL values on nil input.

--- a/gcvctor/example_test.go
+++ b/gcvctor/example_test.go
@@ -1,6 +1,7 @@
 package gcvctor_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"cloud.google.com/go/spanner"
@@ -176,4 +177,18 @@ func ExampleInt64FromPtr_fromNullable() {
 	// true
 	// 42
 	// 42
+}
+
+// A Go string in NullJSON.Value marshals to a quoted JSON string, matching
+// the official client's encodeValue; pass pre-encoded wire JSON as a
+// json.RawMessage to store it as-is.
+func ExampleJSONFromNullable() {
+	str, _ := gcvctor.JSONFromNullable(spanner.NullJSON{Value: `{"a":1}`, Valid: true})
+	raw, _ := gcvctor.JSONFromNullable(spanner.NullJSON{Value: json.RawMessage(`{"a":1}`), Valid: true})
+
+	fmt.Println(str.Value.GetStringValue())
+	fmt.Println(raw.Value.GetStringValue())
+	// Output:
+	// "{\"a\":1}"
+	// {"a":1}
 }

--- a/gcvctor/nullable_input.go
+++ b/gcvctor/nullable_input.go
@@ -170,14 +170,13 @@ func NumericFromNullable(n spanner.NullNumeric) spanner.GenericColumnValue {
 }
 
 // JSONFromNullable returns a JSON GenericColumnValue from a Spanner null wrapper.
-// When Valid and n.Value is a string, the wire JSON is stored as-is; other Value types
-// are marshaled like [JSONValue].
+// When Valid, n.Value is marshaled like [JSONValue]: a Go string becomes a quoted
+// JSON string on the wire, matching the official client's encodeValue. To store
+// pre-encoded wire JSON as-is (validated and compacted), pass it as an
+// [encoding/json.RawMessage], the same convention the client follows.
 func JSONFromNullable(n spanner.NullJSON) (spanner.GenericColumnValue, error) {
 	if !n.Valid {
 		return NullFromCode(sppb.TypeCode_JSON), nil
-	}
-	if s, ok := n.Value.(string); ok {
-		return StringBasedValueFromCode(sppb.TypeCode_JSON, s), nil
 	}
 	return JSONValue(n.Value)
 }
@@ -200,15 +199,13 @@ func PGNumericFromNullable(n spanner.PGNumeric) spanner.GenericColumnValue {
 }
 
 // PGJSONBFromNullable returns a PostgreSQL-dialect JSON GenericColumnValue from a
-// [cloud.google.com/go/spanner.PGJsonB] wrapper. When Valid and n.Value is a string, the
-// wire JSON is stored as-is (not re-marshaled); other Value types are marshaled like
-// [PGJSONBValue].
+// [cloud.google.com/go/spanner.PGJsonB] wrapper. When Valid, n.Value is marshaled
+// like [PGJSONBValue]: a Go string becomes a quoted JSON string on the wire,
+// matching the official client's encodeValue. To store pre-encoded wire JSON
+// as-is (validated and compacted), pass it as an [encoding/json.RawMessage].
 func PGJSONBFromNullable(n spanner.PGJsonB) (spanner.GenericColumnValue, error) {
 	if !n.Valid {
 		return NullOf(typector.PGJSONB()), nil
-	}
-	if s, ok := n.Value.(string); ok {
-		return StringBasedValueOf(typector.PGJSONB(), s), nil
 	}
 	return PGJSONBValue(n.Value)
 }

--- a/gcvctor/nullable_input_test.go
+++ b/gcvctor/nullable_input_test.go
@@ -2,6 +2,7 @@ package gcvctor_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"math/big"
 	"strconv"
 	"testing"
@@ -239,13 +240,25 @@ func TestExtendedFromNullableScalars(t *testing.T) {
 		})
 	}
 
+	wantJSON := wantJSONWire(`{"k":"v"}`)
+	// A Go string marshals to a quoted JSON string, matching the client's
+	// encodeValue; json.RawMessage is the pre-encoded as-is path.
 	gotJSONStr, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: `{"k":"v"}`, Valid: true})
 	if err != nil {
 		t.Fatalf("JSONFromNullable string value: %v", err)
 	}
-	wantJSON := wantJSONWire(`{"k":"v"}`)
-	if diff := cmp.Diff(wantJSON, gotJSONStr, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(wantJSONWire(`"{\"k\":\"v\"}"`), gotJSONStr, protocmp.Transform()); diff != "" {
 		t.Fatalf("JSONFromNullable string value mismatch (-want +got):\n%s", diff)
+	}
+	gotJSONRaw, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: json.RawMessage(`{"k":"v"}`), Valid: true})
+	if err != nil {
+		t.Fatalf("JSONFromNullable raw message: %v", err)
+	}
+	if diff := cmp.Diff(wantJSON, gotJSONRaw, protocmp.Transform()); diff != "" {
+		t.Fatalf("JSONFromNullable raw message mismatch (-want +got):\n%s", diff)
+	}
+	if _, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: json.RawMessage(`{invalid`), Valid: true}); err == nil {
+		t.Fatal("JSONFromNullable invalid raw message: want error, got nil")
 	}
 	gotJSONMap, err := gcvctor.JSONFromNullable(spanner.NullJSON{Value: map[string]string{"k": "v"}, Valid: true})
 	if err != nil {
@@ -262,13 +275,20 @@ func TestExtendedFromNullableScalars(t *testing.T) {
 		t.Fatalf("JSONFromNullable null mismatch (-want +got):\n%s", diff)
 	}
 
-	gotPGJSON, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: `{"k":"v"}`, Valid: true})
-	if err != nil {
-		t.Fatalf("PGJSONBFromNullable wire string: %v", err)
-	}
 	wantPGJSON := wantPGJSONBWire(`{"k":"v"}`)
-	if diff := cmp.Diff(wantPGJSON, gotPGJSON, protocmp.Transform()); diff != "" {
-		t.Fatalf("PGJSONBFromNullable wire string mismatch (-want +got):\n%s", diff)
+	gotPGJSONStr, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: `{"k":"v"}`, Valid: true})
+	if err != nil {
+		t.Fatalf("PGJSONBFromNullable string value: %v", err)
+	}
+	if diff := cmp.Diff(wantPGJSONBWire(`"{\"k\":\"v\"}"`), gotPGJSONStr, protocmp.Transform()); diff != "" {
+		t.Fatalf("PGJSONBFromNullable string value mismatch (-want +got):\n%s", diff)
+	}
+	gotPGJSONRaw, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: json.RawMessage(`{"k":"v"}`), Valid: true})
+	if err != nil {
+		t.Fatalf("PGJSONBFromNullable raw message: %v", err)
+	}
+	if diff := cmp.Diff(wantPGJSON, gotPGJSONRaw, protocmp.Transform()); diff != "" {
+		t.Fatalf("PGJSONBFromNullable raw message mismatch (-want +got):\n%s", diff)
 	}
 	gotPGJSONMap, err := gcvctor.PGJSONBFromNullable(spanner.PGJsonB{Value: map[string]string{"k": "v"}, Valid: true})
 	if err != nil {


### PR DESCRIPTION
Closes #236. Feedback from the spanenc adoption of v0.7.2 (#232 / #207).

## What

`JSONFromNullable` and `PGJSONBFromNullable` no longer special-case a `string` Value as pre-encoded wire JSON. They always delegate to `JSONValue` / `PGJSONBValue`, so a Go string marshals to a **quoted JSON string** on the wire — the same semantics as the official client's `encodeValue`. Pre-encoded wire JSON is passed as `json.RawMessage`, which `jsonWireString`'s `json.Encoder` already stores as-is (validated and compacted, no HTML escaping); the client follows the same `json.Marshal` convention for `RawMessage`, keeping the two aligned.

| Input Value | v0.7.2 wire | this PR wire | client wire |
|---|---|---|---|
| `"x"` (string) | `x` (invalid JSON) | `"x"` | `"x"` |
| `json.RawMessage("{\"a\":1}")` | `{"a":1}` (via marshal) | `{"a":1}` | `{"a":1}` |

## Why this is a bug fix, not a design change

These helpers take the client's own wrapper types, whose `Value` semantics the client defines: a client-decoded JSON **string column** yields a Go `string` in `NullJSON.Value`, and re-encoding it through the v0.7.2 helpers corrupts the round trip (`"x"` becomes bare `x`, which is not valid JSON wire). Interpreting client-typed input differently from the client is a contract violation, and the output is malformed — the same class as the v0.7.1 wire-correctness fixes (`TimestampValue` UTC normalization, JSON HTML-escape removal), which shipped as a patch.

The divergence is also what kept spanenc on its hand-rolled `encodeNullJSON` / `encodePGJsonB` (apstndb/spanenc@662f7a8). With this fix spanenc can adopt these helpers. `json.RawMessage` is the established `encoding/json` idiom for pre-encoded payloads, so the double-marshal-avoidance use case keeps an explicit, client-compatible spelling.

## Changes

- `gcvctor/nullable_input.go`: drop the string special-case in both helpers; document the marshal semantics and the `RawMessage` path.
- `gcvctor/doc.go`: note the behavior in the nullable-inputs section.
- `gcvctor/example_test.go`: `ExampleJSONFromNullable` pinning string-vs-RawMessage wire output.
- `gcvctor/nullable_input_test.go`: update string-Value expectations to quoted wire; add `RawMessage` pass-through and invalid-`RawMessage` error cases.

## Release note

Recommend shipping as a **patch (v0.7.3)**: it fixes invalid wire output from a helper introduced in v0.7.2 (released 2026-06-11) with no known adopters — spanenc, the requester of #232, explicitly declined the special case. Suggested release-notes row:

| Area | v0.7.2 | v0.7.3 |
|---|---|---|
| `JSONFromNullable` / `PGJSONBFromNullable` with `string` Value | Wire as-is (invalid for non-JSON strings) | Quoted JSON string (client-compatible); use `json.RawMessage` for as-is |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
