### PR TITLE
dbsqlrows: fix godoc rendering and move REPL guidance to README

### DIFF
--- a/dbsqlrows/README.md
+++ b/dbsqlrows/README.md
@@ -4,6 +4,38 @@
 
 Package documentation: [pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows)
 
+Streams `database/sql` query results into [`writer`](../writer/README.md) using the `GenericColumnValue` slice export path, or into custom sinks via `SQLRowsHooks`. The package owns the `*sql.Rows` loop (metadata pseudo-row → data rows → optional stats pseudo-row) and keeps database/sql drivers out of the root `go.mod`. See the package godoc for the API contract; this README covers driver integration and application patterns.
+
+## go-sql-spanner integration
+
+Option A (driver-agnostic): configure `ExecOptions` at query time, then pass open `*sql.Rows` to [`WriteRows`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#WriteRows) or [`RunRows`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#RunRows):
+
+```go
+opts := spannerdriver.ExecOptions{
+    DecodeOption:            spannerdriver.DecodeOptionProto,
+    ReturnResultSetMetadata: true,
+    ReturnResultSetStats:    false,
+}
+rows, err := db.QueryContext(ctx, q, opts)
+// ...
+result, err := dbsqlrows.WriteRows(rows, w, dbsqlrows.SQLRowsConfig{})
+```
+
+Option B: nested module [`gospanner/`](gospanner/README.md) provides `DefaultExecOptions` and `QueryExport` for one-shot query → csv/jsonl export when the app already depends on go-sql-spanner. It is a thin reference integration (`ExecOptions` + `QueryContext` + `WriteRows`); root `go.mod` still has no go-sql-spanner. Interactive shells, metadata-first batches, EXPLAIN, and per-query driver options (`QueryMode`, `DirectExecuteQuery`) should use Option A with app-owned `ExecOptions` instead — validated by [spannersh](https://github.com/apstndb/spannersh).
+
+## Stats: driver vs export
+
+A common REPL pattern: set `ReturnResultSetStats` true on the driver at `QueryContext`, keep [`SQLRowsConfig.ReadResultSetStats`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#SQLRowsConfig) false during csv/jsonl/table export, then read the stats pseudo-row in application code after render. dbsqlrows leaves the cursor on the data result set until export completes or `ReadResultSetStats` is enabled.
+
+## Application patterns
+
+- **Metadata-first batch:** [`ReadMetadataAndAdvanceToData`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#ReadMetadataAndAdvanceToData), render (table via [`RunRowsAtData`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#RunRowsAtData) + hooks), then read stats from rows or set `ReadResultSetStats`.
+- **Table sink:** `RunRowsAtData` with [`SQLRowsHooks.WithPrepareMetadata`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#SQLRowsHooks.WithPrepareMetadata), `WithWriteDataRow`, and `WithFinish` — apps own layout libraries and cell formatting.
+- **csv/jsonl:** [`WriteRowsAtData`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#WriteRowsAtData) with [`writer.DelimitedGCVExportOptions`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#DelimitedGCVExportOptions) or [`writer.JSONLGCVExportOptions`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#JSONLGCVExportOptions) at writer construction.
+- **EXPLAIN / drain:** `RunRowsAtData` with [`NewSQLRowsHooks`](https://pkg.go.dev/github.com/apstndb/spanvalue/dbsqlrows#NewSQLRowsHooks) and `SQLRowsConfig.WithReadResultSetStats(true)`.
+
+## Testing
+
 ```bash
 go test ./dbsqlrows/...
 # or from repo root: make check

--- a/dbsqlrows/doc.go
+++ b/dbsqlrows/doc.go
@@ -8,22 +8,31 @@
 // [github.com/googleapis/go-sql-spanner]) configure driver-specific options
 // themselves; this package only iterates [*sql.Rows] once they are open.
 //
+// Extended documentation, go-sql-spanner integration recipes (ExecOptions),
+// and application patterns (REPL stats flow, table sinks):
+// https://github.com/apstndb/spanvalue/blob/main/dbsqlrows/README.md
+//
 // # Naming
 //
 // The name combines db (standard library [database/sql]) and sqlrows
 // ([*sql.Rows] as input). For the native-client export path, use
-// [github.com/apstndb/spanvalue/writer] ([writer.WriteRowIterator] on
+// [github.com/apstndb/spanvalue/writer]
+// ([github.com/apstndb/spanvalue/writer.WriteRowIterator] on
 // [*cloud.google.com/go/spanner.RowIterator]).
 //
 // # writer vs dbsqlrows
 //
-// | Path | Iterator | Row shape | spanvalue entry |
-// |------|----------|-----------|-----------------|
-// | Native client | [*spanner.RowIterator] | [*spanner.Row] | [writer.WriteRowIterator] |
-// | database/sql driver | [*sql.Rows] | []spanner.GenericColumnValue | [writer.DelimitedWriter.WriteGCVs] |
-// | dbsqlrows | [*sql.Rows] (caller-owned) | []spanner.GenericColumnValue | [RunRowsAtData] / [WriteRowsAtData] |
+// Three export paths, by iterator and row shape:
 //
-// dbsqlrows does not convert GCV slices to [*spanner.Row] for [writer.Writer.WriteRow].
+//   - Native client: [*spanner.RowIterator] yielding [*spanner.Row];
+//     spanvalue entry [github.com/apstndb/spanvalue/writer.WriteRowIterator].
+//   - database/sql driver: [*sql.Rows] yielding []spanner.GenericColumnValue;
+//     spanvalue entry [github.com/apstndb/spanvalue/writer.DelimitedWriter.WriteGCVs].
+//   - dbsqlrows: [*sql.Rows] (caller-owned) yielding []spanner.GenericColumnValue;
+//     spanvalue entry [RunRowsAtData] / [WriteRowsAtData].
+//
+// dbsqlrows does not convert GCV slices to [*spanner.Row] for
+// [github.com/apstndb/spanvalue/writer.Writer.WriteRow].
 //
 // # Module layout
 //
@@ -35,87 +44,41 @@
 // # Goals
 //
 //   - Own the [*sql.Rows] loop: metadata pseudo-row → data rows → optional stats pseudo-row.
-//   - Delegate csv/jsonl formatting to [writer.WriteGCVs] / [GCVStreamWriter.Flush].
+//   - Delegate csv/jsonl formatting to [GCVStreamWriter.WriteGCVs] / [GCVStreamWriter.Flush].
 //   - Expose [SQLRowsHooks] for custom sinks (table layout, drain-only) parallel to
-//     [writer.RowIteratorHooks].
+//     [github.com/apstndb/spanvalue/writer.RowIteratorHooks].
 //   - Keep database/sql drivers out of spanvalue go.mod.
 //
 // # Non-goals
 //
-//   - Native [*spanner.RowIterator] export ([writer.WriteRowIterator]).
+//   - Native [*spanner.RowIterator] export
+//     ([github.com/apstndb/spanvalue/writer.WriteRowIterator]).
 //   - String → GCV parsing, PostgreSQL table cells, or built-in ASCII table layout.
 //   - Batch orchestration, SQL INSERT export, or owning db.QueryContext / driver ExecOptions.
 //
 // # API overview
 //
-// | Entry point | When to use |
-// |-------------|-------------|
-// | [WriteRows] | Open [*sql.Rows] at metadata pseudo-row; csv/jsonl via [GCVStreamWriter] |
-// | [RunRows] / [RunRowsAtData] | Custom sinks via [SQLRowsHooks] |
-// | [ReadMetadataAndAdvanceToData] | Metadata-first apps; advances cursor to data rows |
-// | [WriteRowsAtData] | [RunRowsAtData] + [SQLRowsHooksFromGCVWriter] |
+//   - [WriteRows]: open [*sql.Rows] at the metadata pseudo-row; csv/jsonl via
+//     [GCVStreamWriter].
+//   - [RunRows] / [RunRowsAtData]: custom sinks via [SQLRowsHooks].
+//   - [ReadMetadataAndAdvanceToData]: metadata-first apps; advances cursor to
+//     data rows.
+//   - [WriteRowsAtData]: [RunRowsAtData] + [SQLRowsHooksFromGCVWriter].
 //
 // Symmetry with writer:
 //
-// | writer | dbsqlrows |
-// |--------|-----------|
-// | [writer.RunRowIterator] | [RunRows] / [RunRowsAtData] |
-// | [writer.RowIteratorHooks] | [SQLRowsHooks] |
-// | [writer.RowIteratorHooksFromWriter] | [SQLRowsHooksFromGCVWriter] |
-// | [writer.RowIteratorResult] | [SQLRowsResult] |
+//   - [github.com/apstndb/spanvalue/writer.RunRowIterator] ↔ [RunRows] / [RunRowsAtData]
+//   - [github.com/apstndb/spanvalue/writer.RowIteratorHooks] ↔ [SQLRowsHooks]
+//   - [github.com/apstndb/spanvalue/writer.RowIteratorHooksFromWriter] ↔ [SQLRowsHooksFromGCVWriter]
+//   - [github.com/apstndb/spanvalue/writer.RowIteratorResult] ↔ [SQLRowsResult]
 //
 // [SQLRowsResult] carries Metadata when known on error paths (partial-result contract
-// matching [writer.RowIteratorResult]). Stats are not consumed unless
-// [SQLRowsConfig.ReadResultSetStats] is true; the iterator then advances with
-// NextResultSet for multi-statement batches.
+// matching [github.com/apstndb/spanvalue/writer.RowIteratorResult]). Stats are not
+// consumed unless [SQLRowsConfig.ReadResultSetStats] is true; the iterator then
+// advances with NextResultSet for multi-statement batches.
 //
 // An empty [SQLRowsHooks] value advances past data rows without per-row decode when
 // WriteDataRow is nil (EXPLAIN / drain before stats). When WriteDataRow is set, the
 // GCV slice passed to it is reused each row — copy or format before returning if
 // the sink retains row data.
-//
-// # go-sql-spanner integration
-//
-// Option A (driver-agnostic): configure ExecOptions at query time, then pass
-// open [*sql.Rows] to [WriteRows] or [RunRows]:
-//
-//	opts := spannerdriver.ExecOptions{
-//	    DecodeOption:            spannerdriver.DecodeOptionProto,
-//	    ReturnResultSetMetadata: true,
-//	    ReturnResultSetStats:    false,
-//	}
-//	rows, err := db.QueryContext(ctx, q, opts)
-//	// ...
-//	result, err := dbsqlrows.WriteRows(rows, w, dbsqlrows.SQLRowsConfig{})
-//
-// Option B: nested module github.com/apstndb/spanvalue/dbsqlrows/gospanner provides
-// DefaultExecOptions and QueryExport for one-shot query → csv/jsonl export when
-// the app already depends on go-sql-spanner. It is a thin reference integration
-// (ExecOptions + QueryContext + [WriteRows]); root go.mod still has no go-sql-spanner.
-// Interactive shells, metadata-first batches, EXPLAIN, and per-query driver options
-// (QueryMode, DirectExecuteQuery) should use Option A with app-owned ExecOptions
-// instead — validated by [spannersh](https://github.com/apstndb/spannersh).
-//
-// # Stats: driver vs export
-//
-// A common REPL pattern: set ReturnResultSetStats true on the driver at
-// QueryContext, keep [SQLRowsConfig.ReadResultSetStats] false during csv/jsonl/table
-// export, then read the stats pseudo-row in application code after render. dbsqlrows
-// leaves the cursor on the data result set until export completes or
-// ReadResultSetStats is enabled.
-//
-// # Application patterns
-//
-// Metadata-first batch: [ReadMetadataAndAdvanceToData], render (table via
-// [RunRowsAtData] + hooks), then read stats from rows or set ReadResultSetStats.
-//
-// Table sink: [RunRowsAtData] with [SQLRowsHooks.WithPrepareMetadata],
-// [SQLRowsHooks.WithWriteDataRow], and [SQLRowsHooks.WithFinish] — apps own layout
-// libraries and cell formatting.
-//
-// csv/jsonl: [WriteRowsAtData] with [writer.DelimitedGCVExportOptions] or
-// [writer.JSONLGCVExportOptions] at writer construction.
-//
-// EXPLAIN / drain: [RunRowsAtData] with [NewSQLRowsHooks] and
-// SQLRowsConfig.WithReadResultSetStats(true).
 package dbsqlrows

--- a/dbsqlrows/export.go
+++ b/dbsqlrows/export.go
@@ -53,7 +53,8 @@ func (cfg SQLRowsConfig) WithReadResultSetStats(read bool) SQLRowsConfig {
 }
 
 // SQLRowsResult holds metadata and stats surfaced from driver pseudo result sets,
-// analogous to [writer.RowIteratorResult] for native iterators.
+// analogous to [github.com/apstndb/spanvalue/writer.RowIteratorResult] for
+// native iterators.
 // On error paths after metadata is known, Metadata and RowsRead reflect progress
 // at the abort point (same partial-result contract as writer row-iterator helpers).
 type SQLRowsResult struct {

--- a/dbsqlrows/hooks.go
+++ b/dbsqlrows/hooks.go
@@ -21,7 +21,8 @@ import (
 // optional stats consumption succeed; it is not called when PrepareMetadata or
 // WriteDataRow returns an error. The returned [SQLRowsResult] still carries
 // Metadata and RowsRead at the abort point (same partial-result contract as
-// [writer.RowIteratorHooks] and [writer.RunRowIterator]).
+// [github.com/apstndb/spanvalue/writer.RowIteratorHooks] and
+// [github.com/apstndb/spanvalue/writer.RunRowIterator]).
 type SQLRowsHooks struct {
 	PrepareMetadata func(*sppb.ResultSetMetadata) error
 	WriteDataRow    func([]spanner.GenericColumnValue) error


### PR DESCRIPTION
## What

Docs-only change; no behavior or API changes.

- **doc.go:** replace the three markdown tables (`writer vs dbsqlrows`, `API overview`, `Symmetry with writer`) with godoc bullet lists that render correctly on pkg.go.dev, preserving the same content.
- **doc.go, hooks.go, export.go:** replace every `[writer.X]` doc link with the full-import-path form `[github.com/apstndb/spanvalue/writer.X]`, which resolves even though dbsqlrows never imports writer. Also fix the never-resolvable `[writer.WriteGCVs]` (no such package-level function) to `[GCVStreamWriter.WriteGCVs]`.
- **Rebalance toward README** (matching the writer package split): move the `go-sql-spanner integration` (Option A/B incl. the ExecOptions snippet), `Stats: driver vs export`, and `Application patterns` sections from doc.go to `dbsqlrows/README.md`, converting their godoc-bracket references to pkg.go.dev links. The markdown inline `[spannersh](...)` link moved with them, so doc.go no longer contains markdown link syntax. godoc now links to the README the same way writer/doc.go does and keeps the API contract sections (paths, goals/non-goals, API overview, symmetry, partial-result and reused-slice contracts) self-sufficient.

No information was deleted, only relocated.

## Why

The published v0.7.0 dbsqlrows page on pkg.go.dev rendered broken: markdown tables showed as run-on plain text, `[writer.X]` links rendered as literal bracketed text (doc links only resolve for imported packages or full import paths), and the markdown inline spannersh link rendered literally. doc.go was also ~120 lines of REPL-pattern guidance while the README was 12 lines, the inverse of the writer package's godoc/README split.

Verified with `go doc ./dbsqlrows`, `go doc -all ./dbsqlrows` (no unresolvable bracketed references remain), and `make check` (vet, build, test, golangci-lint incl. godoclint) passing.

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
