### PR TITLE
ci: resolve latest Go 1.25 patch in govulncheck job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -116,6 +116,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          # Without check-latest, setup-go may resolve a stale preinstalled
+          # 1.25 patch release whose stdlib still carries fixed advisories
+          # (GO-2026-5037/5039), making this job flap across runners.
+          check-latest: true
           cache: false
 
       - name: Run govulncheck


### PR DESCRIPTION
Follow-up to #240 (#177). Making govulncheck PR-blocking exposed a toolchain-resolution flake: `setup-go` with `go-version: 1.25` and no `check-latest` may use a stale preinstalled 1.25 patch whose stdlib still carries the fixed GO-2026-5037 / GO-2026-5039 advisories. The job then fails or passes depending on which runner image it lands on — observed on three consecutive main pushes (fail, pass, fail) scanning near-identical code.

`check-latest: true` makes setup-go resolve the newest 1.25.x patch release, which is what the job comment already promised ("tracks the latest patched 1.25.x").

🤖 Generated with [Claude Code](https://claude.com/claude-code)