### PR TITLE
writer: latch sticky write errors to enforce the discard-after-write-error contract

### DIFF
--- a/writer/README.md
+++ b/writer/README.md
@@ -6,7 +6,7 @@ Stream Cloud Spanner query results to **CSV**, **quoted TSV**, **JSONL**, or **S
 |--------|-------------|--------|
 | Delimited (CSV / TSV) | `NewCSVWriter`, `NewDelimitedWriter` | Uses `encoding/csv`; call `Flush` after the last row, or `WithFlushEachRow` for incremental output |
 | JSONL | `NewJSONLWriter` | `Flush` is a no-op |
-| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; empty table name rejected at construction; qualified names with empty segments on first write; discard writer after a write error |
+| SQL INSERT | `NewSQLInsertWriter` | `WithSQLBatchSize`, `WithSQLDialect`, `WithSQLInsertKind`; empty table name and out-of-range insert kind rejected at construction; qualified names with empty segments on first write; write errors are latched—discard the writer |
 
 **Write paths:** `WriteRow` (`*spanner.Row`), `WriteStructValues` (`[]*structpb.Value` with registered field types), `WriteGCVs` (pre-built `GenericColumnValue` slices), or per-call `WriteValues`. Use [`Writer`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#Writer) for row-only adapters; use [`FlushWriter`](https://pkg.go.dev/github.com/apstndb/spanvalue/writer#FlushWriter) when the adapter owns finalization.
 
@@ -144,7 +144,7 @@ Match out-of-band headers with [`spanvalue.ColumnNames`](https://pkg.go.dev/gith
 
 - **Duplicate column headers:** CSV/TSV header rows follow resolved [`spanvalue.ColumnNames`](https://pkg.go.dev/github.com/apstndb/spanvalue#ColumnNames) output, **including duplicate explicit aliases** (for example `SELECT 1 AS a, 2 AS a` → header `a,a`). RFC 4180 permits repeated header names; consumers that require unique headers must disambiguate in the application. JSONL object keys from duplicate aliases are a separate concern—see [`spanvalue.NewJSONObjectStructFormatter`](https://pkg.go.dev/github.com/apstndb/spanvalue#NewJSONObjectStructFormatter) and root JSON row docs for duplicate-key behavior.
 - **Quoted TSV:** `NewDelimitedWriter(out, '\t')` uses CSV escaping, not raw tab joins. Legacy raw TAB: implement `Writer` or `RowIteratorWriter` and join formatted columns with `'\t'`.
-- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name at construction (whitespace-only per strings.TrimSpace) and qualified names with empty segments on the first write. After any write error from `SQLInsertWriter`, discard the writer.
+- **SQL INSERT:** GoogleSQL quoting by default; `WithSQLDialect` for PostgreSQL identifiers. `NewSQLInsertWriter` rejects an empty table name at construction (whitespace-only per strings.TrimSpace), an out-of-range `SQLInsertKind` (`ErrInvalidSQLInsertKind`), and qualified names with empty segments on the first write. Each statement is emitted with a single `Write`; batched rows buffer until the multi-row statement completes. After any write error, all writers latch the first output failure—subsequent `Write*`/`Flush` calls return it; discard the writer (package doc "Write errors").
 - **Delimited vs JSONL vs SQL:** spanvalue formats each cell; encodings differ afterward. One-shot helpers: `FormatDelimitedRow`, `FormatJSONLRow`, `RowData`.
 
 ## Future module split

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -58,10 +58,24 @@
 // before the first Next registers an empty schema—use [RowIteratorWriter.PrepareRowType] after
 // the first Next or [WriteRowIterator] instead.
 //
+// # Write errors
+//
+// All three writers latch the first error caused by writing to the underlying
+// io.Writer (the [encoding/csv] Writer.Error pattern): after any Write* or
+// [Flusher.Flush] call fails with an output error, every subsequent Write* or
+// Flush call returns that first error and no further output is attempted.
+// Discard the writer after any write error. Validation errors reported before
+// output is attempted (for example [ErrMissingColumnNames] or
+// [ErrColumnNamesMismatch]) are not latched.
+//
 // # SQL INSERT
 //
 // [NewSQLInsertWriter] accepts [WithSQLInsertKind], [WithSQLDialect], and [WithSQLBatchSize].
-// It rejects an empty table name (after strings.TrimSpace) at construction with [ErrEmptyTableName]. Qualified names with empty segments are rejected on the first write with [ErrEmptyTableName].
-// After any write error from [SQLInsertWriter], discard the writer. [*SQLInsertWriter.Flush]
+// It rejects an empty table name (after strings.TrimSpace) at construction with [ErrEmptyTableName]
+// and an out-of-range [SQLInsertKind] with [ErrInvalidSQLInsertKind]. Qualified names with empty
+// segments are rejected on the first write with [ErrEmptyTableName].
+// Each statement is emitted with a single Write; batched rows are buffered until the multi-row
+// statement completes. After any write error from [SQLInsertWriter], discard the writer; later
+// calls return the latched error (see "Write errors"). [*SQLInsertWriter.Flush]
 // closes a partial batch when batching.
 package writer

--- a/writer/sticky_error_test.go
+++ b/writer/sticky_error_test.go
@@ -1,0 +1,191 @@
+package writer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/apstndb/spanvalue/gcvctor"
+)
+
+// errInjected is the sentinel returned by failNthWrite.
+var errInjected = errors.New("injected write failure")
+
+// failNthWrite is an io.Writer that fails the n-th Write call (1-based) with
+// errInjected, writing nothing for that call, and passes every other call
+// through to buf. It models a sink that fails once and then recovers, so tests
+// can prove that writers stay failed (sticky error) instead of resuming output.
+type failNthWrite struct {
+	buf   bytes.Buffer
+	n     int
+	calls int
+}
+
+func (w *failNthWrite) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls == w.n {
+		return 0, errInjected
+	}
+	return w.buf.Write(p)
+}
+
+// valuesFlushWriter is the common surface of the three writers used by the
+// sticky-error table test.
+type valuesFlushWriter interface {
+	WriteValues(columnNames []string, values []spanner.GenericColumnValue) error
+	Flush() error
+}
+
+func TestWritersStickyErrorAfterWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	columnNames := []string{"id"}
+	row := []spanner.GenericColumnValue{gcvctor.Int64Value(1)}
+
+	tests := []struct {
+		name  string
+		build func(out io.Writer) (valuesFlushWriter, error)
+	}{
+		{
+			name: "DelimitedWriter",
+			build: func(out io.Writer) (valuesFlushWriter, error) {
+				// WithFlushEachRow surfaces the I/O error on the failing row;
+				// WithHeader(false) makes the data row the first output write.
+				return NewDelimitedWriter(out, Comma, WithHeader(false), WithFlushEachRow())
+			},
+		},
+		{
+			name: "JSONLWriter",
+			build: func(out io.Writer) (valuesFlushWriter, error) {
+				return NewJSONLWriter(out)
+			},
+		},
+		{
+			name: "SQLInsertWriter",
+			build: func(out io.Writer) (valuesFlushWriter, error) {
+				return NewSQLInsertWriter(out, "users")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := &failNthWrite{n: 1}
+			w, err := tt.build(out)
+			if err != nil {
+				t.Fatalf("constructor error = %v", err)
+			}
+
+			if err := w.WriteValues(columnNames, row); !errors.Is(err, errInjected) {
+				t.Fatalf("first WriteValues() error = %v, want errInjected", err)
+			}
+			lenAfterFailure := out.buf.Len()
+
+			// The sink has recovered, but the writer must stay failed and must
+			// not write anything more.
+			if err := w.WriteValues(columnNames, row); !errors.Is(err, errInjected) {
+				t.Fatalf("WriteValues() after failure error = %v, want sticky errInjected", err)
+			}
+			if err := w.Flush(); !errors.Is(err, errInjected) {
+				t.Fatalf("Flush() after failure error = %v, want sticky errInjected", err)
+			}
+			if out.buf.Len() != lenAfterFailure {
+				t.Fatalf("output grew after write failure: %q", out.buf.String())
+			}
+		})
+	}
+}
+
+// TestSQLInsertWriterBatchedWriteFailureFlushRegression reproduces #204: with a
+// fail-then-recover sink, a write error inside a multi-row batch used to leave
+// a half-written tuple, and a later Flush appended ";\n" and returned nil,
+// ending the stream with invalid SQL under a success result. Now statements are
+// emitted whole and the error is latched: output contains only complete
+// statements and Flush returns the first error.
+func TestSQLInsertWriterBatchedWriteFailureFlushRegression(t *testing.T) {
+	t.Parallel()
+
+	out := &failNthWrite{n: 2}
+	w := mustNewSQLInsertWriter(t, out, "users", WithSQLBatchSize(2))
+	columnNames := []string{"id"}
+	row := func(id int64) []spanner.GenericColumnValue {
+		return []spanner.GenericColumnValue{gcvctor.Int64Value(id)}
+	}
+
+	// Rows 1-2 close the first batch on the size boundary: Write call 1 succeeds.
+	for id := int64(1); id <= 2; id++ {
+		if err := w.WriteValues(columnNames, row(id)); err != nil {
+			t.Fatalf("WriteValues(%d) error = %v", id, err)
+		}
+	}
+	// Row 3 buffers; row 4 closes the second batch: Write call 2 fails.
+	if err := w.WriteValues(columnNames, row(3)); err != nil {
+		t.Fatalf("WriteValues(3) error = %v", err)
+	}
+	if err := w.WriteValues(columnNames, row(4)); !errors.Is(err, errInjected) {
+		t.Fatalf("WriteValues(4) error = %v, want errInjected", err)
+	}
+
+	// Regression: Flush previously returned nil here and appended ";\n" after a
+	// half-written tuple. It must report the latched error and write nothing,
+	// even though the sink has recovered.
+	if err := w.Flush(); !errors.Is(err, errInjected) {
+		t.Fatalf("Flush() after batched write failure error = %v, want errInjected", err)
+	}
+	if err := w.WriteValues(columnNames, row(5)); !errors.Is(err, errInjected) {
+		t.Fatalf("WriteValues(5) error = %v, want sticky errInjected", err)
+	}
+
+	// Output stays whole-statement-granular: only the first complete statement.
+	want := "INSERT INTO `users` (`id`) VALUES\n  (1),\n  (2);\n"
+	if diff := cmp.Diff(want, out.buf.String()); diff != "" {
+		t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNewSQLInsertWriterRejectsOutOfRangeKind(t *testing.T) {
+	t.Parallel()
+
+	kinds := []SQLInsertKind{SQLInsertKind(-1), SQLInsertOrUpdate + 1, SQLInsertKind(99)}
+	for _, kind := range kinds {
+		t.Run(kind.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w, err := NewSQLInsertWriter(&out, "users", WithSQLInsertKind(kind))
+			if !errors.Is(err, ErrInvalidSQLInsertKind) {
+				t.Fatalf("NewSQLInsertWriter() error = %v, want ErrInvalidSQLInsertKind", err)
+			}
+			if w != nil {
+				t.Fatal("NewSQLInsertWriter() returned non-nil writer with invalid kind")
+			}
+		})
+	}
+}
+
+func TestDelimitedWriterFlushAfterLateHeaderEnable(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	w := mustNewCSVWriter(t, &out, WithHeader(false))
+	if err := w.WriteValues([]string{"name"}, []spanner.GenericColumnValue{gcvctor.StringValue("Alice")}); err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+
+	// The header opportunity has passed; Flush must not return
+	// ErrHeaderAfterData and must not strand the buffered row.
+	w.Header = true
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush() after late Header enable error = %v", err)
+	}
+	want := "Alice\n"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("CSV output mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -56,6 +56,10 @@ var (
 	// or INSERT OR UPDATE with a PostgreSQL dialect. Those prefixes are GoogleSQL-only; use plain
 	// [SQLInsert] with [WithSQLDialect](databasepb.DatabaseDialect_POSTGRESQL) instead.
 	ErrInvalidSQLInsertKindForDialect = errors.New("INSERT OR IGNORE/UPDATE not supported for PostgreSQL dialect")
+	// ErrInvalidSQLInsertKind reports that [WithSQLInsertKind] received a [SQLInsertKind]
+	// outside the defined constants ([SQLInsert], [SQLInsertOrIgnore], [SQLInsertOrUpdate]).
+	// [NewSQLInsertWriter] rejects such kinds at construction.
+	ErrInvalidSQLInsertKind = errors.New("invalid SQLInsertKind")
 	// ErrTableNameChangedMidBatch reports that the SQL INSERT table name was mutated while
 	// a multi-row INSERT batch was open.
 	ErrTableNameChangedMidBatch = errors.New("table name changed mid-batch")
@@ -85,6 +89,23 @@ type Flusher interface {
 type FlushWriter interface {
 	Writer
 	Flusher
+}
+
+// stickyWriteError latches the first output write failure so subsequent
+// Write*/Flush calls fail fast instead of corrupting the stream (the
+// [encoding/csv] Writer.Error pattern). Validation errors that occur before
+// output is attempted (for example [ErrMissingColumnNames]) are not latched.
+type stickyWriteError struct {
+	writeErr error
+}
+
+// latchWriteErr records err as the sticky write error if none is latched yet
+// and returns err unchanged.
+func (s *stickyWriteError) latchWriteErr(err error) error {
+	if err != nil && s.writeErr == nil {
+		s.writeErr = err
+	}
+	return err
 }
 
 // Option configures any writer type created by a writer constructor.
@@ -140,11 +161,13 @@ func (k SQLInsertKind) String() string {
 	case SQLInsertOrUpdate:
 		return "INSERT OR UPDATE"
 	default:
-		return "INSERT"
+		return fmt.Sprintf("SQLInsertKind(%d)", int(k))
 	}
 }
 
 // WithSQLInsertKind sets the INSERT statement variant for a [SQLInsertWriter].
+// Kinds outside the defined constants are rejected by [NewSQLInsertWriter]
+// with [ErrInvalidSQLInsertKind].
 func WithSQLInsertKind(kind SQLInsertKind) SQLInsertOption {
 	return sqlInsertKindOption{kind: kind}
 }
@@ -181,6 +204,8 @@ func (o sqlDialectOption) applySQLInsertOption(w *SQLInsertWriter) error {
 // WithSQLBatchSize sets how many rows [SQLInsertWriter] combines into one INSERT
 // statement. Values 0 or 1 keep the default of one row per statement. Values greater
 // than 1 emit multi-row INSERT ... VALUES (...), (...); up to n rows per statement.
+// Rows of a multi-row statement are buffered in memory and the completed statement is
+// emitted with a single Write, so an I/O failure never leaves a partially written tuple.
 // Call [SQLInsertWriter.Flush] after the final row to close a partial batch (Flush is
 // also safe when the last batch closed exactly on a size boundary).
 //
@@ -446,7 +471,10 @@ func (s *columnSchema) applyNamesOnly(names []string) {
 // DelimitedWriter writes rows as CSV-style delimited text. By default, call Flush after the
 // final write; [WithFlushEachRow] flushes encoding/csv after each data row instead.
 // Header controls automatic header output; see [WithHeader] and [DelimitedWriter.WriteHeader].
+// After the first output write failure, every later Write*/Flush call returns that error;
+// discard the writer (see package doc "Write errors").
 type DelimitedWriter struct {
+	stickyWriteError
 	formatter *spanvalue.FormatConfig
 	// Header enables a header line before the first data row when true (default).
 	// See [WithHeader].
@@ -565,6 +593,9 @@ func (w *DelimitedWriter) prepareColumnNames(names []string) error {
 // With no registered schema, it returns [ErrMissingColumnNames].
 // When [DelimitedWriter.Header] is true, [DelimitedWriter.Flush] also writes a pending header.
 func (w *DelimitedWriter) WriteHeader() error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if w.wroteHeader {
 		return nil
 	}
@@ -588,7 +619,7 @@ func (w *DelimitedWriter) WriteHeader() error {
 		return err
 	}
 	if err := csvWriter.Write(resolvedNames); err != nil {
-		return err
+		return w.latchWriteErr(err)
 	}
 	w.wroteHeader = true
 	return nil
@@ -596,6 +627,9 @@ func (w *DelimitedWriter) WriteHeader() error {
 
 // WriteValues writes one row from column names and GCVs.
 func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
 	}
@@ -604,6 +638,9 @@ func (w *DelimitedWriter) WriteValues(columnNames []string, values []spanner.Gen
 
 // WriteGCVs writes one row from GCVs; see package doc "Column names and field types".
 func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	csvWriter, err := w.csvWriter()
 	if err != nil {
 		return err
@@ -630,12 +667,12 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 	}
 
 	if err := csvWriter.Write(formattedValues); err != nil {
-		return err
+		return w.latchWriteErr(err)
 	}
 	w.wroteData = true
 	if w.flushEachRow {
 		csvWriter.Flush()
-		return csvWriter.Error()
+		return w.latchWriteErr(csvWriter.Error())
 	}
 	return nil
 }
@@ -643,6 +680,9 @@ func (w *DelimitedWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 // WriteStructValues writes one row from []*structpb.Value; see package doc
 // "Column names and field types".
 func (w *DelimitedWriter) WriteStructValues(values []*structpb.Value) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
@@ -718,13 +758,20 @@ func validDelimiter(delimiter rune) bool {
 }
 
 // Flush flushes buffered delimited data to the underlying writer. When [DelimitedWriter.Header]
-// is true, a schema is registered, len(column names) > 0, and no header was written yet,
-// Flush writes the header first (including zero-row SELECT exports). With a registered
-// zero-column schema, Flush succeeds without writing. With no registered schema and
-// [DelimitedWriter.Header] true, Flush returns [ErrMissingColumnNames]. Flush does not close
-// the underlying writer.
+// is true, a schema is registered, len(column names) > 0, no header was written yet, and no
+// data row was written yet, Flush writes the header first (including zero-row SELECT exports).
+// When data rows were already written without a header (for example [DelimitedWriter.Header]
+// was enabled only after the first row), the header opportunity has passed: Flush skips the
+// header and still flushes buffered rows. With a registered zero-column schema, Flush succeeds
+// without writing. With no registered schema, no written data, and [DelimitedWriter.Header]
+// true, Flush returns [ErrMissingColumnNames]. After a write failure, Flush returns the latched
+// error without flushing (see package doc "Write errors"). Flush does not close the underlying
+// writer.
 func (w *DelimitedWriter) Flush() error {
-	if w.Header && !w.wroteHeader {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	if w.Header && !w.wroteHeader && !w.wroteData {
 		if !w.schema.registered {
 			return ErrMissingColumnNames
 		}
@@ -736,7 +783,7 @@ func (w *DelimitedWriter) Flush() error {
 		return nil
 	}
 	w.writer.Flush()
-	return w.writer.Error()
+	return w.latchWriteErr(w.writer.Error())
 }
 
 func (w *DelimitedWriter) resolvedNames() ([]string, error) {
@@ -755,7 +802,10 @@ func (w *DelimitedWriter) resolvedNames() ([]string, error) {
 }
 
 // JSONLWriter streams one JSON object per line using [github.com/apstndb/spanvalue] JSON formatting.
+// After the first output write failure, every later Write*/Flush call returns that error;
+// discard the writer (see package doc "Write errors").
 type JSONLWriter struct {
+	stickyWriteError
 	formatter *spanvalue.FormatConfig
 	// Set before the first write. Once names have been resolved for the current
 	// schema, later changes do not retroactively rewrite cached object keys.
@@ -847,6 +897,9 @@ func (w *JSONLWriter) prepareColumnNames(names []string) error {
 
 // WriteValues writes one row; see [DelimitedWriter.WriteValues].
 func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if err := w.initOrValidateColumnNames(columnNames); err != nil {
 		return err
 	}
@@ -855,6 +908,9 @@ func (w *JSONLWriter) WriteValues(columnNames []string, values []spanner.Generic
 
 // WriteStructValues writes one row; see [DelimitedWriter.WriteStructValues].
 func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
@@ -864,6 +920,9 @@ func (w *JSONLWriter) WriteStructValues(values []*structpb.Value) error {
 
 // WriteGCVs writes one row; see [DelimitedWriter.WriteGCVs].
 func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if w.out == nil {
 		return ErrNilOutputWriter
 	}
@@ -893,12 +952,13 @@ func (w *JSONLWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 		return err
 	}
 	_, err = fmt.Fprintln(w.out, s)
-	return err
+	return w.latchWriteErr(err)
 }
 
-// Flush finalizes JSONL output. JSONLWriter is unbuffered, so this is a no-op.
+// Flush finalizes JSONL output. JSONLWriter is unbuffered, so this writes nothing;
+// after a write failure it returns the latched error (see package doc "Write errors").
 func (w *JSONLWriter) Flush() error {
-	return nil
+	return w.writeErr
 }
 
 func (w *JSONLWriter) setRowType(rowType *sppb.StructType) {
@@ -973,11 +1033,14 @@ func (w *JSONLWriter) marshalResolvedNames(resolvedNames []string) ([][]byte, er
 }
 
 // SQLInsertWriter streams INSERT (or INSERT OR …) statements with dialect-aware identifier
-// quoting for a fixed table. After any error from [*SQLInsertWriter.WriteRow],
-// [*SQLInsertWriter.WriteGCVs], [*SQLInsertWriter.WriteValues], or
-// [*SQLInsertWriter.WriteStructValues], discard the writer; partial batched INSERT output
-// may be unrecoverable on retry.
+// quoting for a fixed table. Each statement is built in memory and emitted with a single
+// Write, so an I/O failure never leaves a partially written statement appended to by later
+// calls. After any write error from [*SQLInsertWriter.WriteRow], [*SQLInsertWriter.WriteGCVs],
+// [*SQLInsertWriter.WriteValues], [*SQLInsertWriter.WriteStructValues], or
+// [*SQLInsertWriter.Flush], every later Write*/Flush call returns that first error; discard
+// the writer (see package doc "Write errors").
 type SQLInsertWriter struct {
+	stickyWriteError
 	table     string
 	formatter *spanvalue.FormatConfig
 
@@ -985,6 +1048,7 @@ type SQLInsertWriter struct {
 	sqlDialect        databasepb.DatabaseDialect
 	batchSize         int
 	batchPending      int
+	batch             strings.Builder
 	schema            columnSchema
 	quotedColumnNames string
 	quotedTable       string
@@ -1110,6 +1174,9 @@ func (w *SQLInsertWriter) prepareColumnNames(names []string) error {
 }
 
 func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	quotedColumns, err := w.initOrValidateQuotedColumns(columnNames)
 	if err != nil {
 		return err
@@ -1120,6 +1187,9 @@ func (w *SQLInsertWriter) WriteValues(columnNames []string, values []spanner.Gen
 // WriteStructValues writes one row from structpb values using the field-type schema
 // registered by [WithRowType], [WithMetadata], or [*SQLInsertWriter.PrepareRowType].
 func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	gcvs, err := gcvsFromStructValues(w.schema.types, values)
 	if err != nil {
 		return err
@@ -1128,6 +1198,9 @@ func (w *SQLInsertWriter) WriteStructValues(values []*structpb.Value) error {
 }
 
 func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if !w.schema.registered {
 		return ErrMissingColumnNames
 	}
@@ -1143,21 +1216,30 @@ func (w *SQLInsertWriter) WriteGCVs(values []spanner.GenericColumnValue) error {
 
 // Flush finalizes a partial multi-row INSERT batch started by [WithSQLBatchSize].
 // When batch size is 0 or 1, or when the last batch closed on a size boundary,
-// Flush is a no-op. Flush is safe to call unconditionally after the final row.
+// Flush is a no-op. Flush is safe to call unconditionally after the final row:
+// after a write failure it returns the latched error without writing (see
+// package doc "Write errors").
 func (w *SQLInsertWriter) Flush() error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
 	if w.sqlBatchSize() <= 1 || w.batchPending == 0 {
 		return nil
 	}
 	return w.closePendingBatch()
 }
 
+// closePendingBatch terminates the buffered multi-row statement and emits it
+// with a single Write so output stays whole-statement-granular on I/O failure.
 func (w *SQLInsertWriter) closePendingBatch() error {
 	if w.batchPending == 0 {
 		return nil
 	}
-	if _, err := io.WriteString(w.out, ";\n"); err != nil {
-		return err
+	w.batch.WriteString(";\n")
+	if _, err := io.WriteString(w.out, w.batch.String()); err != nil {
+		return w.latchWriteErr(err)
 	}
+	w.batch.Reset()
 	w.batchPending = 0
 	return nil
 }
@@ -1170,6 +1252,11 @@ func (w *SQLInsertWriter) sqlBatchSize() int {
 }
 
 func (w *SQLInsertWriter) validateSQLInsertConfig() error {
+	switch w.insertKind {
+	case SQLInsert, SQLInsertOrIgnore, SQLInsertOrUpdate:
+	default:
+		return fmt.Errorf("%w: %d", ErrInvalidSQLInsertKind, int(w.insertKind))
+	}
 	if w.sqlDialect != databasepb.DatabaseDialect_POSTGRESQL {
 		return nil
 	}
@@ -1201,20 +1288,24 @@ func (w *SQLInsertWriter) writeGCVs(values []spanner.GenericColumnValue, quotedC
 	return w.appendBatchedInsert(quotedColumns, formattedValues)
 }
 
+// writeSingleInsert builds the whole statement in memory and emits it with a
+// single Write so an I/O failure never leaves a partially written statement.
 func (w *SQLInsertWriter) writeSingleInsert(quotedColumns string, formattedValues []string) error {
 	quotedTable, err := w.quotedQualifiedTable()
 	if err != nil {
 		return err
 	}
-	prefix := w.insertKind.String()
-	if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES (", prefix, quotedTable, quotedColumns); err != nil {
-		return err
-	}
-	if err := w.writeFormattedValues(formattedValues); err != nil {
-		return err
-	}
-	_, err = io.WriteString(w.out, ");\n")
-	return err
+	var b strings.Builder
+	b.WriteString(w.insertKind.String())
+	b.WriteString(" INTO ")
+	b.WriteString(quotedTable)
+	b.WriteString(" (")
+	b.WriteString(quotedColumns)
+	b.WriteString(") VALUES (")
+	appendFormattedValues(&b, formattedValues)
+	b.WriteString(");\n")
+	_, err = io.WriteString(w.out, b.String())
+	return w.latchWriteErr(err)
 }
 
 func (w *SQLInsertWriter) rejectTableChangeMidBatch() error {
@@ -1224,6 +1315,9 @@ func (w *SQLInsertWriter) rejectTableChangeMidBatch() error {
 	return fmt.Errorf("%w: %q to %q", ErrTableNameChangedMidBatch, w.quotedTableInput, w.table)
 }
 
+// appendBatchedInsert buffers the row into the pending multi-row statement.
+// No output is written until the statement completes (size boundary or Flush),
+// keeping I/O failures whole-statement-granular; see closePendingBatch.
 func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedValues []string) error {
 	if err := w.rejectTableChangeMidBatch(); err != nil {
 		return err
@@ -1233,19 +1327,18 @@ func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedVal
 		if err != nil {
 			return err
 		}
-		prefix := w.insertKind.String()
-		if _, err := fmt.Fprintf(w.out, "%s INTO %s (%s) VALUES\n  (", prefix, quotedTable, quotedColumns); err != nil {
-			return err
-		}
-	} else if _, err := io.WriteString(w.out, ",\n  ("); err != nil {
-		return err
+		w.batch.Reset()
+		w.batch.WriteString(w.insertKind.String())
+		w.batch.WriteString(" INTO ")
+		w.batch.WriteString(quotedTable)
+		w.batch.WriteString(" (")
+		w.batch.WriteString(quotedColumns)
+		w.batch.WriteString(") VALUES\n  (")
+	} else {
+		w.batch.WriteString(",\n  (")
 	}
-	if err := w.writeFormattedValues(formattedValues); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w.out, ")"); err != nil {
-		return err
-	}
+	appendFormattedValues(&w.batch, formattedValues)
+	w.batch.WriteString(")")
 	w.batchPending++
 	if w.batchPending >= w.sqlBatchSize() {
 		return w.closePendingBatch()
@@ -1253,18 +1346,14 @@ func (w *SQLInsertWriter) appendBatchedInsert(quotedColumns string, formattedVal
 	return nil
 }
 
-func (w *SQLInsertWriter) writeFormattedValues(formattedValues []string) error {
+// appendFormattedValues appends comma-separated value literals to b.
+func appendFormattedValues(b *strings.Builder, formattedValues []string) {
 	for i, val := range formattedValues {
 		if i > 0 {
-			if _, err := io.WriteString(w.out, ", "); err != nil {
-				return err
-			}
+			b.WriteString(", ")
 		}
-		if _, err := io.WriteString(w.out, val); err != nil {
-			return err
-		}
+		b.WriteString(val)
 	}
-	return nil
 }
 
 func (w *SQLInsertWriter) setRowType(rowType *sppb.StructType) {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -958,13 +958,12 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 				t.Fatalf("WriteValues() error = %v", err)
 			}
 		}
-		// Intentionally no Flush(): the third row leaves a partial batch without a trailing semicolon.
+		// Intentionally no Flush(): the third row stays buffered in the partial
+		// batch and is not emitted (statements are written whole; see #204).
 		want := "" +
 			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
 			"  (1, \"a\"),\n" +
-			"  (2, \"b\");\n" +
-			"INSERT INTO `users` (`id`, `name`) VALUES\n" +
-			"  (3, \"c\")"
+			"  (2, \"b\");\n"
 		if diff := cmp.Diff(want, out.String()); diff != "" {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}
@@ -1022,12 +1021,15 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		if err := w.WriteValues(columnNames, row(3, "c")); err != nil {
 			t.Fatalf("WriteValues() after table change error = %v", err)
 		}
+		if err := w.Flush(); err != nil {
+			t.Fatalf("Flush() error = %v", err)
+		}
 		want := "" +
 			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
 			"  (1, \"a\"),\n" +
 			"  (2, \"b\");\n" +
 			"INSERT INTO `archive`.`users` (`id`, `name`) VALUES\n" +
-			"  (3, \"c\")"
+			"  (3, \"c\");\n"
 		if diff := cmp.Diff(want, out.String()); diff != "" {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}
@@ -1047,9 +1049,18 @@ func TestSQLInsertWriterBatchSize(t *testing.T) {
 		if !errors.Is(err, ErrTableNameChangedMidBatch) {
 			t.Fatalf("WriteValues() after table change error = %v, want ErrTableNameChangedMidBatch", err)
 		}
+		// The rejected row was never buffered, so nothing was emitted yet.
+		if got := out.String(); got != "" {
+			t.Fatalf("output before Flush = %q, want empty", got)
+		}
+		// Validation errors are not latched: Flush still emits the pending batch
+		// for the table captured at batch start.
+		if err := w.Flush(); err != nil {
+			t.Fatalf("Flush() error = %v", err)
+		}
 		want := "" +
 			"INSERT INTO `db`.`users` (`id`, `name`) VALUES\n" +
-			"  (1, \"a\")"
+			"  (1, \"a\");\n"
 		if diff := cmp.Diff(want, out.String()); diff != "" {
 			t.Fatalf("SQL output mismatch (-want +got):\n%s", diff)
 		}


### PR DESCRIPTION
## What

Hardens the three `writer` package writers (`SQLInsertWriter`, `DelimitedWriter`, `JSONLWriter`) against silent output corruption after write errors:

- **Sticky error:** all three writers latch the first output write failure; every subsequent `Write*`/`Flush` call returns that first error (the `csv.Writer.Error` pattern). Validation errors reported before output is attempted (for example `ErrMissingColumnNames`, `ErrColumnNamesMismatch`, `ErrTableNameChangedMidBatch`) are not latched.
- **Whole-statement SQL emission:** each SQL INSERT statement is built in a `strings.Builder` and emitted with a single `Write`. Batched rows buffer in memory until the multi-row statement completes (size boundary or `Flush`), so an I/O failure is whole-statement-granular.
- **Out-of-range `SQLInsertKind`:** `NewSQLInsertWriter` rejects kinds outside the defined constants with the new `ErrInvalidSQLInsertKind`. `SQLInsertKind.String` no longer silently maps unknown kinds to `"INSERT"` (it now returns `SQLInsertKind(%d)`).
- **`DelimitedWriter.Flush` after late `Header = true`:** when data rows were already written, `Flush` skips the header attempt (the header opportunity has passed) instead of returning `ErrHeaderAfterData` and stranding buffered rows. The `Header` field stays exported (unexporting is tracked in #221). A direct `WriteHeader` call after data still returns `ErrHeaderAfterData`.

## Why

The package documented "after any write error, discard the writer", but nothing enforced it. Reproduced failure mode (#204): with a fail-then-recover `io.Writer`, a mid-tuple write error inside a multi-row batch left dangling output, and a later `Flush` appended `";\n"` and returned **nil** — invalid SQL under a success exit code. The smaller items are the same theme: invalid states accepted silently (typo'd `SQLInsertKind` emitting plain `INSERT`, late `Header` mutation stranding buffered rows).

## Behavior changes

- After any output write failure, subsequent `Write*`/`Flush` calls return the first error and write nothing (previously they could resume and corrupt the stream). `JSONLWriter.Flush` now returns the latched error instead of always nil.
- Batched SQL INSERT rows are no longer streamed per row: a multi-row statement appears in the output only when it completes. Mid-batch partial statements are never visible (existing batch tests updated accordingly).
- `WithSQLInsertKind(SQLInsertKind(99))` now fails at construction with `ErrInvalidSQLInsertKind` instead of silently emitting plain `INSERT`.
- `DelimitedWriter.Flush` with `Header` enabled after the first data row now flushes buffered rows instead of returning `ErrHeaderAfterData`.
- Package docs gain a "Write errors" section; `SQLInsertWriter`, `Flush`, `WithSQLBatchSize`, and README docs updated to describe the now-enforced discard contract.

## Tests

- New `failNthWrite` fail-then-recover `io.Writer` helper in `writer/sticky_error_test.go`.
- `TestWritersStickyErrorAfterWriteFailure`: table-driven over all three writers; asserts the first failure is returned, later `WriteValues`/`Flush` return the same error even though the sink recovered, and no further bytes are written.
- `TestSQLInsertWriterBatchedWriteFailureFlushRegression`: reproduces the #204 scenario; asserts `Flush` returns the latched error (previously nil) and output contains only complete statements.
- `TestNewSQLInsertWriterRejectsOutOfRangeKind`: negative, past-end, and far out-of-range kinds.
- `TestDelimitedWriterFlushAfterLateHeaderEnable`: buffered row is flushed, no `ErrHeaderAfterData`.
- Existing batch tests adjusted to whole-statement output timing; `make check` passes.

Closes #204.

This also partially addresses the writer-package items of #213 (sticky write errors, whole-statement SQL emission, `SQLInsertKind` range validation, `Flush` header handling); the remaining #213 items are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
