### PR TITLE
dialect: use GoogleSQL string-literal escapes in QuoteIdentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Requires **Go 1.24** or later (see [`go.mod`](go.mod)).
 
 `QuoteIdentifier` and `QuoteQualifiedIdentifier` are conservative quoting
 helpers. They always quote for the selected dialect, escape embedded quote
-characters, and do **not** attempt a minimal "quote only when necessary"
-strategy.
+characters (for GoogleSQL, string-literal escapes: backslash to `\\` and
+backtick to ``\` ``), and do **not** attempt a minimal "quote only when
+necessary" strategy.
 
 - `DATABASE_DIALECT_UNSPECIFIED` follows the Spanner default and uses GoogleSQL
   quoting.

--- a/dialect.go
+++ b/dialect.go
@@ -6,7 +6,17 @@ import (
 	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 )
 
+// googleSQLIdentifierEscaper escapes the characters that must be escaped inside a
+// GoogleSQL backquoted identifier. Quoted identifiers use the same escape sequences
+// as string literals, so backslash becomes \\ and backtick becomes \`.
+// strings.Replacer replaces in a single pass, so the backslash escape never
+// re-processes the backslash introduced by the backtick escape (and vice versa).
+var googleSQLIdentifierEscaper = strings.NewReplacer(`\`, `\\`, "`", "\\`")
+
 // QuoteIdentifier quotes a single identifier for dialect.
+// For GoogleSQL it escapes the identifier with string-literal escape sequences
+// (backslash to \\ and backtick to \`) per the GoogleSQL lexical structure;
+// for PostgreSQL it doubles embedded double quotes.
 // It does not validate the identifier; for example, an empty string becomes an empty quoted
 // identifier (two backticks for GoogleSQL, "" for PostgreSQL), which is invalid SQL in both dialects.
 // DATABASE_DIALECT_UNSPECIFIED follows the Spanner default and uses GoogleSQL quoting.
@@ -15,7 +25,7 @@ func QuoteIdentifier(dialect databasepb.DatabaseDialect, name string) string {
 	case databasepb.DatabaseDialect_POSTGRESQL:
 		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 	default:
-		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+		return "`" + googleSQLIdentifierEscaper.Replace(name) + "`"
 	}
 }
 

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -16,7 +16,10 @@ func TestQuoteIdentifier(t *testing.T) {
 		want    string
 	}{
 		{"GoogleSQL simple", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "table", "`table`"},
-		{"GoogleSQL escapes backtick", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "a`b", "`a``b`"},
+		{"GoogleSQL plain name unchanged", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "Singers", "`Singers`"},
+		{"GoogleSQL escapes backtick", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "a`b", "`a\\`b`"},
+		{"GoogleSQL escapes trailing backslash", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, `a\`, "`a\\\\`"},
+		{"GoogleSQL escapes backslash then backtick", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, "a\\`b", "`a\\\\\\`b`"},
 		{"PostgreSQL simple", databasepb.DatabaseDialect_POSTGRESQL, "table", `"table"`},
 		{"PostgreSQL escapes quote", databasepb.DatabaseDialect_POSTGRESQL, `a"b`, `"a""b"`},
 		{"Unspecified defaults to GoogleSQL", databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, "table", "`table`"},

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -816,7 +816,7 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 				gcvctor.Int64Value(42),
 				gcvctor.StringValue("Alice"),
 			},
-			want: "INSERT INTO `user``table` (`id`, `na``me`) VALUES (42, \"Alice\");\n",
+			want: "INSERT INTO `user\\`table` (`id`, `na\\`me`) VALUES (42, \"Alice\");\n",
 		},
 		{
 			name:        "value escaping delegated to literal formatter",
@@ -834,7 +834,7 @@ func TestSQLInsertWriterWriteValues(t *testing.T) {
 			values: []spanner.GenericColumnValue{
 				gcvctor.Int64Value(42),
 			},
-			want: "INSERT INTO `my``db`.`users` (`id`) VALUES (42);\n",
+			want: "INSERT INTO `my\\`db`.`users` (`id`) VALUES (42);\n",
 		},
 	}
 
@@ -1252,7 +1252,7 @@ func TestSQLInsertWriterWriteRow(t *testing.T) {
 		t.Fatalf("WriteRow() error = %v", err)
 	}
 
-	want := "INSERT INTO `db`.`user``table` (`na``me`, `payload`) VALUES (\"Alice\", \"semi;\\nline\");\n"
+	want := "INSERT INTO `db`.`user\\`table` (`na\\`me`, `payload`) VALUES (\"Alice\", \"semi;\\nline\");\n"
 	if diff := cmp.Diff(want, out.String()); diff != "" {
 		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
## What

Fix the GoogleSQL branch of `QuoteIdentifier` to use GoogleSQL string-literal escape sequences instead of MySQL-style backtick doubling:

- Escape `\` as `\\` and `` ` `` as `` \` ``, implemented with a single-pass `strings.Replacer` so the two escapes cannot re-process each other's output (equivalent to "backslash first, then backtick").
- Document the escaping rule in the `QuoteIdentifier` doc comment and the README identifier-quoting section.
- Fix the existing incorrect backtick assertion in `dialect_test.go` and add cases for an embedded backtick, a trailing backslash, a backslash+backtick combination, and a plain name (unchanged output).
- Regold the `writer` SQL INSERT test expectations that asserted the old doubled-backtick output.

The PostgreSQL branch (double-quote doubling) is correct and unchanged.

## Why

Per the [GoogleSQL lexical structure](https://cloud.google.com/spanner/docs/reference/standard-sql/lexical), quoted identifiers use the same escape sequences as string literals; `` `` `` doubling is MySQL syntax and any sequence not in the escape table is an error. Concretely:

- `QuoteIdentifier(GOOGLE_STANDARD_SQL, "a`b")` produced ``` `a``b` ```, which is not a valid GoogleSQL identifier.
- A trailing backslash (`"a\"` → `` `a\` ``) escaped the closing backtick, so the identifier swallowed the SQL that follows — an injection-shaped failure mode for the `writer` SQL INSERT path with caller-supplied table/column names.

The documented "does not validate the identifier" contract is kept. The optional empty-identifier rejection mentioned in the issue was deliberately left out as out of scope per triage; the existing docs already state that an empty string becomes an empty quoted identifier, which is invalid SQL in both dialects.

## Tests

- New/updated `TestQuoteIdentifier` cases: plain name, embedded backtick, trailing backslash, backslash+backtick.
- `writer` SQL INSERT identifier-escaping expectations updated to the corrected output.
- `make check` passes (fmt-check, vet, build, test, golangci-lint).

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
