### PR TITLE
gcvctor: remaining constructor coverage gaps (Must* wrappers, PGOIDValue, UUID/JSON string inputs)

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -53,9 +53,11 @@
 // instead of panicking. The legacy [NumericValue] and [PGNumericValue] helpers keep their
 // original signatures and return typed SQL NULL values on nil input.
 //
-// [PGNumericValue] and [PGJSONBValue] build PostgreSQL-dialect annotated NUMERIC/JSON values
+// [PGNumericValue], [PGJSONBValue], and [PGOIDValue] build PostgreSQL-dialect annotated
+// NUMERIC/JSON/OID values
 // ([cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_NUMERIC],
-// [cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_JSONB]).
+// [cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_JSONB],
+// [cloud.google.com/go/spanner/apiv1/spannerpb.TypeAnnotationCode_PG_OID]).
 //
 // NUMERIC wire strings: [NumericValue] and [PGNumericValue] store Spanner-canonical decimals.
 // [StringBasedValueFromCode] does not normalize; callers that build NUMERIC cells by hand must
@@ -69,16 +71,19 @@
 //
 // # Test fixtures
 //
-// For nested ARRAY and STRUCT trees in tests, prefer [MustArrayValueOf], [MustStructValueOf],
-// [MustStructValueOfFields], and [MustNormalizeArrayElements] over local panic-on-error helpers.
+// For nested ARRAY and STRUCT trees in tests, prefer [MustArrayValue], [MustArrayValueOf],
+// [MustStructValueOf], [MustStructValueOfFields], and [MustNormalizeArrayElements] over local
+// panic-on-error helpers. For checked NUMERIC fixtures, [MustNumericValueChecked] and
+// [MustPGNumericValueChecked] panic on nil input instead of returning a typed NULL.
 // They wrap the error-returning constructors and are intended for schema-known fixture data, not production paths.
 //
 // String payloads: [StringBasedValueOf] and [StringBasedValueFromCode] store the wire string as-is
 // with no validation (no extra imports beyond typector). Use [StringBasedValueOf] when the Type
 // carries annotations (for example PG-dialect NUMERIC). When the test cares about canonical wire
 // form, use validated
-// helpers such as [DateStringValue] or the corresponding [MustDateStringValue], [MustTimestampStringValue],
-// [MustIntervalStringValue], and [MustJSONValue] for inline nesting. Typed Go inputs ([DateValue] with
+// helpers such as [DateStringValue], [UUIDStringValue], and [JSONStringValue], or the corresponding
+// [MustDateStringValue], [MustTimestampStringValue], [MustIntervalStringValue], [MustUUIDStringValue],
+// [MustJSONStringValue], and [MustJSONValue] for inline nesting. Typed Go inputs ([DateValue] with
 // [cloud.google.com/go/civil.Date], [TimestampValue] with [time.Time], and so on) avoid parse errors
 // when you already hold the native value.
 //

--- a/gcvctor/gcvctor.go
+++ b/gcvctor/gcvctor.go
@@ -36,6 +36,8 @@ var (
 	ErrNilFieldType = errors.New("gcvctor: nil struct field type")
 	// ErrNilNumeric is returned by [NumericValueChecked] and [PGNumericValueChecked] when v is nil.
 	ErrNilNumeric = errors.New("gcvctor: nil numeric input")
+	// ErrInvalidJSON is returned by [JSONStringValue] when v is not syntactically valid JSON.
+	ErrInvalidJSON = errors.New("gcvctor: invalid JSON input")
 )
 
 // ArrayElementError adds an element index to an ARRAY construction error while preserving
@@ -274,6 +276,20 @@ func UUIDValue(v uuid.UUID) spanner.GenericColumnValue {
 	return StringBasedValueFromCode(sppb.TypeCode_UUID, v.String())
 }
 
+// UUIDStringValue validates a UUID string via [github.com/google/uuid.Parse] and returns a
+// non-null UUID GenericColumnValue using the canonical lowercase wire string from
+// [github.com/google/uuid.UUID.String]. Non-canonical forms accepted by uuid.Parse
+// (uppercase hex digits, surrounding braces, a "urn:uuid:" prefix) are normalized to the
+// canonical lowercase 8-4-4-4-12 form on the wire, so the stored payload can differ from v.
+// Use [UUIDValue] when you already hold a [github.com/google/uuid.UUID].
+func UUIDStringValue(v string) (spanner.GenericColumnValue, error) {
+	u, err := uuid.Parse(v)
+	if err != nil {
+		return spanner.GenericColumnValue{}, err
+	}
+	return UUIDValue(u), nil
+}
+
 // JSONValue marshals v to JSON and returns a non-null JSON GenericColumnValue.
 func JSONValue(v any) (spanner.GenericColumnValue, error) {
 	s, err := jsonWireString(v)
@@ -281,6 +297,19 @@ func JSONValue(v any) (spanner.GenericColumnValue, error) {
 		return spanner.GenericColumnValue{}, err
 	}
 	return StringBasedValueFromCode(sppb.TypeCode_JSON, s), nil
+}
+
+// JSONStringValue validates that v is syntactically valid JSON ([encoding/json.Valid]) and
+// returns a non-null JSON GenericColumnValue with v stored as-is on the wire. It does not
+// normalize, compact, or re-marshal the payload, matching the package's wire-as-is convention
+// for string payloads (see [StringBasedValueFromCode]); whitespace and key order are preserved
+// exactly as given. Invalid JSON returns [ErrInvalidJSON]. Use [JSONValue] to marshal a Go
+// value to a canonical compact wire string instead.
+func JSONStringValue(v string) (spanner.GenericColumnValue, error) {
+	if !json.Valid([]byte(v)) {
+		return spanner.GenericColumnValue{}, ErrInvalidJSON
+	}
+	return StringBasedValueFromCode(sppb.TypeCode_JSON, v), nil
 }
 
 // PGNumericValue returns a PostgreSQL-dialect NUMERIC GenericColumnValue
@@ -303,6 +332,12 @@ func PGNumericValueChecked(v *big.Rat) (spanner.GenericColumnValue, error) {
 		return spanner.GenericColumnValue{}, ErrNilNumeric
 	}
 	return PGNumericValue(v), nil
+}
+
+// PGOIDValue returns a non-null PostgreSQL-dialect OID GenericColumnValue
+// ([sppb.TypeAnnotationCode_PG_OID]) with a decimal string wire payload like [Int64Value].
+func PGOIDValue(v int64) spanner.GenericColumnValue {
+	return StringBasedValueOf(typector.PGOID(), strconv.FormatInt(v, 10))
 }
 
 // PGJSONBValue marshals v to JSON and returns a non-null PostgreSQL-dialect JSON GenericColumnValue

--- a/gcvctor/gcvctor_test.go
+++ b/gcvctor/gcvctor_test.go
@@ -467,6 +467,81 @@ func TestValidatedStringValueHelpers(t *testing.T) {
 			call:    gcvctor.IntervalStringValue,
 			wantErr: true,
 		},
+		{
+			name:  "UUID valid canonical",
+			input: "0e0b9caa-3f06-4b75-9d97-fadcc9d4b3e1",
+			call:  gcvctor.UUIDStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_UUID),
+				Value: structpb.NewStringValue("0e0b9caa-3f06-4b75-9d97-fadcc9d4b3e1"),
+			},
+		},
+		{
+			name:  "UUID uppercase normalized to lowercase",
+			input: "0E0B9CAA-3F06-4B75-9D97-FADCC9D4B3E1",
+			call:  gcvctor.UUIDStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_UUID),
+				Value: structpb.NewStringValue("0e0b9caa-3f06-4b75-9d97-fadcc9d4b3e1"),
+			},
+		},
+		{
+			name:  "UUID braced normalized to canonical",
+			input: "{0e0b9caa-3f06-4b75-9d97-fadcc9d4b3e1}",
+			call:  gcvctor.UUIDStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_UUID),
+				Value: structpb.NewStringValue("0e0b9caa-3f06-4b75-9d97-fadcc9d4b3e1"),
+			},
+		},
+		{
+			name:    "UUID invalid wrong length",
+			input:   "0e0b9caa-3f06-4b75-9d97",
+			call:    gcvctor.UUIDStringValue,
+			wantErr: true,
+		},
+		{
+			name:    "UUID invalid bad characters",
+			input:   "0e0b9caa-3f06-4b75-9d97-fadcc9d4b3zz",
+			call:    gcvctor.UUIDStringValue,
+			wantErr: true,
+		},
+		{
+			name:    "UUID invalid empty",
+			input:   "",
+			call:    gcvctor.UUIDStringValue,
+			wantErr: true,
+		},
+		{
+			name:  "JSON valid object stored as-is without compaction",
+			input: `{"b": 1, "a": [true, null]}`,
+			call:  gcvctor.JSONStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+				Value: structpb.NewStringValue(`{"b": 1, "a": [true, null]}`),
+			},
+		},
+		{
+			name:  "JSON valid string scalar with HTML characters as-is",
+			input: `"<a>"`,
+			call:  gcvctor.JSONStringValue,
+			want: spanner.GenericColumnValue{
+				Type:  typector.CodeToSimpleType(sppb.TypeCode_JSON),
+				Value: structpb.NewStringValue(`"<a>"`),
+			},
+		},
+		{
+			name:    "JSON invalid truncated object",
+			input:   `{"a":`,
+			call:    gcvctor.JSONStringValue,
+			wantErr: true,
+		},
+		{
+			name:    "JSON invalid empty",
+			input:   "",
+			call:    gcvctor.JSONStringValue,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -484,6 +559,62 @@ func TestValidatedStringValueHelpers(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJSONStringValue_invalidReturnsErrInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	got, err := gcvctor.JSONStringValue(`{"a":`)
+	if !errors.Is(err, gcvctor.ErrInvalidJSON) {
+		t.Fatalf("error = %v, want ErrInvalidJSON", err)
+	}
+	if diff := cmp.Diff(spanner.GenericColumnValue{}, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("got non-zero value (-want +got):\n%s", diff)
+	}
+}
+
+func TestPGOIDValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  spanner.GenericColumnValue
+		want spanner.GenericColumnValue
+	}{
+		{
+			name: "positive",
+			got:  gcvctor.PGOIDValue(42),
+			want: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_INT64, TypeAnnotation: sppb.TypeAnnotationCode_PG_OID},
+				Value: structpb.NewStringValue("42"),
+			},
+		},
+		{
+			name: "zero",
+			got:  gcvctor.PGOIDValue(0),
+			want: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_INT64, TypeAnnotation: sppb.TypeAnnotationCode_PG_OID},
+				Value: structpb.NewStringValue("0"),
+			},
+		},
+		{
+			name: "negative",
+			got:  gcvctor.PGOIDValue(-1),
+			want: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_INT64, TypeAnnotation: sppb.TypeAnnotationCode_PG_OID},
+				Value: structpb.NewStringValue("-1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.got, protocmp.Transform()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/gcvctor/must.go
+++ b/gcvctor/must.go
@@ -1,9 +1,21 @@
 package gcvctor
 
 import (
+	"math/big"
+
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
+
+// MustArrayValue is like [ArrayValue] but panics on error.
+// Use only in tests and table-driven fixtures where schema and inputs are known good.
+func MustArrayValue(vs ...spanner.GenericColumnValue) spanner.GenericColumnValue {
+	gcv, err := ArrayValue(vs...)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
 
 // MustArrayValueOf is like [ArrayValueOf] but panics on error.
 // Use only in tests and table-driven fixtures where schema and inputs are known good.
@@ -70,6 +82,46 @@ func MustTimestampStringValue(v string) spanner.GenericColumnValue {
 // Use only in tests and table-driven fixtures where inputs are known good.
 func MustIntervalStringValue(v string) spanner.GenericColumnValue {
 	gcv, err := IntervalStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustUUIDStringValue is like [UUIDStringValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustUUIDStringValue(v string) spanner.GenericColumnValue {
+	gcv, err := UUIDStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustJSONStringValue is like [JSONStringValue] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustJSONStringValue(v string) spanner.GenericColumnValue {
+	gcv, err := JSONStringValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustNumericValueChecked is like [NumericValueChecked] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustNumericValueChecked(v *big.Rat) spanner.GenericColumnValue {
+	gcv, err := NumericValueChecked(v)
+	if err != nil {
+		panic(err)
+	}
+	return gcv
+}
+
+// MustPGNumericValueChecked is like [PGNumericValueChecked] but panics on error.
+// Use only in tests and table-driven fixtures where inputs are known good.
+func MustPGNumericValueChecked(v *big.Rat) spanner.GenericColumnValue {
+	gcv, err := PGNumericValueChecked(v)
 	if err != nil {
 		panic(err)
 	}

--- a/gcvctor/must_test.go
+++ b/gcvctor/must_test.go
@@ -2,6 +2,7 @@ package gcvctor_test
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -241,5 +242,151 @@ func TestMustStructValueOf_panicsPreserveErrMismatchedCounts(t *testing.T) {
 	}
 	if !errors.Is(err, gcvctor.ErrMismatchedCounts) {
 		t.Fatalf("panic = %v, want ErrMismatchedCounts", panicked)
+	}
+}
+
+func TestMustArrayValue_matchesArrayValue(t *testing.T) {
+	t.Parallel()
+
+	elems := []spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.Int64Value(2)}
+	want, err := gcvctor.ArrayValue(elems...)
+	if err != nil {
+		t.Fatalf("ArrayValue: %v", err)
+	}
+	got := gcvctor.MustArrayValue(elems...)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustArrayValue mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustArrayValue_panicsOnTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustArrayValue(gcvctor.Int64Value(1), gcvctor.StringValue("x"))
+	})
+}
+
+func TestMustNumericValueChecked_matchesNumericValueChecked(t *testing.T) {
+	t.Parallel()
+
+	v := big.NewRat(199, 2)
+	want, err := gcvctor.NumericValueChecked(v)
+	if err != nil {
+		t.Fatalf("NumericValueChecked: %v", err)
+	}
+	got := gcvctor.MustNumericValueChecked(v)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustNumericValueChecked mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustNumericValueChecked_panicsPreserveErrNilNumeric(t *testing.T) {
+	t.Parallel()
+
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		gcvctor.MustNumericValueChecked(nil)
+	}()
+	if panicked == nil {
+		t.Fatal("expected panic")
+	}
+	err, ok := panicked.(error)
+	if !ok {
+		t.Fatalf("panic value type = %T, want error", panicked)
+	}
+	if !errors.Is(err, gcvctor.ErrNilNumeric) {
+		t.Fatalf("panic = %v, want ErrNilNumeric", panicked)
+	}
+}
+
+func TestMustPGNumericValueChecked_matchesPGNumericValueChecked(t *testing.T) {
+	t.Parallel()
+
+	v := big.NewRat(199, 2)
+	want, err := gcvctor.PGNumericValueChecked(v)
+	if err != nil {
+		t.Fatalf("PGNumericValueChecked: %v", err)
+	}
+	got := gcvctor.MustPGNumericValueChecked(v)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustPGNumericValueChecked mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustPGNumericValueChecked_panicsPreserveErrNilNumeric(t *testing.T) {
+	t.Parallel()
+
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		gcvctor.MustPGNumericValueChecked(nil)
+	}()
+	if panicked == nil {
+		t.Fatal("expected panic")
+	}
+	err, ok := panicked.(error)
+	if !ok {
+		t.Fatalf("panic value type = %T, want error", panicked)
+	}
+	if !errors.Is(err, gcvctor.ErrNilNumeric) {
+		t.Fatalf("panic = %v, want ErrNilNumeric", panicked)
+	}
+}
+
+func TestMustUUIDStringValue_matchesUUIDStringValue(t *testing.T) {
+	t.Parallel()
+
+	const input = "0E0B9CAA-3F06-4B75-9D97-FADCC9D4B3E1"
+	want, err := gcvctor.UUIDStringValue(input)
+	if err != nil {
+		t.Fatalf("UUIDStringValue: %v", err)
+	}
+	got := gcvctor.MustUUIDStringValue(input)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustUUIDStringValue mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustUUIDStringValue_panicsOnInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	expectPanic(t, func() {
+		gcvctor.MustUUIDStringValue("not-a-uuid")
+	})
+}
+
+func TestMustJSONStringValue_matchesJSONStringValue(t *testing.T) {
+	t.Parallel()
+
+	const input = `{"b": 1, "a": [true, null]}`
+	want, err := gcvctor.JSONStringValue(input)
+	if err != nil {
+		t.Fatalf("JSONStringValue: %v", err)
+	}
+	got := gcvctor.MustJSONStringValue(input)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("MustJSONStringValue mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMustJSONStringValue_panicsPreserveErrInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		gcvctor.MustJSONStringValue(`{"a":`)
+	}()
+	if panicked == nil {
+		t.Fatal("expected panic")
+	}
+	err, ok := panicked.(error)
+	if !ok {
+		t.Fatalf("panic value type = %T, want error", panicked)
+	}
+	if !errors.Is(err, gcvctor.ErrInvalidJSON) {
+		t.Fatalf("panic = %v, want ErrInvalidJSON", panicked)
 	}
 }


### PR DESCRIPTION
## What

Completes the remainder of #207. Item 1 of the issue (the `FromNullable`/`FromPtr` family for NUMERIC/JSON/INTERVAL plus the `PGNumeric`/`PGJsonB` wrappers) already shipped in v0.7.2/v0.7.3 (#232/#236); this PR adds the remaining additive constructors in `gcvctor`:

- **Must\* coverage gaps** (`must.go`): `MustArrayValue` (wraps `ArrayValue`), `MustNumericValueChecked` (wraps `NumericValueChecked`), `MustPGNumericValueChecked` (wraps `PGNumericValueChecked`), following the existing fixture-only `Must<FuncName>` convention.
- **`PGOIDValue(v int64)`**: PostgreSQL-dialect PG.OID constructor using `typector.PGOID()` (exported by the pinned spantype v0.3.11) with a decimal-string wire payload like `Int64Value`.
- **Validated string-input helpers**:
  - `UUIDStringValue(s string)`: validates via `uuid.Parse` and stores the canonical lowercase `uuid.UUID.String()` wire form; non-canonical inputs accepted by `uuid.Parse` (uppercase hex, braces, `urn:uuid:` prefix) are normalized, as documented.
  - `JSONStringValue(s string)`: validates with `json.Valid` and stores the input string as-is on the wire (no re-marshaling, compaction, or normalization — matching the package's wire-as-is convention for NUMERIC/`StringBasedValueOf`). Invalid JSON returns the new sentinel `ErrInvalidJSON`.
  - Plus `MustUUIDStringValue` and `MustJSONStringValue`.
- `doc.go`: the Test fixtures and String payloads sections now list the new helpers, and the PG-dialect paragraph mentions `PGOIDValue`.

## Why

The constructor surface had systematic family gaps (issue #207): fixture code needed local `must()` helpers for type-inferred arrays and checked numerics, PG-dialect pipelines could not build PG.OID values without hand-assembling the GCV, and UUID/JSON had no validated string paths parallel to `DateStringValue`/`TimestampStringValue`/`IntervalStringValue`.

## Tests

- `TestValidatedStringValueHelpers` extended with UUID cases (canonical, uppercase-normalized, braced-normalized, wrong length, bad characters, empty) and JSON cases (object stored as-is without compaction, HTML characters preserved, truncated object, empty), with expected GCVs built from typector+structpb oracles.
- `TestPGOIDValue` (positive/zero/negative) with the expected annotated Type built directly from `sppb.Type` literals.
- `TestJSONStringValue_invalidReturnsErrInvalidJSON` for the sentinel.
- Must wrapper tests: match-the-wrapped-function checks plus panic tests preserving `ErrNilNumeric`/`ErrInvalidJSON` in the panic value.
- `make check` passes (fmt-check, vet, build, test, golangci-lint).

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
