### PR TITLE
ci: make govulncheck PR-blocking and add make vulncheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,6 @@
 # CI mirrors local `make check` (fmt-check, vet, build, test, lint) plus
-# race detection, Example tests, and scheduled govulncheck.
+# race detection, Example tests, and govulncheck (PR-blocking; also scheduled
+# weekly to catch newly published advisories without a code change).
 
 name: Go
 
@@ -99,7 +100,10 @@ jobs:
 
   govulncheck:
     name: govulncheck
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # Runs on every trigger (push, pull_request, schedule) and is PR-blocking:
+    # the baseline is clean at the symbol level (#177), so any reachable
+    # finding is a regression. The weekly schedule still catches advisories
+    # published between merges.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check fmt fmt-check lint test test-v vet
+.PHONY: build check fmt fmt-check lint test test-v vet vulncheck
 
 build:
 	go build ./...
@@ -26,3 +26,9 @@ test-v:
 
 vet:
 	go vet ./...
+
+# Mirrors the CI govulncheck job for local parity. Deliberately not part of
+# `check`: it needs network access (vuln DB + @latest scanner) and would slow
+# the inner loop.
+vulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## What

- `.github/workflows/go.yml`: drop the `if: github.event_name == 'push' || github.event_name == 'schedule'` gate on the `govulncheck` job so it also runs (and blocks) on `pull_request`. `continue-on-error: true` was already removed in 39b88c4, so removing the gate is the remaining step to make the job PR-blocking. The weekly schedule and the Go 1.25 + `govulncheck@latest` setup (stdlib findings stay current without manual pin bumps) are preserved, including the explanatory comment.
- `Makefile`: add a `make vulncheck` target mirroring the CI invocation (`go run golang.org/x/vuln/cmd/govulncheck@latest ./...`) for local parity. It is deliberately **not** part of `make check`: it needs network access (vuln DB + `@latest` scanner) and would slow the inner loop; a Makefile comment says so.

## Baseline

`govulncheck ./...` on this branch (Go 1.26.4, scanner `@latest`, 2026-06-11) is clean at the symbol level:

```
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 3 vulnerabilities in packages you import and 24
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
```

The imported-package findings (informational, not reachable, govulncheck exits 0): GO-2026-5026 / GO-2026-4918 (`golang.org/x/net@v0.42.0`), GO-2026-4762 (`google.golang.org/grpc@v1.74.2`). The module-level entries are transitive `x/net` / `x/crypto` / `x/sys` advisories with no reachable symbols. No accepted exceptions are needed; govulncheck only fails on reachable (symbol-level) findings, so these do not block CI.

`make vulncheck` and `make check` both pass locally; the workflow parses cleanly (actionlint reports only a pre-existing `install-only` input warning on the untouched golangci-lint-action step).

## Why

#159 wired govulncheck as non-blocking while the baseline was untriaged. The previously reachable advisories were fixed by dependency bumps (39b88c4, v0.7.0), so the baseline is now clean and any future reachable finding is a regression that should fail PRs rather than be discovered on the weekly schedule.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
