### PR TITLE
Add gcvctor WithType helpers for GCV retyping

### DIFF
--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -27,8 +27,10 @@
 // [NullOf], [NullArrayOf], and [EmptyArrayOf] normalize a nil Type pointer input to
 // TYPE_CODE_UNSPECIFIED so they never fabricate malformed nil Type pointers.
 // [WithType] applies the same nil-type normalization when retyping; use
-// [WithEquivalentType] or [WithExactType] when the destination type must be
-// validated. For NULL detection on existing values, see [github.com/apstndb/spanvalue.IsNull].
+// [WithEquivalentType] or [WithExactType] when the source and destination type
+// metadata must be checked. Those helpers validate Type only; Value is preserved
+// unchanged and not validated or canonicalized. For NULL detection on existing
+// values, see [github.com/apstndb/spanvalue.IsNull].
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //

--- a/gcvctor/doc.go
+++ b/gcvctor/doc.go
@@ -26,6 +26,9 @@
 // scalar type codes only—it cannot express STRUCT field layouts or ARRAY element types.
 // [NullOf], [NullArrayOf], and [EmptyArrayOf] normalize a nil Type pointer input to
 // TYPE_CODE_UNSPECIFIED so they never fabricate malformed nil Type pointers.
+// [WithType] applies the same nil-type normalization when retyping; use
+// [WithEquivalentType] or [WithExactType] when the destination type must be
+// validated. For NULL detection on existing values, see [github.com/apstndb/spanvalue.IsNull].
 // Neither encodes a non-null STRUCT whose fields are all null; use [StructValueOf] with
 // per-field nulls when you need that shape.
 //
@@ -89,6 +92,14 @@
 // [MustJSONStringValue], and [MustJSONValue] for inline nesting. Typed Go inputs ([DateValue] with
 // [cloud.google.com/go/civil.Date], [TimestampValue] with [time.Time], and so on) avoid parse errors
 // when you already hold the native value.
+//
+// Literal evaluation (preserve the parsed wire as-is) vs CAST/coercion (validate and canonicalize):
+//
+//   - Literal paths — [StringBasedValueFromCode] or [StringBasedValueOf] when the SQL literal's
+//     wire form must round-trip unchanged (for example DATE "1970-01-01" from a parser).
+//   - CAST/coercion paths — validated helpers such as [DateStringValue], [TimestampStringValue],
+//     [IntervalStringValue], [UUIDStringValue], and [NumericValueChecked] when semantics require
+//     Spanner-canonical wire.
 //
 // See ExampleStringBasedValueFromCode_validatedDate and ExampleNormalizeArrayElements.
 package gcvctor

--- a/gcvctor/with_type.go
+++ b/gcvctor/with_type.go
@@ -14,7 +14,7 @@ import (
 // when typ is nil.
 var ErrNilDestinationType = errors.New("gcvctor: nil destination type")
 
-// WithType returns a copy of gcv with Type replaced by typ and Value unchanged.
+// WithType returns a shallow copy of gcv with Type replaced by typ and Value unchanged.
 // A nil typ is normalized to TYPE_CODE_UNSPECIFIED, matching [NullOf].
 // For validation, use [WithEquivalentType] or [WithExactType].
 func WithType(typ *sppb.Type, gcv spanner.GenericColumnValue) spanner.GenericColumnValue {
@@ -26,6 +26,7 @@ func WithType(typ *sppb.Type, gcv spanner.GenericColumnValue) spanner.GenericCol
 
 // WithEquivalentType returns gcv retyped to typ when [github.com/apstndb/spantype.EquivalentTypes]
 // reports the source and destination types are Spanner-equivalent.
+// It only validates Type metadata; Value is preserved unchanged and not validated or canonicalized.
 func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if typ == nil {
 		return spanner.GenericColumnValue{}, ErrNilDestinationType
@@ -47,6 +48,7 @@ func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner
 // WithExactType returns gcv retyped to typ when proto.Equal(gcv.Type, typ).
 // Use this when expected-type coercion requires identical type metadata, not
 // merely Spanner equivalence.
+// It only validates Type metadata; Value is preserved unchanged and not validated or canonicalized.
 func WithExactType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if typ == nil {
 		return spanner.GenericColumnValue{}, ErrNilDestinationType

--- a/gcvctor/with_type.go
+++ b/gcvctor/with_type.go
@@ -56,9 +56,10 @@ func WithExactType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.Gene
 	}
 	if !proto.Equal(gcv.Type, typ) {
 		return spanner.GenericColumnValue{}, fmt.Errorf(
-			"%w: destination type metadata differs from %v",
+			"%w: %v is not exactly equal to %v",
 			ErrTypeMismatch,
 			spantype.FormatTypeMoreVerbose(gcv.Type),
+			spantype.FormatTypeMoreVerbose(typ),
 		)
 	}
 	return WithType(typ, gcv), nil

--- a/gcvctor/with_type.go
+++ b/gcvctor/with_type.go
@@ -1,0 +1,100 @@
+package gcvctor
+
+import (
+	"errors"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype"
+	"google.golang.org/protobuf/proto"
+)
+
+// ErrNilDestinationType is returned by [WithEquivalentType] and [WithExactType]
+// when typ is nil.
+var ErrNilDestinationType = errors.New("gcvctor: nil destination type")
+
+// WithType returns a copy of gcv with Type replaced by typ and Value unchanged.
+// A nil typ is normalized to TYPE_CODE_UNSPECIFIED, matching [NullOf].
+// For validation, use [WithEquivalentType] or [WithExactType].
+func WithType(typ *sppb.Type, gcv spanner.GenericColumnValue) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{
+		Type:  normalizeNilType(typ),
+		Value: gcv.Value,
+	}
+}
+
+// WithEquivalentType returns gcv retyped to typ when the source and destination
+// types are Spanner-equivalent: scalar types require proto.Equal metadata;
+// ARRAY types require equivalent element types; STRUCT types require the same
+// number of fields with pairwise equivalent field types (field names are not
+// compared). This mirrors identity CAST and ARRAY cast paths in semantic layers.
+func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	if typ == nil {
+		return spanner.GenericColumnValue{}, ErrNilDestinationType
+	}
+	if !equivalentTypes(gcv.Type, typ) {
+		return spanner.GenericColumnValue{}, fmt.Errorf(
+			"%w: %v is not equivalent to %v",
+			ErrTypeMismatch,
+			spantype.FormatTypeMoreVerbose(gcv.Type),
+			spantype.FormatTypeMoreVerbose(typ),
+		)
+	}
+	return WithType(typ, gcv), nil
+}
+
+// WithExactType returns gcv retyped to typ when proto.Equal(gcv.Type, typ).
+// Use this when expected-type coercion requires identical type metadata, not
+// merely Spanner equivalence.
+func WithExactType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	if typ == nil {
+		return spanner.GenericColumnValue{}, ErrNilDestinationType
+	}
+	if !proto.Equal(gcv.Type, typ) {
+		return spanner.GenericColumnValue{}, fmt.Errorf(
+			"%w: destination type metadata differs from %v",
+			ErrTypeMismatch,
+			spantype.FormatTypeMoreVerbose(gcv.Type),
+		)
+	}
+	return WithType(typ, gcv), nil
+}
+
+func equivalentTypes(a, b *sppb.Type) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.GetCode() != b.GetCode() {
+		return false
+	}
+	switch a.GetCode() {
+	case sppb.TypeCode_ARRAY:
+		return equivalentTypes(a.GetArrayElementType(), b.GetArrayElementType())
+	case sppb.TypeCode_STRUCT:
+		aStruct := a.GetStructType()
+		bStruct := b.GetStructType()
+		if aStruct == nil || bStruct == nil {
+			return aStruct == nil && bStruct == nil
+		}
+		aFields := aStruct.GetFields()
+		bFields := bStruct.GetFields()
+		if len(aFields) != len(bFields) {
+			return false
+		}
+		for i := range aFields {
+			if aFields[i] == nil || bFields[i] == nil {
+				if aFields[i] != bFields[i] {
+					return false
+				}
+				continue
+			}
+			if !equivalentTypes(aFields[i].GetType(), bFields[i].GetType()) {
+				return false
+			}
+		}
+		return true
+	default:
+		return proto.Equal(a, b)
+	}
+}

--- a/gcvctor/with_type.go
+++ b/gcvctor/with_type.go
@@ -30,6 +30,9 @@ func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner
 	if typ == nil {
 		return spanner.GenericColumnValue{}, ErrNilDestinationType
 	}
+	if gcv.Type == nil {
+		return spanner.GenericColumnValue{}, fmt.Errorf("%w: source type is nil", ErrTypeMismatch)
+	}
 	if !spantype.EquivalentTypes(gcv.Type, typ) {
 		return spanner.GenericColumnValue{}, fmt.Errorf(
 			"%w: %v is not equivalent to %v",
@@ -47,6 +50,9 @@ func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner
 func WithExactType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if typ == nil {
 		return spanner.GenericColumnValue{}, ErrNilDestinationType
+	}
+	if gcv.Type == nil {
+		return spanner.GenericColumnValue{}, fmt.Errorf("%w: source type is nil", ErrTypeMismatch)
 	}
 	if !proto.Equal(gcv.Type, typ) {
 		return spanner.GenericColumnValue{}, fmt.Errorf(

--- a/gcvctor/with_type.go
+++ b/gcvctor/with_type.go
@@ -24,16 +24,13 @@ func WithType(typ *sppb.Type, gcv spanner.GenericColumnValue) spanner.GenericCol
 	}
 }
 
-// WithEquivalentType returns gcv retyped to typ when the source and destination
-// types are Spanner-equivalent: scalar types require proto.Equal metadata;
-// ARRAY types require equivalent element types; STRUCT types require the same
-// number of fields with pairwise equivalent field types (field names are not
-// compared). This mirrors identity CAST and ARRAY cast paths in semantic layers.
+// WithEquivalentType returns gcv retyped to typ when [github.com/apstndb/spantype.EquivalentTypes]
+// reports the source and destination types are Spanner-equivalent.
 func WithEquivalentType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	if typ == nil {
 		return spanner.GenericColumnValue{}, ErrNilDestinationType
 	}
-	if !equivalentTypes(gcv.Type, typ) {
+	if !spantype.EquivalentTypes(gcv.Type, typ) {
 		return spanner.GenericColumnValue{}, fmt.Errorf(
 			"%w: %v is not equivalent to %v",
 			ErrTypeMismatch,
@@ -59,42 +56,4 @@ func WithExactType(typ *sppb.Type, gcv spanner.GenericColumnValue) (spanner.Gene
 		)
 	}
 	return WithType(typ, gcv), nil
-}
-
-func equivalentTypes(a, b *sppb.Type) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
-	}
-	if a.GetCode() != b.GetCode() {
-		return false
-	}
-	switch a.GetCode() {
-	case sppb.TypeCode_ARRAY:
-		return equivalentTypes(a.GetArrayElementType(), b.GetArrayElementType())
-	case sppb.TypeCode_STRUCT:
-		aStruct := a.GetStructType()
-		bStruct := b.GetStructType()
-		if aStruct == nil || bStruct == nil {
-			return aStruct == nil && bStruct == nil
-		}
-		aFields := aStruct.GetFields()
-		bFields := bStruct.GetFields()
-		if len(aFields) != len(bFields) {
-			return false
-		}
-		for i := range aFields {
-			if aFields[i] == nil || bFields[i] == nil {
-				if aFields[i] != bFields[i] {
-					return false
-				}
-				continue
-			}
-			if !equivalentTypes(aFields[i].GetType(), bFields[i].GetType()) {
-				return false
-			}
-		}
-		return true
-	default:
-		return proto.Equal(a, b)
-	}
 }

--- a/gcvctor/with_type_test.go
+++ b/gcvctor/with_type_test.go
@@ -1,0 +1,170 @@
+package gcvctor_test
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/apstndb/spanvalue/gcvctor"
+)
+
+func TestWithType(t *testing.T) {
+	t.Parallel()
+
+	src := spanner.GenericColumnValue{
+		Type:  typector.CodeToSimpleType(sppb.TypeCode_INT64),
+		Value: structpb.NewStringValue("1"),
+	}
+	destType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+
+	got := gcvctor.WithType(destType, src)
+	want := spanner.GenericColumnValue{
+		Type:  destType,
+		Value: structpb.NewStringValue("1"),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestWithTypeNilDestinationNormalizesUnspecified(t *testing.T) {
+	t.Parallel()
+
+	src := gcvctor.Int64Value(1)
+	got := gcvctor.WithType(nil, src)
+	wantType := typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
+	if got.Type.GetCode() != wantType.GetCode() {
+		t.Fatalf("Type code = %v, want %v", got.Type.GetCode(), wantType.GetCode())
+	}
+	if diff := cmp.Diff(src.Value, got.Value, protocmp.Transform()); diff != "" {
+		t.Fatalf("Value changed (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithEquivalentTypeScalar(t *testing.T) {
+	t.Parallel()
+
+	src := gcvctor.Int64Value(42)
+	destType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+
+	got, err := gcvctor.WithEquivalentType(destType, src)
+	if err != nil {
+		t.Fatalf("WithEquivalentType: %v", err)
+	}
+	want := spanner.GenericColumnValue{Type: destType, Value: src.Value}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestWithEquivalentTypeArray(t *testing.T) {
+	t.Parallel()
+
+	elemType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	src, err := gcvctor.ArrayValueOf(elemType, gcvctor.Int64Value(1), gcvctor.Int64Value(2))
+	if err != nil {
+		t.Fatalf("ArrayValueOf: %v", err)
+	}
+	destArrayType := typector.ElemTypeToArrayType(elemType)
+
+	got, err := gcvctor.WithEquivalentType(destArrayType, src)
+	if err != nil {
+		t.Fatalf("WithEquivalentType: %v", err)
+	}
+	want := spanner.GenericColumnValue{Type: destArrayType, Value: src.Value}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestWithEquivalentTypeStructIgnoresFieldNames(t *testing.T) {
+	t.Parallel()
+
+	fieldType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	srcType := typector.NameTypeToStructType("a", fieldType)
+	destType := typector.NameTypeToStructType("b", fieldType)
+	src, err := gcvctor.StructValueOf([]string{"a"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)})
+	if err != nil {
+		t.Fatalf("StructValueOf: %v", err)
+	}
+	src.Type = srcType
+
+	got, err := gcvctor.WithEquivalentType(destType, src)
+	if err != nil {
+		t.Fatalf("WithEquivalentType: %v", err)
+	}
+	want := spanner.GenericColumnValue{Type: destType, Value: src.Value}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestWithEquivalentTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	src := gcvctor.Int64Value(1)
+	destType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+
+	_, err := gcvctor.WithEquivalentType(destType, src)
+	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+		t.Fatalf("error = %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestWithEquivalentTypeNilDestination(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcvctor.WithEquivalentType(nil, gcvctor.Int64Value(1))
+	if !errors.Is(err, gcvctor.ErrNilDestinationType) {
+		t.Fatalf("error = %v, want ErrNilDestinationType", err)
+	}
+}
+
+func TestWithExactTypeMatch(t *testing.T) {
+	t.Parallel()
+
+	destType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	src := spanner.GenericColumnValue{Type: destType, Value: structpb.NewStringValue("7")}
+
+	got, err := gcvctor.WithExactType(destType, src)
+	if err != nil {
+		t.Fatalf("WithExactType: %v", err)
+	}
+	want := spanner.GenericColumnValue{Type: destType, Value: src.Value}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestWithExactTypeStructFieldNamesDiffer(t *testing.T) {
+	t.Parallel()
+
+	fieldType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	srcType := typector.NameTypeToStructType("a", fieldType)
+	destType := typector.NameTypeToStructType("b", fieldType)
+	src, err := gcvctor.StructValueOf([]string{"a"}, []spanner.GenericColumnValue{gcvctor.Int64Value(1)})
+	if err != nil {
+		t.Fatalf("StructValueOf: %v", err)
+	}
+	src.Type = srcType
+
+	_, err = gcvctor.WithExactType(destType, src)
+	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+		t.Fatalf("error = %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestWithExactTypeNilDestination(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcvctor.WithExactType(nil, gcvctor.Int64Value(1))
+	if !errors.Is(err, gcvctor.ErrNilDestinationType) {
+		t.Fatalf("error = %v, want ErrNilDestinationType", err)
+	}
+}

--- a/gcvctor/with_type_test.go
+++ b/gcvctor/with_type_test.go
@@ -126,6 +126,17 @@ func TestWithEquivalentTypeNilDestination(t *testing.T) {
 	}
 }
 
+func TestWithEquivalentTypeNilSourceType(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcvctor.WithEquivalentType(typector.Int64(), spanner.GenericColumnValue{
+		Value: structpb.NewStringValue("1"),
+	})
+	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+		t.Fatalf("error = %v, want ErrTypeMismatch", err)
+	}
+}
+
 func TestWithExactTypeMatch(t *testing.T) {
 	t.Parallel()
 
@@ -166,5 +177,16 @@ func TestWithExactTypeNilDestination(t *testing.T) {
 	_, err := gcvctor.WithExactType(nil, gcvctor.Int64Value(1))
 	if !errors.Is(err, gcvctor.ErrNilDestinationType) {
 		t.Fatalf("error = %v, want ErrNilDestinationType", err)
+	}
+}
+
+func TestWithExactTypeNilSourceType(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcvctor.WithExactType(typector.Int64(), spanner.GenericColumnValue{
+		Value: structpb.NewStringValue("1"),
+	})
+	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+		t.Fatalf("error = %v, want ErrTypeMismatch", err)
 	}
 }

--- a/gcvctor/with_type_test.go
+++ b/gcvctor/with_type_test.go
@@ -38,9 +38,12 @@ func TestWithTypeNilDestinationNormalizesUnspecified(t *testing.T) {
 
 	src := gcvctor.Int64Value(1)
 	got := gcvctor.WithType(nil, src)
+	if got.Type == nil {
+		t.Fatal("Type is nil, want TYPE_CODE_UNSPECIFIED Type")
+	}
 	wantType := typector.CodeToSimpleType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED)
-	if got.Type.GetCode() != wantType.GetCode() {
-		t.Fatalf("Type code = %v, want %v", got.Type.GetCode(), wantType.GetCode())
+	if diff := cmp.Diff(wantType, got.Type, protocmp.Transform()); diff != "" {
+		t.Fatalf("Type (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(src.Value, got.Value, protocmp.Transform()); diff != "" {
 		t.Fatalf("Value changed (-want +got):\n%s", diff)
@@ -66,12 +69,13 @@ func TestWithEquivalentTypeScalar(t *testing.T) {
 func TestWithEquivalentTypeArray(t *testing.T) {
 	t.Parallel()
 
-	elemType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
-	src, err := gcvctor.ArrayValueOf(elemType, gcvctor.Int64Value(1), gcvctor.Int64Value(2))
+	srcElemType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	src, err := gcvctor.ArrayValueOf(srcElemType, gcvctor.Int64Value(1), gcvctor.Int64Value(2))
 	if err != nil {
 		t.Fatalf("ArrayValueOf: %v", err)
 	}
-	destArrayType := typector.ElemTypeToArrayType(elemType)
+	destElemType := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	destArrayType := typector.ElemTypeToArrayType(destElemType)
 
 	got, err := gcvctor.WithEquivalentType(destArrayType, src)
 	if err != nil {
@@ -189,4 +193,74 @@ func TestWithExactTypeNilSourceType(t *testing.T) {
 	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
 		t.Fatalf("error = %v, want ErrTypeMismatch", err)
 	}
+}
+
+func TestWithExactTypeScalarMismatch(t *testing.T) {
+	t.Parallel()
+
+	src := gcvctor.Int64Value(1)
+	destType := typector.CodeToSimpleType(sppb.TypeCode_STRING)
+
+	_, err := gcvctor.WithExactType(destType, src)
+	if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+		t.Fatalf("error = %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestWithEquivalentTypeMalformedTypesDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("array without element type", func(t *testing.T) {
+		t.Parallel()
+
+		malformed := &sppb.Type{Code: sppb.TypeCode_ARRAY}
+		_, err := gcvctor.WithEquivalentType(typector.Int64(), spanner.GenericColumnValue{Type: malformed})
+		if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+			t.Fatalf("error = %v, want ErrTypeMismatch", err)
+		}
+	})
+
+	t.Run("struct field with nil type", func(t *testing.T) {
+		t.Parallel()
+
+		malformed := &sppb.Type{
+			Code: sppb.TypeCode_STRUCT,
+			StructType: &sppb.StructType{
+				Fields: []*sppb.StructType_Field{{Name: "f"}},
+			},
+		}
+		_, err := gcvctor.WithEquivalentType(typector.Int64(), spanner.GenericColumnValue{Type: malformed})
+		if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+			t.Fatalf("error = %v, want ErrTypeMismatch", err)
+		}
+	})
+}
+
+func TestWithExactTypeMalformedTypesDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("array without element type", func(t *testing.T) {
+		t.Parallel()
+
+		malformed := &sppb.Type{Code: sppb.TypeCode_ARRAY}
+		_, err := gcvctor.WithExactType(typector.Int64(), spanner.GenericColumnValue{Type: malformed})
+		if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+			t.Fatalf("error = %v, want ErrTypeMismatch", err)
+		}
+	})
+
+	t.Run("struct field with nil type", func(t *testing.T) {
+		t.Parallel()
+
+		malformed := &sppb.Type{
+			Code: sppb.TypeCode_STRUCT,
+			StructType: &sppb.StructType{
+				Fields: []*sppb.StructType_Field{{Name: "f"}},
+			},
+		}
+		_, err := gcvctor.WithExactType(typector.Int64(), spanner.GenericColumnValue{Type: malformed})
+		if !errors.Is(err, gcvctor.ErrTypeMismatch) {
+			t.Fatalf("error = %v, want ErrTypeMismatch", err)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go v0.121.4
 	cloud.google.com/go/spanner v1.84.1
-	github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d
+	github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.53.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go v0.121.4
 	cloud.google.com/go/spanner v1.84.1
-	github.com/apstndb/spantype v0.3.11
+	github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.53.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go v0.121.4
 	cloud.google.com/go/spanner v1.84.1
-	github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09
+	github.com/apstndb/spantype v0.3.13-0.20260627190830-1950000ac5c1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.53.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	cloud.google.com/go v0.121.4
 	cloud.google.com/go/spanner v1.84.1
-	github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab
+	github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -636,6 +636,8 @@ github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d h1:Sb5WliFi0f7
 github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab h1:DLazJd/98BJja7n9HveeRy6rD4opoK1QwFdwddDmdG8=
 github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09 h1:IXE6mQPirDmi9smtV0+pUPescIwZh5ssxAOoQxwTjfA=
+github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -632,6 +632,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d h1:Sb5WliFi0f7Fm/IEExQfAfKAo/a5qMJt/0eWHi6I+4Q=
+github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -630,14 +630,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
-github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d h1:Sb5WliFi0f7Fm/IEExQfAfKAo/a5qMJt/0eWHi6I+4Q=
-github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab h1:DLazJd/98BJja7n9HveeRy6rD4opoK1QwFdwddDmdG8=
-github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09 h1:IXE6mQPirDmi9smtV0+pUPescIwZh5ssxAOoQxwTjfA=
-github.com/apstndb/spantype v0.3.13-0.20260627183148-91cc5f096e09/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spantype v0.3.13-0.20260627190830-1950000ac5c1 h1:mMAc72OIRP0hQJWM7+d2ugd/ADkTSl4IqJq/z9iByM0=
+github.com/apstndb/spantype v0.3.13-0.20260627190830-1950000ac5c1/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -634,6 +634,8 @@ github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtn
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d h1:Sb5WliFi0f7Fm/IEExQfAfKAo/a5qMJt/0eWHi6I+4Q=
 github.com/apstndb/spantype v0.3.13-0.20260627180028-689f405fef1d/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab h1:DLazJd/98BJja7n9HveeRy6rD4opoK1QwFdwddDmdG8=
+github.com/apstndb/spantype v0.3.13-0.20260627182227-474d762afcab/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
## Summary

- Add `gcvctor.WithType` — unchecked retype: preserve `Value`, replace `Type` (nil destination normalizes to `TYPE_CODE_UNSPECIFIED`, matching `NullOf`).
- Add `gcvctor.WithEquivalentType` — checked retype using Spanner-equivalent type metadata (scalar `proto.Equal`, recursive ARRAY/STRUCT layouts; STRUCT field names are not compared).
- Add `gcvctor.WithExactType` — checked retype requiring `proto.Equal` type metadata.
- Introduce `gcvctor.ErrNilDestinationType` for nil destination types on checked helpers.
- Extend `gcvctor` package docs: literal wire preservation (`StringBasedValueFromCode`) vs validated construction (`DateStringValue`, etc.), and cross-link `spanvalue.IsNull`.

Motivated by [memebridge](https://github.com/apstndb/memebridge) CAST/coercion paths that repeatedly retype GCVs during identity casts, ARRAY casts, and expected-type coercion. Local prototypes lived in `gcv_helpers.go` (`gcvWithType`, `gcvWithEquivalentType`, `gcvWithExactType`).

Follows the gcvctor package boundary: **only APIs whose result is `GenericColumnValue` belong in gcvctor**.

## Test plan

- [x] `make check`
- [x] Table tests for scalar, ARRAY, and STRUCT equivalence vs exact metadata
- [x] Negative cases: type mismatch, nil destination


Made with [Cursor](https://cursor.com)