### PR TITLE
Add PluginForNullable, the pre-composed per-scalar-type override

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -48,8 +48,9 @@
 // a prepended plugin runs before the preset handlers, so it can override any
 // type (for tuple STRUCT with Spanner CLI scalars, prepend
 // [PluginForStruct]([FormatSimpleStructField], [FormatTupleStruct]); see the
-// README). For per-scalar-type overrides compose [PluginFromNullable] with
-// [NullableFormatterFor]; values the override defers keep the preset behavior.
+// README). For per-scalar-type overrides use [PluginForNullable] (the
+// pre-composed [PluginFromNullable] + [NullableFormatterFor] form); values
+// the override defers keep the preset behavior.
 // A prepended [PluginFromNullable] with a total formatter replaces preset
 // scalar formatting wholesale.
 //

--- a/format_plugin.go
+++ b/format_plugin.go
@@ -146,3 +146,24 @@ func NullableFormatterFor[T NullableValue](f func(T) (string, error)) FormatNull
 		return "", ErrFallthrough
 	}
 }
+
+// PluginForNullable is the pre-composed
+// [PluginFromNullable]([NullableFormatterFor](f)): a chain plugin that
+// formats exactly the scalar values decoding to the [NullableValue] wrapper
+// type T and defers everything else — other scalar types, SQL NULL, ARRAY,
+// STRUCT, and unsupported type codes all fall through ([ErrFallthrough]).
+// Because the Decode dispatch is annotation-aware, T selects the dialect
+// variant precisely: [cloud.google.com/go/spanner.PGNumeric] matches only
+// PG_NUMERIC-annotated NUMERIC, [cloud.google.com/go/spanner.NullNumeric]
+// only the GoogleSQL form.
+//
+//	cfg := spanvalue.SimpleFormatConfig().WithComplexPlugin(
+//	    spanvalue.PluginForNullable(func(v spanner.NullNumeric) (string, error) {
+//	        return v.Numeric.FloatString(2), nil
+//	    }))
+//
+// Use the two primitives directly when one function should claim several
+// wrapper types.
+func PluginForNullable[T NullableValue](f func(T) (string, error)) FormatComplexFunc {
+	return PluginFromNullable(NullableFormatterFor(f))
+}

--- a/format_plugin.go
+++ b/format_plugin.go
@@ -147,8 +147,8 @@ func NullableFormatterFor[T NullableValue](f func(T) (string, error)) FormatNull
 	}
 }
 
-// PluginForNullable is the pre-composed
-// [PluginFromNullable]([NullableFormatterFor](f)): a chain plugin that
+// PluginForNullable is the pre-composed combination of [PluginFromNullable]
+// and [NullableFormatterFor]: a chain plugin that
 // formats exactly the scalar values decoding to the [NullableValue] wrapper
 // type T and defers everything else — other scalar types, SQL NULL, ARRAY,
 // STRUCT, and unsupported type codes all fall through ([ErrFallthrough]).

--- a/format_plugin_test.go
+++ b/format_plugin_test.go
@@ -399,3 +399,32 @@ func TestComplexCombinatorsNilType(t *testing.T) {
 		}
 	}
 }
+
+// TestPluginForNullable pins the pre-composed combinator's equivalence with
+// PluginFromNullable(NullableFormatterFor(f)).
+func TestPluginForNullable(t *testing.T) {
+	t.Parallel()
+
+	fc := pluginConfig(spanvalue.PluginForNullable(func(v spanner.NullNumeric) (string, error) {
+		return "N:" + v.Numeric.FloatString(2), nil
+	}))
+
+	got, err := fc.FormatToplevelColumn(gcvctor.NumericValue(big.NewRat(3, 2)))
+	if err != nil || got != "N:1.50" {
+		t.Errorf("NUMERIC = (%q, %v), want (N:1.50, nil)", got, err)
+	}
+	// PG_NUMERIC decodes to PGNumeric, not NullNumeric: falls through.
+	got, err = fc.FormatToplevelColumn(gcvctor.PGNumericValue(big.NewRat(3, 2)))
+	if err != nil || got != "1.500000000" {
+		t.Errorf("PG_NUMERIC = (%q, %v), want preset wire string", got, err)
+	}
+	// NULL and other scalars keep preset behavior.
+	got, err = fc.FormatToplevelColumn(gcvctor.NullFromCode(sppb.TypeCode_NUMERIC))
+	if err != nil || got != fc.GetNullString() {
+		t.Errorf("NULL = (%q, %v), want (%q, nil)", got, err, fc.GetNullString())
+	}
+	got, err = fc.FormatToplevelColumn(gcvctor.StringValue("s"))
+	if err != nil || got != "s" {
+		t.Errorf("STRING = (%q, %v), want (s, nil)", got, err)
+	}
+}


### PR DESCRIPTION
Refs #250 (follow-on from review discussion: the PluginFromNullable + NullableFormatterFor nesting was itself becoming boilerplate for the dominant single-type-override case).

`PluginForNullable[T NullableValue](f func(T) (string, error)) FormatComplexFunc` ≡ `PluginFromNullable(NullableFormatterFor(f))` — pure composition, no new dispatch mechanism. Annotation dispatch comes free from the Decode path (PGNumeric matches only PG_NUMERIC; pinned by test alongside NULL/other-scalar fallthrough). The two primitives remain for multi-wrapper-type plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)