### PR TITLE
spanvalue: split malformed-wire errors out of ErrUnknownType (ErrMalformedWire sentinel)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ PostgreSQL TypeAnnotation integration probes live in [**spanpg**](https://github
 ## gcvctor & errors (short)
 
 - `IsNull`: nil `Value` or protobuf `NullValue`. `NullOf` for typed NULL; empty `ArrayValue` = length 0, not NULL.
-- Strict `ArrayValue` / `StructValueOf`: `ErrTypeMismatch`, `ErrMismatchedCounts`, `ErrNilElementType`. Format: `ErrUnknownType`, `ErrMismatchedFields`.
+- Strict `ArrayValue` / `StructValueOf`: `ErrTypeMismatch`, `ErrMismatchedCounts`, `ErrNilElementType`. Format: `ErrUnknownType` (unsupported type code; coverage problem), `ErrMalformedWire` (known type, invalid wire payload or unexpected NULL at the wire validator; data problem—the two do not `errors.Is`-match each other), `ErrMismatchedFields`.
 - `Float32Value`/`Float64Value`: `NaN`/`±Inf` as strings (Spanner wire).
 - **Tests:** `t.Parallel()`, `cmp.Diff`, `protocmp.Transform()`. `gcvctor` tests: expected GCV via `typector`+`structpb`, not the helper under test. Keep attribution comments in `literal_test.go`, `spanner_cli_compatible_test.go`.
 

--- a/common.go
+++ b/common.go
@@ -16,9 +16,25 @@ import (
 )
 
 var (
-	ErrNilRow                     = errors.New("nil row")
-	ErrNilStructField             = errors.New("nil struct field descriptor")
-	ErrUnknownType                = errors.New("unknown type")
+	ErrNilRow         = errors.New("nil row")
+	ErrNilStructField = errors.New("nil struct field descriptor")
+	// ErrUnknownType is returned when a type code (or, on the Decode path, a Go
+	// value type) is not supported by the formatter. It signals a
+	// configuration/coverage problem: the value may become formattable by adding
+	// a [FormatComplexFunc] plugin or choosing a different preset. For known
+	// types whose wire payload is invalid, see [ErrMalformedWire].
+	ErrUnknownType = errors.New("unknown type")
+	// ErrMalformedWire is returned when the type code of a value is known but
+	// its wire payload does not match the encoding Spanner uses for that type —
+	// for example a BOOL whose [structpb.Value] kind is a string, a FLOAT64
+	// string other than "NaN"/"Infinity"/"-Infinity", or a NULL that
+	// unexpectedly reaches the scalar wire validator. Unlike [ErrUnknownType]
+	// (a configuration problem that a plugin or preset change can address),
+	// ErrMalformedWire means the [cloud.google.com/go/spanner.GenericColumnValue]
+	// itself is corrupt: consumers should treat it as a data problem and fail
+	// the export rather than reconfigure formatting. It does not match
+	// [ErrUnknownType] via [errors.Is].
+	ErrMalformedWire              = errors.New("malformed wire value")
 	ErrMismatchedFields           = errors.New("mismatched struct value/field count")
 	ErrUnexpectedComplexValueKind = errors.New("unexpected complex value kind")
 	ErrEmptyTypeFQN               = errors.New("empty type FQN")

--- a/common_test.go
+++ b/common_test.go
@@ -369,8 +369,11 @@ func TestFormatProtoEnumCastRejectsNonStringWire(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := LiteralFormatConfig().FormatToplevelColumn(tt.gcv)
-			if !errors.Is(err, ErrUnknownType) {
-				t.Fatalf("error = %v, want ErrUnknownType", err)
+			if !errors.Is(err, ErrMalformedWire) {
+				t.Fatalf("error = %v, want ErrMalformedWire", err)
+			}
+			if errors.Is(err, ErrUnknownType) {
+				t.Fatalf("error = %v, must not match ErrUnknownType", err)
 			}
 		})
 	}
@@ -387,5 +390,54 @@ func TestFormatEnumAsCastRejectsInvalidWirePayload(t *testing.T) {
 	_, err := LiteralFormatConfig().FormatToplevelColumn(gcv)
 	if err == nil {
 		t.Fatal("expected error for non-integer ENUM wire payload")
+	}
+}
+
+// TestErrMalformedWireClassification pins the split introduced for
+// https://github.com/apstndb/spanvalue/issues/216: a known type with an
+// invalid wire payload is ErrMalformedWire (and not ErrUnknownType), while a
+// genuinely unknown type code stays ErrUnknownType (and is not
+// ErrMalformedWire).
+func TestErrMalformedWireClassification(t *testing.T) {
+	t.Parallel()
+
+	malformedBool := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_BOOL),
+		Value: structpb.NewStringValue("true"),
+	}
+	unknownCode := spanner.GenericColumnValue{
+		Type:  &sppb.Type{Code: sppb.TypeCode(9999)},
+		Value: structpb.NewStringValue("whatever"),
+	}
+
+	configs := []struct {
+		name string
+		fc   *FormatConfig
+	}{
+		{name: "simple", fc: SimpleFormatConfig()},
+		{name: "literal", fc: LiteralFormatConfig()},
+		{name: "spanner cli compatible", fc: SpannerCLICompatibleFormatConfig()},
+	}
+
+	for _, tt := range configs {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tt.fc.FormatToplevelColumn(malformedBool)
+			if !errors.Is(err, ErrMalformedWire) {
+				t.Errorf("malformed BOOL wire: error = %v, want ErrMalformedWire", err)
+			}
+			if errors.Is(err, ErrUnknownType) {
+				t.Errorf("malformed BOOL wire: error = %v, must not match ErrUnknownType", err)
+			}
+
+			_, err = tt.fc.FormatToplevelColumn(unknownCode)
+			if !errors.Is(err, ErrUnknownType) {
+				t.Errorf("unknown type code: error = %v, want ErrUnknownType", err)
+			}
+			if errors.Is(err, ErrMalformedWire) {
+				t.Errorf("unknown type code: error = %v, must not match ErrMalformedWire", err)
+			}
+		})
 	}
 }

--- a/format_gcv_scalar.go
+++ b/format_gcv_scalar.go
@@ -317,10 +317,10 @@ func gcvFloat64(v *structpb.Value) (float64, error) {
 		case "-Infinity":
 			return math.Inf(-1), nil
 		default:
-			return 0, fmt.Errorf("%w: unexpected FLOAT64 string %q", ErrUnknownType, x.StringValue)
+			return 0, fmt.Errorf("%w: FLOAT64 unexpected float string %q", ErrMalformedWire, x.StringValue)
 		}
 	default:
-		return 0, fmt.Errorf("%w: FLOAT64 value kind %T", ErrUnknownType, v.GetKind())
+		return 0, fmt.Errorf("%w: FLOAT64 value kind %T", ErrMalformedWire, v.GetKind())
 	}
 }
 
@@ -338,10 +338,10 @@ func gcvFloat32(v *structpb.Value) (float32, error) {
 		case "-Infinity":
 			return float32(math.Inf(-1)), nil
 		default:
-			return 0, fmt.Errorf("%w: unexpected FLOAT32 string %q", ErrUnknownType, x.StringValue)
+			return 0, fmt.Errorf("%w: FLOAT32 unexpected float string %q", ErrMalformedWire, x.StringValue)
 		}
 	default:
-		return 0, fmt.Errorf("%w: FLOAT32 value kind %T", ErrUnknownType, v.GetKind())
+		return 0, fmt.Errorf("%w: FLOAT32 value kind %T", ErrMalformedWire, v.GetKind())
 	}
 }
 

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -25,11 +25,14 @@ func isScalarFastPathTypeCode(code sppb.TypeCode) bool {
 }
 
 func validateScalarWire(gcv spanner.GenericColumnValue) error {
+	// Callers handle NULL before validation, so NULL or a nil type reaching
+	// here means the GCV is structurally invalid, not an unsupported type:
+	// classify as ErrMalformedWire, not ErrUnknownType.
 	if IsNull(gcv) {
-		return fmt.Errorf("%w: null value", ErrUnknownType)
+		return fmt.Errorf("%w: %v unexpected null value", ErrMalformedWire, gcv.Type.GetCode())
 	}
 	if gcv.Type == nil {
-		return fmt.Errorf("%w: nil type", ErrUnknownType)
+		return fmt.Errorf("%w: nil type with value kind %T", ErrMalformedWire, gcv.Value.GetKind())
 	}
 	code := gcv.Type.GetCode()
 	switch code {
@@ -52,14 +55,14 @@ func validateScalarWire(gcv spanner.GenericColumnValue) error {
 
 func requireBoolWire(v *structpb.Value, code sppb.TypeCode) error {
 	if _, ok := v.GetKind().(*structpb.Value_BoolValue); !ok {
-		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+		return fmt.Errorf("%w: %v value kind %T", ErrMalformedWire, code, v.GetKind())
 	}
 	return nil
 }
 
 func requireStringWire(v *structpb.Value, code sppb.TypeCode) error {
 	if _, ok := v.GetKind().(*structpb.Value_StringValue); !ok {
-		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+		return fmt.Errorf("%w: %v value kind %T", ErrMalformedWire, code, v.GetKind())
 	}
 	return nil
 }
@@ -76,9 +79,9 @@ func validateFloatWire(v *structpb.Value, code sppb.TypeCode) error {
 		case "NaN", "Infinity", "-Infinity":
 			return nil
 		default:
-			return fmt.Errorf("%w: %v unexpected float string %q", ErrUnknownType, code, k.StringValue)
+			return fmt.Errorf("%w: %v unexpected float string %q", ErrMalformedWire, code, k.StringValue)
 		}
 	default:
-		return fmt.Errorf("%w: %v value kind %T", ErrUnknownType, code, v.GetKind())
+		return fmt.Errorf("%w: %v value kind %T", ErrMalformedWire, code, v.GetKind())
 	}
 }

--- a/format_gcv_scalar_wire.go
+++ b/format_gcv_scalar_wire.go
@@ -27,12 +27,14 @@ func isScalarFastPathTypeCode(code sppb.TypeCode) bool {
 func validateScalarWire(gcv spanner.GenericColumnValue) error {
 	// Callers handle NULL before validation, so NULL or a nil type reaching
 	// here means the GCV is structurally invalid, not an unsupported type:
-	// classify as ErrMalformedWire, not ErrUnknownType.
-	if IsNull(gcv) {
-		return fmt.Errorf("%w: %v unexpected null value", ErrMalformedWire, gcv.Type.GetCode())
-	}
+	// classify as ErrMalformedWire, not ErrUnknownType. The nil-type check
+	// runs first so a nil Type with a nil Value reports the missing type
+	// rather than a misleading TYPE_CODE_UNSPECIFIED null.
 	if gcv.Type == nil {
 		return fmt.Errorf("%w: nil type with value kind %T", ErrMalformedWire, gcv.Value.GetKind())
+	}
+	if IsNull(gcv) {
+		return fmt.Errorf("%w: %v unexpected null value", ErrMalformedWire, gcv.Type.GetCode())
 	}
 	code := gcv.Type.GetCode()
 	switch code {

--- a/protofmt/protofmt.go
+++ b/protofmt/protofmt.go
@@ -297,7 +297,7 @@ func find[T any](resolvers []ProtoEnumResolver, lookup func(ProtoEnumResolver) (
 
 func stringWire(value spanner.GenericColumnValue, code sppb.TypeCode) (string, error) {
 	if _, ok := value.Value.GetKind().(*structpb.Value_StringValue); !ok {
-		return "", fmt.Errorf("%w: %v value kind %T", spanvalue.ErrUnknownType, code, value.Value.GetKind())
+		return "", fmt.Errorf("%w: %v value kind %T", spanvalue.ErrMalformedWire, code, value.Value.GetKind())
 	}
 	return value.Value.GetStringValue(), nil
 }


### PR DESCRIPTION
## What

Introduces the exported sentinel `ErrMalformedWire` and reclassifies wire-payload validation errors away from `ErrUnknownType`. `ErrUnknownType` now covers only genuinely unsupported type codes (class 1); `ErrMalformedWire` covers malformed wire payloads (class 2) and NULL unexpectedly reaching the scalar wire validator (class 3). The two sentinels intentionally do not `errors.Is`-match each other.

Closes #216.

## Why

`errors.Is(err, ErrUnknownType)` could not distinguish "this type is not supported by the formatter" (a configuration/coverage problem; maybe add a plugin) from "this GCV is corrupt" (a data problem; fail the export). The `"unknown type:"` message prefix was also misleading for classes 2 and 3 — the type is perfectly known; the payload is wrong. Messages for reclassified sites now carry the type code and the offending wire kind under the `"malformed wire value:"` prefix.

## Reclassified sites (now wrap `ErrMalformedWire`)

- `format_gcv_scalar_wire.go` `validateScalarWire`: NULL reaching the validator (class 3; callers handle NULL first, so this means a structurally invalid GCV) — message now `"<code> unexpected null value"` instead of `"null value"`.
- `format_gcv_scalar_wire.go` `validateScalarWire`: nil `Type` with a non-null `Value` — judged a data problem (the GCV is structurally invalid; no plugin can fix it), so migrated alongside class 3 — message now `"nil type with value kind %T"`.
- `format_gcv_scalar_wire.go` `requireBoolWire`: BOOL with a non-`BoolValue` wire kind (e.g. the issue's `"BOOL value kind *structpb.Value_StringValue"`).
- `format_gcv_scalar_wire.go` `requireStringWire`: INT64/ENUM/STRING/BYTES/PROTO/TIMESTAMP/DATE/NUMERIC/INTERVAL/UUID/JSON with a non-`StringValue` wire kind. This also covers the v0.7.1 (#228) `FormatProtoAsCast`/`FormatEnumAsCast` wire-kind rejections, which call this helper — they are class 2 (PROTO/ENUM is a known type; the payload kind is wrong) and migrate with it.
- `format_gcv_scalar_wire.go` `validateFloatWire`: FLOAT32/FLOAT64 string other than `NaN`/`Infinity`/`-Infinity`, and non-number/non-string wire kinds.
- `format_gcv_scalar.go` `gcvFloat64` / `gcvFloat32`: the same float wire violations on the value-read path (messages now name the type code: `"FLOAT64 unexpected float string …"`).
- `protofmt/protofmt.go` `stringWire`: PROTO/ENUM display plugins rejecting non-string wire kinds (class 2).

Unchanged (still `ErrUnknownType`, class 1): `validateScalarWire`'s unknown-type-code default, the `formatGCVScalar{Simple,Literal,SpannerCLI}` defensive defaults, the Decode-path dispatch default in `common.go`, and `formatNullableValueLiteralWithQuote`'s unknown Go type rejection. Out of scope: `ENUM`/`INT64` `strconv.ParseInt` failures and base64 decode failures keep their plain wrapped errors (they never carried `ErrUnknownType`), and the JSON preset plugin validation gaps are tracked separately in #205, which will build on this sentinel.

## Behavior changes

- `errors.Is(err, ErrUnknownType)` no longer matches any of the reclassified sites above; use `errors.Is(err, ErrMalformedWire)` instead. Per the issue, this is treated as a plain behavioral fix — no combined wrap for compatibility.
- Error texts for those sites changed from the `"unknown type:"` prefix to `"malformed wire value:"` (type code and offending wire kind/string included).

## Tests

- New `TestErrMalformedWireClassification`: a BOOL with a string wire payload yields `ErrMalformedWire` (and not `ErrUnknownType`), and an unknown type code (9999) yields `ErrUnknownType` (and not `ErrMalformedWire`), across the Simple/Literal/SpannerCLI presets.
- `TestFormatProtoEnumCastRejectsNonStringWire` updated to assert `ErrMalformedWire` and explicitly assert the old sentinel no longer matches.
- `make check` (fmt-check, vet, build, test, golangci-lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
