### PR TITLE
Add wire value extraction helpers

### DIFF
--- a/common.go
+++ b/common.go
@@ -170,6 +170,33 @@ func IsNull(gcv spanner.GenericColumnValue) bool {
 	return internal.IsNullGenericColumnValue(gcv)
 }
 
+// WireValue returns gcv's protobuf wire value for low-level ARRAY or STRUCT
+// assembly. When gcv.Value is nil, it returns a fresh explicit protobuf NULL,
+// so the result is never nil. Otherwise it returns gcv.Value without cloning;
+// callers must treat the returned value as read-only.
+//
+// WireValue does not validate that gcv.Type and gcv.Value form a valid Spanner
+// wire value. Use it when the caller already owns type validation and needs to
+// preserve the encoded value as-is.
+func WireValue(gcv spanner.GenericColumnValue) *structpb.Value {
+	if gcv.Value == nil {
+		return structpb.NewNullValue()
+	}
+	return gcv.Value
+}
+
+// WireValues maps [WireValue] over gcvs for low-level ARRAY or STRUCT
+// assembly. It always returns a newly allocated, non-nil slice, including for
+// nil or empty input. Non-nil element values are borrowed from gcvs and must
+// be treated as read-only.
+func WireValues(gcvs []spanner.GenericColumnValue) []*structpb.Value {
+	values := make([]*structpb.Value, len(gcvs))
+	for i, gcv := range gcvs {
+		values[i] = WireValue(gcv)
+	}
+	return values
+}
+
 // FormatProtoAsCast formats PROTO values as CAST(b"..." AS `fqn`) with the
 // default (legacy double-quote) bytes-literal quoting. The literal preset
 // constructors install a quote-aware equivalent that follows the

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
@@ -71,4 +72,20 @@ func ExampleNewFormatConfig() {
 	fmt.Println(out)
 	// Output:
 	// [1.50, NULL]
+}
+
+// Materialize nil cells as explicit protobuf NULL values before low-level
+// ARRAY or STRUCT wire assembly.
+func ExampleWireValues() {
+	wireValues := spanvalue.WireValues([]spanner.GenericColumnValue{
+		gcvctor.Int64Value(7),
+		{Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+	})
+	arrayWire := structpb.NewListValue(&structpb.ListValue{Values: wireValues})
+
+	fmt.Println(arrayWire.GetListValue().GetValues()[0].GetStringValue())
+	fmt.Println(arrayWire.GetListValue().GetValues()[1].GetNullValue())
+	// Output:
+	// 7
+	// NULL_VALUE
 }

--- a/wire_value_test.go
+++ b/wire_value_test.go
@@ -1,0 +1,108 @@
+package spanvalue
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestWireValue(t *testing.T) {
+	t.Parallel()
+
+	stringValue := structpb.NewStringValue("hello")
+	listValue := structpb.NewListValue(&structpb.ListValue{
+		Values: []*structpb.Value{structpb.NewBoolValue(true)},
+	})
+	explicitNull := structpb.NewNullValue()
+	tests := []struct {
+		name      string
+		gcv       spanner.GenericColumnValue
+		want      *structpb.Value
+		wantAlias bool
+	}{
+		{
+			name: "nil value",
+			gcv:  spanner.GenericColumnValue{},
+			want: structpb.NewNullValue(),
+		},
+		{
+			name:      "explicit null",
+			gcv:       spanner.GenericColumnValue{Value: explicitNull},
+			want:      structpb.NewNullValue(),
+			wantAlias: true,
+		},
+		{
+			name:      "scalar",
+			gcv:       spanner.GenericColumnValue{Value: stringValue},
+			want:      structpb.NewStringValue("hello"),
+			wantAlias: true,
+		},
+		{
+			name:      "list",
+			gcv:       spanner.GenericColumnValue{Value: listValue},
+			want:      listValue,
+			wantAlias: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := WireValue(tt.gcv)
+			if got == nil {
+				t.Fatal("WireValue() = nil, want a protobuf value")
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("WireValue() mismatch (-want +got):\n%s", diff)
+			}
+			if tt.wantAlias && got != tt.gcv.Value {
+				t.Error("WireValue() did not return the input Value pointer")
+			}
+		})
+	}
+
+	first := WireValue(spanner.GenericColumnValue{})
+	second := WireValue(spanner.GenericColumnValue{})
+	if first == second {
+		t.Error("WireValue() reused a protobuf NULL for distinct nil inputs")
+	}
+}
+
+func TestWireValues(t *testing.T) {
+	t.Parallel()
+
+	stringValue := structpb.NewStringValue("hello")
+	explicitNull := structpb.NewNullValue()
+	gcvs := []spanner.GenericColumnValue{
+		{},
+		{Value: stringValue},
+		{Value: explicitNull},
+	}
+
+	got := WireValues(gcvs)
+	want := []*structpb.Value{
+		structpb.NewNullValue(),
+		structpb.NewStringValue("hello"),
+		structpb.NewNullValue(),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("WireValues() mismatch (-want +got):\n%s", diff)
+	}
+	if got[1] != stringValue || got[2] != explicitNull {
+		t.Error("WireValues() did not borrow non-nil input Value pointers")
+	}
+
+	got[1] = structpb.NewBoolValue(true)
+	if gcvs[1].Value != stringValue {
+		t.Error("mutating the result slice changed the input slice")
+	}
+
+	empty := WireValues(nil)
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("WireValues(nil) = %#v, want a non-nil empty slice", empty)
+	}
+}


### PR DESCRIPTION
## Summary

- add `spanvalue.WireValue` to expose a GCV's protobuf wire value while materializing an absent value as an explicit protobuf NULL
- add `spanvalue.WireValues` for slice-based ARRAY and STRUCT assembly
- document and test the borrowed-pointer contract, fresh NULL materialization, fresh result slices, and low-level assembly usage

## Motivation

`memebridge` currently carries local `gcvToProtoValue` and `gcvArrayWireValues` helpers for STRUCT casts and permissive ARRAY assembly. Moving the generic wire extraction behavior into `spanvalue` avoids duplicated NULL handling while keeping type validation and coercion policy in the downstream application.

This addresses S1 and S2 from #262. S3 remains intentionally separate because "known type" still needs a precise definition.

The final names are `WireValue` / `WireValues`, rather than the issue's provisional `ToProtoValue` / `ArrayWireValues`: "wire" matches the repository's existing terminology and avoids confusion with `gcvctor.ProtoValue`, while the slice helper is equally applicable to ARRAY and STRUCT assembly.

## Compatibility

Additive only. Existing APIs and formatting behavior are unchanged.

## Validation

- `make check`
- downstream adaptation probe: replace the two `memebridge` helper call sites with `WireValue` / `WireValues`, point its module at this branch, and run `go test ./...`
