### PR TITLE
protofmt: OnUnresolved handler for descriptor resolution failures

### DIFF
--- a/protofmt/doc.go
+++ b/protofmt/doc.go
@@ -15,4 +15,9 @@
 // To enable descriptor-aware display, clone an existing spanvalue format preset
 // and prepend [FormatProtoTextValue] and [FormatEnumNameValue] before the
 // preset's existing plugins. See the package examples for the minimal pattern.
+//
+// Resolution failures fall through to wire forms by default (base64 for PROTO,
+// numeric string for ENUM). Set [ProtoTextValueOptions.OnUnresolved] /
+// [EnumNameValueOptions.OnUnresolved] to observe such fallthroughs when a
+// resolver is configured, or to turn them into errors (strict mode).
 package protofmt

--- a/protofmt/example_test.go
+++ b/protofmt/example_test.go
@@ -3,6 +3,7 @@ package protofmt_test
 import (
 	"fmt"
 
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/apstndb/spanvalue/protofmt"
@@ -44,4 +45,34 @@ func Example_spannerCLICompatibleFormatConfigWithProto() {
 	fmt.Println(out)
 	// Output:
 	// TYPE_STRING
+}
+
+// Strict mode: when a resolver is configured but a non-NULL PROTO or ENUM
+// value cannot be resolved, a one-line OnUnresolved handler turns the silent
+// wire-form fallthrough into an error surfaced to the formatter caller.
+func ExampleProtoTextValueOptions_onUnresolved() {
+	// An empty resolver stands in for a misconfigured descriptor set (for
+	// example a missing import or a type FQN typo).
+	resolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	strict := func(typeFQN string, code sppb.TypeCode) error {
+		return fmt.Errorf("protofmt: unresolved %v type %q", code, typeFQN)
+	}
+
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: strict}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: strict}),
+		},
+		fc.FormatComplexPlugins...,
+	)
+
+	_, err = fc.FormatToplevelColumn(gcvctor.ProtoValue("example.music.SingerInfo", nil))
+	fmt.Println(err)
+	// Output:
+	// protofmt: unresolved PROTO type "example.music.SingerInfo"
 }

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -56,11 +56,38 @@ type ProtoTextValueOptions struct {
 	Resolver  ProtoEnumResolver
 	Unmarshal proto.UnmarshalOptions
 	Marshal   prototext.MarshalOptions
+
+	// OnUnresolved, when non-nil, is invoked before falling through when
+	// Resolver is non-nil but cannot resolve the message type of a non-NULL
+	// PROTO value with a non-empty type FQN (lookup returns exact
+	// [protoregistry.NotFound] or a nil type). If OnUnresolved returns a
+	// non-nil error, the plugin returns that error to the formatter caller;
+	// if it returns nil, the plugin falls through to wire-form output as
+	// usual. A nil OnUnresolved keeps the default lenient behavior.
+	//
+	// OnUnresolved is never invoked for nil resolvers, non-PROTO values,
+	// typed NULL values, empty type FQNs, or successful resolution. Returning
+	// an error from OnUnresolved is the strict-mode recipe; see the example.
+	OnUnresolved func(typeFQN string, code sppb.TypeCode) error
 }
 
 // EnumNameValueOptions configures [FormatEnumNameValue].
 type EnumNameValueOptions struct {
 	Resolver EnumResolver
+
+	// OnUnresolved, when non-nil, is invoked before falling through when
+	// Resolver is non-nil but cannot resolve the enum type of a non-NULL
+	// ENUM value with a non-empty type FQN (lookup returns exact
+	// [protoregistry.NotFound] or a nil type). If OnUnresolved returns a
+	// non-nil error, the plugin returns that error to the formatter caller;
+	// if it returns nil, the plugin falls through to wire-form output as
+	// usual. A nil OnUnresolved keeps the default lenient behavior.
+	//
+	// OnUnresolved is never invoked for nil resolvers, non-ENUM values,
+	// typed NULL values, empty type FQNs, or successful resolution. Returning
+	// an error from OnUnresolved is the strict-mode recipe; see
+	// [ProtoTextValueOptions.OnUnresolved] for the parallel PROTO option.
+	OnUnresolved func(typeFQN string, code sppb.TypeCode) error
 }
 
 // FormatProtoTextValue returns a spanvalue plugin that formats Spanner PROTO
@@ -72,6 +99,10 @@ type EnumNameValueOptions struct {
 // PROTO values return [spanvalue.Formatter.GetNullString] without consulting the resolver.
 // Malformed non-NULL wire payloads, base64 decode failures, unmarshal failures,
 // and marshal failures are returned as real errors.
+//
+// [ProtoTextValueOptions.OnUnresolved] optionally observes (and can turn into
+// errors) the missing-message-type fallthrough when a non-nil resolver is
+// configured.
 //
 // Protobuf text output is display-oriented and intentionally not stable. Tests
 // and callers must not depend on byte-for-byte stable output.
@@ -93,6 +124,7 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 	unmarshal.Resolver = resolver
 	marshal := opts.Marshal
 	marshal.Resolver = resolver
+	onUnresolved := opts.OnUnresolved
 
 	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 		if value.Type.GetCode() != sppb.TypeCode_PROTO {
@@ -108,13 +140,13 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 		}
 		messageType, err := resolver.FindMessageByName(typeName)
 		if isExactNotFound(err) {
-			return "", spanvalue.ErrFallthrough
+			return "", unresolvedFallthrough(onUnresolved, typeName, sppb.TypeCode_PROTO)
 		}
 		if err != nil {
 			return "", err
 		}
 		if messageType == nil {
-			return "", spanvalue.ErrFallthrough
+			return "", unresolvedFallthrough(onUnresolved, typeName, sppb.TypeCode_PROTO)
 		}
 
 		wire, err := stringWire(value, sppb.TypeCode_PROTO)
@@ -148,6 +180,10 @@ func FormatProtoTextValue(opts ProtoTextValueOptions) spanvalue.FormatComplexFun
 // values return [spanvalue.Formatter.GetNullString] without consulting the resolver. Known
 // enum types with unknown or out-of-range numeric values return the original
 // numeric string.
+//
+// [EnumNameValueOptions.OnUnresolved] optionally observes (and can turn into
+// errors) the missing-enum-type fallthrough when a non-nil resolver is
+// configured.
 func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc {
 	resolver := opts.Resolver
 	if isNilResolver(resolver) {
@@ -162,6 +198,7 @@ func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc 
 		}
 	}
 
+	onUnresolved := opts.OnUnresolved
 	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
 		if value.Type.GetCode() != sppb.TypeCode_ENUM {
 			return "", spanvalue.ErrFallthrough
@@ -176,13 +213,13 @@ func FormatEnumNameValue(opts EnumNameValueOptions) spanvalue.FormatComplexFunc 
 		}
 		enumType, err := resolver.FindEnumByName(typeName)
 		if isExactNotFound(err) {
-			return "", spanvalue.ErrFallthrough
+			return "", unresolvedFallthrough(onUnresolved, typeName, sppb.TypeCode_ENUM)
 		}
 		if err != nil {
 			return "", err
 		}
 		if enumType == nil {
-			return "", spanvalue.ErrFallthrough
+			return "", unresolvedFallthrough(onUnresolved, typeName, sppb.TypeCode_ENUM)
 		}
 
 		wire, err := stringWire(value, sppb.TypeCode_ENUM)
@@ -300,6 +337,18 @@ func stringWire(value spanner.GenericColumnValue, code sppb.TypeCode) (string, e
 		return "", fmt.Errorf("%w: %v value kind %T", spanvalue.ErrUnknownType, code, value.Value.GetKind())
 	}
 	return value.Value.GetStringValue(), nil
+}
+
+// unresolvedFallthrough reports a descriptor resolution failure to
+// onUnresolved when set and returns the error the plugin should surface: the
+// handler's non-nil error, or [spanvalue.ErrFallthrough] otherwise.
+func unresolvedFallthrough(onUnresolved func(typeFQN string, code sppb.TypeCode) error, typeName protoreflect.FullName, code sppb.TypeCode) error {
+	if onUnresolved != nil {
+		if err := onUnresolved(string(typeName), code); err != nil {
+			return err
+		}
+	}
+	return spanvalue.ErrFallthrough
 }
 
 func isExactNotFound(err error) bool {

--- a/protofmt/protofmt_test.go
+++ b/protofmt/protofmt_test.go
@@ -235,6 +235,277 @@ func TestFormatPlugins_fallthroughCases(t *testing.T) {
 	}
 }
 
+func TestFormatPlugins_onUnresolvedInvoked(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	nilTypeProtoResolver := fakeResolver{
+		findMessageByName: func(protoreflect.FullName) (protoreflect.MessageType, error) {
+			return nil, nil
+		},
+	}
+	nilTypeEnumResolver := fakeResolver{
+		findEnumByName: func(protoreflect.FullName) (protoreflect.EnumType, error) {
+			return nil, nil
+		},
+	}
+
+	tests := []struct {
+		name     string
+		plugin   func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc
+		gcv      spanner.GenericColumnValue
+		wantFQN  string
+		wantCode sppb.TypeCode
+	}{
+		{
+			name: "proto not found",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv:      gcvctor.ProtoValue("example.music.Missing", nil),
+			wantFQN:  "example.music.Missing",
+			wantCode: sppb.TypeCode_PROTO,
+		},
+		{
+			name: "proto nil message type from resolver",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: nilTypeProtoResolver, OnUnresolved: onUnresolved})
+			},
+			gcv:      gcvctor.ProtoValue(singerInfoFQN, nil),
+			wantFQN:  singerInfoFQN,
+			wantCode: sppb.TypeCode_PROTO,
+		},
+		{
+			name: "enum not found",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv:      gcvctor.EnumValue("example.music.Missing", 1),
+			wantFQN:  "example.music.Missing",
+			wantCode: sppb.TypeCode_ENUM,
+		},
+		{
+			name: "enum nil enum type from resolver",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: nilTypeEnumResolver, OnUnresolved: onUnresolved})
+			},
+			gcv:      gcvctor.EnumValue(genreFQN, 1),
+			wantFQN:  genreFQN,
+			wantCode: sppb.TypeCode_ENUM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls int
+			plugin := tt.plugin(func(typeFQN string, code sppb.TypeCode) error {
+				calls++
+				if typeFQN != tt.wantFQN {
+					t.Errorf("typeFQN = %q, want %q", typeFQN, tt.wantFQN)
+				}
+				if code != tt.wantCode {
+					t.Errorf("code = %v, want %v", code, tt.wantCode)
+				}
+				return nil
+			})
+
+			_, err := plugin(spanvalue.SpannerCLICompatibleFormatConfig(), tt.gcv, true)
+			if !errors.Is(err, spanvalue.ErrFallthrough) {
+				t.Fatalf("error = %v, want ErrFallthrough when handler returns nil", err)
+			}
+			if calls != 1 {
+				t.Fatalf("OnUnresolved calls = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestFormatPlugins_onUnresolvedNotInvoked(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	singerPayload := marshalProto(t, newSingerInfo(t, resolver, 1, "Alice", 1))
+
+	tests := []struct {
+		name            string
+		plugin          func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc
+		gcv             spanner.GenericColumnValue
+		wantFallthrough bool
+	}{
+		{
+			name: "proto nil resolver",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{OnUnresolved: onUnresolved})
+			},
+			gcv:             gcvctor.ProtoValue("example.music.Missing", nil),
+			wantFallthrough: true,
+		},
+		{
+			name: "proto typed null",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: gcvctor.NullOf(&sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: "example.music.Missing"}),
+		},
+		{
+			name: "proto empty fqn",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_PROTO},
+				Value: structpb.NewStringValue(""),
+			},
+			wantFallthrough: true,
+		},
+		{
+			name: "proto resolution succeeds",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: gcvctor.ProtoValue(singerInfoFQN, singerPayload),
+		},
+		{
+			name: "non-proto column",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv:             gcvctor.StringValue("plain"),
+			wantFallthrough: true,
+		},
+		{
+			name: "enum nil resolver",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{OnUnresolved: onUnresolved})
+			},
+			gcv:             gcvctor.EnumValue("example.music.Missing", 1),
+			wantFallthrough: true,
+		},
+		{
+			name: "enum typed null",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: gcvctor.NullOf(&sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: "example.music.Missing"}),
+		},
+		{
+			name: "enum empty fqn",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: spanner.GenericColumnValue{
+				Type:  &sppb.Type{Code: sppb.TypeCode_ENUM},
+				Value: structpb.NewStringValue("1"),
+			},
+			wantFallthrough: true,
+		},
+		{
+			name: "enum resolution succeeds",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv: gcvctor.EnumValue(genreFQN, 1),
+		},
+		{
+			name: "non-enum column",
+			plugin: func(onUnresolved func(string, sppb.TypeCode) error) spanvalue.FormatComplexFunc {
+				return protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved})
+			},
+			gcv:             gcvctor.StringValue("plain"),
+			wantFallthrough: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls int
+			plugin := tt.plugin(func(string, sppb.TypeCode) error {
+				calls++
+				return errors.New("OnUnresolved must not be invoked")
+			})
+
+			_, err := plugin(spanvalue.SpannerCLICompatibleFormatConfig(), tt.gcv, true)
+			if tt.wantFallthrough {
+				if !errors.Is(err, spanvalue.ErrFallthrough) {
+					t.Fatalf("error = %v, want ErrFallthrough", err)
+				}
+			} else if err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+			if calls != 0 {
+				t.Fatalf("OnUnresolved calls = %d, want 0", calls)
+			}
+		})
+	}
+}
+
+func TestFormatPlugins_onUnresolvedErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	sentinel := errors.New("strict: unresolved type")
+	onUnresolved := func(string, sppb.TypeCode) error { return sentinel }
+
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved}),
+		},
+		fc.FormatComplexPlugins...,
+	)
+
+	tests := []spanner.GenericColumnValue{
+		gcvctor.ProtoValue("example.music.Missing", nil),
+		gcvctor.EnumValue("example.music.Missing", 1),
+	}
+	for _, gcv := range tests {
+		_, err := fc.FormatToplevelColumn(gcv)
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("error = %v, want %v", err, sentinel)
+		}
+	}
+}
+
+func TestFormatPlugins_onUnresolvedNilResultKeepsWireOutput(t *testing.T) {
+	t.Parallel()
+
+	resolver := testResolver(t)
+	lenient := descriptorAwareConfig(resolver)
+
+	observing := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	onUnresolved := func(string, sppb.TypeCode) error { return nil }
+	observing.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{Resolver: resolver, OnUnresolved: onUnresolved}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver, OnUnresolved: onUnresolved}),
+		},
+		observing.FormatComplexPlugins...,
+	)
+
+	tests := []spanner.GenericColumnValue{
+		gcvctor.ProtoValue("example.music.Missing", []byte{0x08, 0x01}),
+		gcvctor.EnumValue("example.music.Missing", 1),
+	}
+	for _, gcv := range tests {
+		want, err := lenient.FormatToplevelColumn(gcv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := observing.FormatToplevelColumn(gcv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("got %q, want wire-form fallthrough %q", got, want)
+		}
+	}
+}
+
 func TestFormatPlugins_typedNullUsesFormatter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds an opt-in `OnUnresolved` callback to `protofmt.ProtoTextValueOptions` and `protofmt.EnumNameValueOptions`:

```go
OnUnresolved func(typeFQN string, code sppb.TypeCode) error
```

The handler is invoked only when all of the following hold:

- the resolver is non-nil,
- the value is non-NULL,
- the type FQN is non-empty, and
- lookup returns exact `protoregistry.NotFound` or a nil type.

If the handler returns a non-nil error, the plugin returns that error to the formatter caller; if it returns nil, the plugin falls through to wire-form output exactly as today. A nil handler is byte-for-byte current behavior.

The documented cases table is unchanged: nil/missing resolver, non-PROTO/ENUM columns, and empty FQNs still fall through; typed NULL still returns `GetNullString`; malformed wire / unmarshal / marshal failures are still real errors.

A runnable `ExampleProtoTextValueOptions_onUnresolved` documents the strict-mode recipe (one-line handler returning an error), and the package doc and both plugin docs mention the option.

## Why

`FormatProtoTextValue` and `FormatEnumNameValue` intentionally return `spanvalue.ErrFallthrough` when descriptor resolution fails, degrading to wire forms (base64 for PROTO, numeric string for ENUM). For integrators that do configure a descriptor set and expect PROTO/ENUM columns to decode, that silent fallthrough hides misconfiguration: a type FQN typo or a missing import in the descriptor bundle just produces base64 in some columns.

## Design

Issue #180 proposed either a strict bool or a handler. The handler form was chosen because it subsumes strict mode — `func(fqn string, code sppb.TypeCode) error { return fmt.Errorf(...) }` is strict mode in one line — while also letting integrators log-and-continue per column (return nil after recording the unresolved FQN), which a bool cannot express. The signature carries the type FQN and the type code so a shared handler can serve both plugins.

## Tests

- Handler invoked exactly once on not-found and on nil-type lookups, for both PROTO and ENUM, with the expected FQN and type code.
- Handler not invoked when the resolver is nil, the value is typed NULL, the FQN is empty, resolution succeeds, or the column is not PROTO/ENUM.
- Handler returning nil keeps wire-form fallthrough output identical to a config without a handler.
- Handler error propagates through `FormatToplevelColumn` (`errors.Is` against the sentinel).
- `make check` passes (fmt-check, vet, build, test, golangci-lint: 0 issues).

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
