### PR TITLE
dbsqlrows: align RowsRead with writer mirror and harden stats phase

### DIFF
--- a/dbsqlrows/doc.go
+++ b/dbsqlrows/doc.go
@@ -67,8 +67,8 @@
 // [SQLRowsResult] carries Metadata when known on error paths (partial-result contract
 // matching [writer.RowIteratorResult]). Stats are not consumed unless
 // [SQLRowsConfig.ReadResultSetStats] is true; the iterator then advances with
-// NextResultSet for multi-statement batches. [SQLRowsResult].RowsRead follows
-// [writer.RowIteratorResult] RowsRead semantics: it counts data rows for which
+// NextResultSet for multi-statement batches. [SQLRowsResult.RowsRead] follows
+// [github.com/apstndb/spanvalue/writer.RowIteratorResult] RowsRead semantics: it counts data rows for which
 // WriteDataRow returned nil and stays zero when WriteDataRow is nil, even though
 // rows are still drained.
 //

--- a/dbsqlrows/doc.go
+++ b/dbsqlrows/doc.go
@@ -67,10 +67,13 @@
 // [SQLRowsResult] carries Metadata when known on error paths (partial-result contract
 // matching [writer.RowIteratorResult]). Stats are not consumed unless
 // [SQLRowsConfig.ReadResultSetStats] is true; the iterator then advances with
-// NextResultSet for multi-statement batches.
+// NextResultSet for multi-statement batches. [SQLRowsResult].RowsRead follows
+// [writer.RowIteratorResult] RowsRead semantics: it counts data rows for which
+// WriteDataRow returned nil and stays zero when WriteDataRow is nil, even though
+// rows are still drained.
 //
 // An empty [SQLRowsHooks] value advances past data rows without per-row decode when
-// WriteDataRow is nil (EXPLAIN / drain before stats). When WriteDataRow is set, the
+// WriteDataRow is nil (EXPLAIN / drain before stats; RowsRead stays zero). When WriteDataRow is set, the
 // GCV slice passed to it is reused each row — copy or format before returning if
 // the sink retains row data.
 //
@@ -103,6 +106,13 @@
 // export, then read the stats pseudo-row in application code after render. dbsqlrows
 // leaves the cursor on the data result set until export completes or
 // ReadResultSetStats is enabled.
+//
+// [SQLRowsConfig.ReadResultSetStats] requires the driver to produce a stats
+// pseudo result set (ReturnResultSetStats: true at QueryContext); otherwise the
+// run fails with [ErrMissingStatsResultSet]. With driver stats disabled in a
+// multi-statement batch, NextResultSet would otherwise land on the next
+// statement's metadata result set and consume its pseudo-row before the scan
+// fails, corrupting the batch cursor position.
 //
 // # Application patterns
 //

--- a/dbsqlrows/export.go
+++ b/dbsqlrows/export.go
@@ -27,6 +27,11 @@ var (
 	ErrMissingDataResultSet = errors.New("missing data rows result set after metadata")
 	// ErrMissingStatsRow reports that the stats result set had no stats pseudo-row.
 	ErrMissingStatsRow = errors.New("missing result set stats row")
+	// ErrMissingStatsResultSet reports that NextResultSet did not advance to the
+	// stats result set when [SQLRowsConfig.ReadResultSetStats] was requested.
+	// This typically means the driver was not opened with ReturnResultSetStats
+	// enabled (see the precondition on [SQLRowsConfig.ReadResultSetStats]).
+	ErrMissingStatsResultSet = errors.New("missing result set stats result set")
 )
 
 // GCVStreamWriter is the subset of [github.com/apstndb/spanvalue/writer] types
@@ -43,6 +48,15 @@ type SQLRowsConfig struct {
 	// ReadResultSetStats, when true, advances past data rows to read the stats
 	// pseudo-row into [SQLRowsResult.Stats]. For [WriteRowsAtData] this field is
 	// consulted directly (default false). For [WriteRows] the same field applies.
+	//
+	// Precondition: the driver must produce a stats pseudo result set (for
+	// go-sql-spanner, open rows with ReturnResultSetStats: true). When no stats
+	// result set follows the data rows, the run fails with
+	// [ErrMissingStatsResultSet]. Note that in a multi-statement batch with
+	// driver stats disabled, NextResultSet can instead land on the next
+	// statement's metadata result set; the resulting scan error is reported only
+	// after that pseudo-row has been consumed, so the batch cursor position is
+	// not recoverable.
 	ReadResultSetStats bool
 }
 
@@ -56,6 +70,12 @@ func (cfg SQLRowsConfig) WithReadResultSetStats(read bool) SQLRowsConfig {
 // analogous to [writer.RowIteratorResult] for native iterators.
 // On error paths after metadata is known, Metadata and RowsRead reflect progress
 // at the abort point (same partial-result contract as writer row-iterator helpers).
+// Stats is also populated on the abort path when the stats pseudo-row was
+// already read but the trailing NextResultSet advance failed.
+//
+// RowsRead counts data rows for which [SQLRowsHooks].WriteDataRow returned nil.
+// It stays zero when WriteDataRow is nil (rows may still be drained), matching
+// [writer.RowIteratorResult] RowsRead semantics.
 type SQLRowsResult struct {
 	Metadata *sppb.ResultSetMetadata
 	Stats    *sppb.ResultSetStats
@@ -162,10 +182,13 @@ func runRows(fac rowsFacade, hooks SQLRowsHooks, run sqlRowsRunConfig) (*SQLRows
 
 	if run.readResultSetStats {
 		stats, err := readResultSetStats(fac)
+		// Populate Stats even on the abort path: when the stats pseudo-row was
+		// read but the trailing NextResultSet advance failed, the caller still
+		// gets the completed statement's stats (partial-result contract).
+		result.Stats = stats
 		if err != nil {
 			return abort(err)
 		}
-		result.Stats = stats
 	}
 
 	return finishRun(result, hooks)
@@ -185,8 +208,10 @@ func callPrepareMetadata(hooks SQLRowsHooks, md *sppb.ResultSetMetadata) error {
 
 func processDataRows(fac rowsFacade, hooks SQLRowsHooks, result *SQLRowsResult) error {
 	if hooks.WriteDataRow == nil {
+		// Drain without decoding. RowsRead stays zero so the count keeps the
+		// same meaning as writer.RowIteratorResult.RowsRead (rows written by
+		// the per-row callback), not rows merely consumed.
 		for fac.next() {
-			result.RowsRead++
 		}
 		return nil
 	}
@@ -209,12 +234,20 @@ func processDataRows(fac rowsFacade, hooks SQLRowsHooks, result *SQLRowsResult) 
 	return nil
 }
 
+// readResultSetStats advances to the stats result set, scans the stats
+// pseudo-row, and advances past it for multi-statement batches. When the scan
+// succeeded but the trailing NextResultSet advance fails, the scanned stats are
+// returned alongside the error so the caller can surface them at the abort
+// point.
 func readResultSetStats(fac rowsFacade) (*sppb.ResultSetStats, error) {
 	if !fac.nextResultSet() {
 		if err := fac.err(); err != nil {
 			return nil, err
 		}
-		return nil, nil
+		// No stats result set after the data rows: the driver was not opened
+		// with stats enabled. Fail loudly instead of silently returning nil
+		// stats (see SQLRowsConfig.ReadResultSetStats).
+		return nil, ErrMissingStatsResultSet
 	}
 	if !fac.next() {
 		if err := fac.err(); err != nil {
@@ -228,7 +261,7 @@ func readResultSetStats(fac rowsFacade) (*sppb.ResultSetStats, error) {
 	}
 	if !fac.nextResultSet() {
 		if err := fac.err(); err != nil {
-			return nil, err
+			return stats, err
 		}
 	}
 	return stats, nil

--- a/dbsqlrows/export.go
+++ b/dbsqlrows/export.go
@@ -75,7 +75,7 @@ func (cfg SQLRowsConfig) WithReadResultSetStats(read bool) SQLRowsConfig {
 //
 // RowsRead counts data rows for which [SQLRowsHooks].WriteDataRow returned nil.
 // It stays zero when WriteDataRow is nil (rows may still be drained), matching
-// [writer.RowIteratorResult] RowsRead semantics.
+// [github.com/apstndb/spanvalue/writer.RowIteratorResult] RowsRead semantics.
 type SQLRowsResult struct {
 	Metadata *sppb.ResultSetMetadata
 	Stats    *sppb.ResultSetStats

--- a/dbsqlrows/export_test.go
+++ b/dbsqlrows/export_test.go
@@ -536,8 +536,37 @@ func TestWriteRows_statsNextResultSetError(t *testing.T) {
 	if got.Metadata == nil {
 		t.Fatal("Metadata is nil on stats nextResultSet error")
 	}
+	// Stats were already scanned before the trailing NextResultSet advance
+	// failed; the partial result carries them at the abort point.
+	if diff := cmp.Diff(stats, got.Stats, protocmp.Transform()); diff != "" {
+		t.Fatalf("Stats mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWriteRows_missingStatsResultSet(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	stub := &stubSQLRows{
+		columns: []string{"id"},
+		resultSets: [][]stubRow{
+			{{values: []any{md}}},
+			nil,
+		},
+	}
+
+	got, err := runRowsWithGCVWriter(stub, &stubGCVWriter{}, sqlRowsRunConfig{
+		readMetadataPseudoRow: true,
+		readResultSetStats:    true,
+	})
+	if !errors.Is(err, ErrMissingStatsResultSet) {
+		t.Fatalf("error = %v, want ErrMissingStatsResultSet", err)
+	}
+	if got.Metadata == nil {
+		t.Fatal("Metadata is nil on missing stats result set")
+	}
 	if got.Stats != nil {
-		t.Fatalf("Stats = %v, want nil on error", got.Stats)
+		t.Fatalf("Stats = %v, want nil when no stats result set", got.Stats)
 	}
 }
 
@@ -913,11 +942,48 @@ func TestRunRowsAtData_emptyHooksDrainWithStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.RowsRead != 2 {
-		t.Fatalf("RowsRead = %d, want 2", got.RowsRead)
+	// Drained rows are not counted: RowsRead stays zero when WriteDataRow is
+	// nil, matching writer.RowIteratorResult.RowsRead semantics.
+	if got.RowsRead != 0 {
+		t.Fatalf("RowsRead = %d, want 0 for drained rows", got.RowsRead)
 	}
 	if diff := cmp.Diff(stats, got.Stats, protocmp.Transform()); diff != "" {
 		t.Fatalf("Stats mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRunRowsAtData_nilWriteDataRowKeepsRowsReadZero(t *testing.T) {
+	t.Parallel()
+
+	md := metadataWithNames("id")
+	stub := &stubSQLRows{
+		columns: []string{"id"},
+		resultSets: [][]stubRow{
+			{
+				{values: []any{gcvctor.Int64Value(1)}},
+				{values: []any{gcvctor.Int64Value(2)}},
+			},
+		},
+	}
+
+	var finishRowsRead int
+	hooks := NewSQLRowsHooks().WithFinish(func(res *SQLRowsResult) error {
+		finishRowsRead = res.RowsRead
+		return nil
+	})
+
+	got, err := runRows(stub, hooks, sqlRowsRunConfig{metadata: md})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RowsRead != 0 {
+		t.Fatalf("RowsRead = %d, want 0 when WriteDataRow is nil", got.RowsRead)
+	}
+	if finishRowsRead != 0 {
+		t.Fatalf("Finish saw RowsRead = %d, want 0", finishRowsRead)
+	}
+	if stub.row != 2 {
+		t.Fatalf("cursor row = %d, want 2 (rows drained)", stub.row)
 	}
 }
 

--- a/dbsqlrows/hooks.go
+++ b/dbsqlrows/hooks.go
@@ -11,7 +11,7 @@ import (
 //
 // An empty hooks value (from [NewSQLRowsHooks]) still advances past data rows
 // while WriteDataRow is nil (no per-row decode), but [SQLRowsResult.RowsRead]
-// stays zero for drained rows, matching [writer.RowIteratorResult] RowsRead
+// stays zero for drained rows, matching [github.com/apstndb/spanvalue/writer.RowIteratorResult] RowsRead
 // semantics. Use that to drain rows before reading stats (for example EXPLAIN
 // with [SQLRowsConfig.ReadResultSetStats]).
 //

--- a/dbsqlrows/hooks.go
+++ b/dbsqlrows/hooks.go
@@ -9,10 +9,11 @@ import (
 
 // SQLRowsHooks drives [RunRows] and [RunRowsAtData]. Nil function fields are skipped.
 //
-// An empty hooks value (from [NewSQLRowsHooks]) still advances past data rows and
-// increments [SQLRowsResult.RowsRead] while WriteDataRow is nil (no per-row decode).
-// Use that to drain rows before reading stats (for example EXPLAIN with
-// [SQLRowsConfig.ReadResultSetStats]).
+// An empty hooks value (from [NewSQLRowsHooks]) still advances past data rows
+// while WriteDataRow is nil (no per-row decode), but [SQLRowsResult.RowsRead]
+// stays zero for drained rows, matching [writer.RowIteratorResult] RowsRead
+// semantics. Use that to drain rows before reading stats (for example EXPLAIN
+// with [SQLRowsConfig.ReadResultSetStats]).
 //
 // PrepareMetadata runs once after metadata is known and before data rows are scanned.
 // WriteDataRow runs per data row when set. The []spanner.GenericColumnValue argument


### PR DESCRIPTION
## What

Two behavioral fixes in the experimental `dbsqlrows` package:

- **RowsRead drain semantics (#209):** when `SQLRowsHooks.WriteDataRow` is nil, data rows are still drained but `SQLRowsResult.RowsRead` now stays zero, matching `writer.RowIteratorResult.RowsRead` ("counts data rows for which hooks.WriteRow returned nil ... stays zero when WriteRow is nil"). No separate `RowsDrained` field is added.
- **Stats-phase edge cases (#210):**
  - New sentinel `ErrMissingStatsResultSet`: `readResultSetStats` no longer silently returns `(nil, nil)` when `ReadResultSetStats` is requested but no stats result set follows the data rows (driver opened without `ReturnResultSetStats: true`).
  - When the stats pseudo-row was scanned but the trailing `NextResultSet` advance fails, the scanned stats are returned alongside the error so `SQLRowsResult.Stats` is populated at the abort point.

## Why

- `RowsRead` shares a name with the writer mirror and is presented as its analogue in the doc.go symmetry table, but counted drained rows that writer does not — silently different numbers for callers porting between the two mirrors (the package's stated design goal).
- Silent nil stats hides a misconfiguration (export wants stats, driver stats disabled); in a multi-statement batch the same misconfiguration corrupts the batch cursor by consuming the next statement's metadata pseudo-row before the scan error surfaces. The sentinel makes the single-statement case detectable, and the doc now states the precondition and the batch consequence.
- Dropping already-scanned stats on a trailing advance error was inconsistent with the package's partial-result philosophy (Metadata and RowsRead are carried at the abort point).

## Behavior changes

- `SQLRowsResult.RowsRead` is 0 (was: drained row count) when `WriteDataRow` is nil.
- `ReadResultSetStats: true` with no stats result set now fails with `ErrMissingStatsResultSet` (was: success with `Stats == nil`).
- `SQLRowsResult.Stats` is populated on the abort path when the stats row was read but the post-stats `NextResultSet` advance fails (was: nil).
- Docs updated minimally and in scope: `SQLRowsConfig.ReadResultSetStats` precondition, `SQLRowsResult` partial-result contract, `SQLRowsHooks` drain note, doc.go symmetry section and "Stats: driver vs export" section.

## Tests

- `TestRunRowsAtData_nilWriteDataRowKeepsRowsReadZero` (new): drain keeps `RowsRead == 0`, cursor still advanced, `Finish` sees 0.
- `TestRunRowsAtData_emptyHooksDrainWithStats` (updated): `RowsRead` expectation 2 → 0.
- `TestWriteRows_missingStatsResultSet` (new): absent stats result set returns `ErrMissingStatsResultSet` with Metadata populated and Stats nil.
- `TestWriteRows_statsNextResultSetError` (updated): now pins `Stats` populated at the abort point instead of nil.
- `make check` passes; nested module `dbsqlrows/gospanner` tests pass.

Closes #209.
Closes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
